### PR TITLE
update scraping, data journalism and foia skills

### DIFF
--- a/data-journalism/SKILL.md
+++ b/data-journalism/SKILL.md
@@ -1,489 +1,32 @@
 ---
 name: data-journalism
-description: Data journalism workflows for analysis, visualization, and storytelling. Use when analyzing datasets, creating charts and maps, cleaning messy data, calculating statistics, or building data-driven stories. Essential for reporters, newsrooms, and researchers working with quantitative information.
+description: Data journalism workflows for analysis, visualization, and storytelling. Use when analyzing datasets, creating charts and maps, cleaning messy data, calculating statistics or building data-driven stories. Essential for reporters, newsrooms and researchers working with quantitative information.
 ---
 
 # Data journalism methodology
 
-Systematic approaches for finding, analyzing, and presenting data in journalism.
-
-## Data acquisition
-
-### Public data sources
-
-```markdown
-## Federal data sources
-
-### General
-- Data.gov - Federal open data portal
-- Census Bureau (census.gov) - Demographics, economic data
-- BLS (bls.gov) - Employment, inflation, wages
-- BEA (bea.gov) - GDP, economic accounts
-- Federal Reserve (federalreserve.gov) - Financial data
-- SEC EDGAR - Corporate filings
-
-### Specific domains
-- EPA (epa.gov/data) - Environmental data
-- FDA (fda.gov/data) - Drug approvals, recalls, adverse events
-- CDC WONDER - Health statistics
-- NHTSA - Vehicle safety data
-- DOT - Transportation statistics
-- FEC - Campaign finance
-- USASpending.gov - Federal contracts and grants
-
-### State and local
-- State open data portals (search: "[state] open data")
-- Socrata-powered sites (many cities/states)
-- OpenStreets, municipal GIS portals
-- State comptroller/auditor reports
-```
-
-### Data request strategies
-
-```markdown
-## Getting data that isn't public
-
-### FOIA for datasets
-- Request databases, not just documents
-- Ask for data dictionary/schema
-- Request in native format (CSV, SQL dump)
-- Specify field-level needs
-
-### Building your own dataset
-- Scraping public information
-- Crowdsourcing from readers
-- Systematic document review
-- Surveys (with proper methodology)
-
-### Commercial data sources (for newsrooms)
-- LexisNexis
-- Refinitiv
-- Bloomberg
-- Industry-specific databases
-```
-
-## Data cleaning and preparation
-
-### Common data problems
-
-```python
-import pandas as pd
-import numpy as np
-
-# Load messy data
-df = pd.read_csv('raw_data.csv')
-
-# 1. INCONSISTENT FORMATTING
-# Problem: Names in different formats
-# "SMITH, JOHN" vs "John Smith" vs "smith john"
-
-def standardize_name(name):
-    """Standardize name format to 'First Last'."""
-    if pd.isna(name):
-        return None
-    name = str(name).strip().lower()
-    # Handle "LAST, FIRST" format
-    if ',' in name:
-        parts = name.split(',')
-        name = f"{parts[1].strip()} {parts[0].strip()}"
-    return name.title()
-
-df['name_clean'] = df['name'].apply(standardize_name)
-
-
-# 2. DATE INCONSISTENCIES
-# Problem: Dates in multiple formats
-# "01/15/2024", "2024-01-15", "January 15, 2024", "15-Jan-24"
-
-def parse_date(date_str):
-    """Parse dates in various formats."""
-    if pd.isna(date_str):
-        return None
-
-    formats = [
-        '%m/%d/%Y', '%Y-%m-%d', '%B %d, %Y',
-        '%d-%b-%y', '%m-%d-%Y', '%Y/%m/%d'
-    ]
-
-    for fmt in formats:
-        try:
-            return pd.to_datetime(date_str, format=fmt)
-        except:
-            continue
-
-    # Fall back to pandas parser
-    try:
-        return pd.to_datetime(date_str)
-    except:
-        return None
-
-df['date_clean'] = df['date'].apply(parse_date)
-
-
-# 3. MISSING VALUES
-# Strategy depends on context
-
-# Check missing value patterns
-print(df.isnull().sum())
-print(df.isnull().sum() / len(df) * 100)  # Percentage
-
-# Options:
-# - Drop rows with critical missing values
-df_clean = df.dropna(subset=['required_field'])
-
-# - Fill with appropriate values
-df['category'] = df['category'].fillna('Unknown')
-df['amount'] = df['amount'].fillna(df['amount'].median())
-
-# - Flag as missing (preserve for analysis)
-df['amount_missing'] = df['amount'].isna()
-
-
-# 4. DUPLICATES
-# Find and handle duplicates
-
-# Exact duplicates
-print(f"Exact duplicates: {df.duplicated().sum()}")
-df = df.drop_duplicates()
-
-# Fuzzy duplicates (similar but not identical)
-# Use record linkage or manual review
-from fuzzywuzzy import fuzz
-
-def find_similar_names(names, threshold=85):
-    """Find potentially duplicate names."""
-    duplicates = []
-    for i, name1 in enumerate(names):
-        for j, name2 in enumerate(names[i+1:], i+1):
-            score = fuzz.ratio(str(name1).lower(), str(name2).lower())
-            if score >= threshold:
-                duplicates.append((name1, name2, score))
-    return duplicates
-
-
-# 5. OUTLIERS
-# Identify potential data entry errors
-
-def flag_outliers(series, method='iqr', threshold=1.5):
-    """Flag statistical outliers."""
-    if method == 'iqr':
-        Q1 = series.quantile(0.25)
-        Q3 = series.quantile(0.75)
-        IQR = Q3 - Q1
-        lower = Q1 - threshold * IQR
-        upper = Q3 + threshold * IQR
-        return (series < lower) | (series > upper)
-    elif method == 'zscore':
-        z_scores = np.abs((series - series.mean()) / series.std())
-        return z_scores > threshold
-
-df['amount_outlier'] = flag_outliers(df['amount'])
-print(f"Outliers found: {df['amount_outlier'].sum()}")
-
-
-# 6. DATA TYPE CORRECTIONS
-# Ensure proper types for analysis
-
-# Convert to numeric (handling errors)
-df['amount'] = pd.to_numeric(df['amount'], errors='coerce')
-
-# Convert to categorical (saves memory, enables ordering)
-df['status'] = pd.Categorical(df['status'],
-                              categories=['Pending', 'Active', 'Closed'],
-                              ordered=True)
-
-# Convert to datetime
-df['date'] = pd.to_datetime(df['date'], errors='coerce')
-```
-
-### Data validation checklist
-
-```markdown
-## Pre-analysis data validation
-
-### Structural checks
-- [ ] Row count matches expected
-- [ ] Column count and names correct
-- [ ] Data types appropriate
-- [ ] No unexpected null columns
-
-### Content checks
-- [ ] Date ranges make sense
-- [ ] Numeric values within expected bounds
-- [ ] Categorical values match expected options
-- [ ] Geographic data resolves correctly
-- [ ] IDs are unique where expected
-
-### Consistency checks
-- [ ] Totals add up to expected values
-- [ ] Cross-tabulations balance
-- [ ] Related fields are consistent
-- [ ] Time series is continuous
-
-### Source verification
-- [ ] Can trace back to original source
-- [ ] Methodology documented
-- [ ] Known limitations noted
-- [ ] Update frequency understood
-```
-
-## Statistical analysis for journalism
-
-### Basic statistics with context
-
-```python
-# Essential statistics for any dataset
-def describe_for_journalism(df, column):
-    """Generate journalist-friendly statistics."""
-    stats = {
-        'count': len(df[column].dropna()),
-        'missing': df[column].isna().sum(),
-        'min': df[column].min(),
-        'max': df[column].max(),
-        'mean': df[column].mean(),
-        'median': df[column].median(),
-        'std': df[column].std(),
-    }
-
-    # Percentiles for context
-    stats['25th_percentile'] = df[column].quantile(0.25)
-    stats['75th_percentile'] = df[column].quantile(0.75)
-    stats['90th_percentile'] = df[column].quantile(0.90)
-    stats['99th_percentile'] = df[column].quantile(0.99)
-
-    # Distribution shape
-    stats['skewness'] = df[column].skew()
-
-    return stats
-
-# Example interpretation
-stats = describe_for_journalism(df, 'salary')
-print(f"""
-SALARY ANALYSIS
----------------
-We analyzed {stats['count']:,} salary records.
-
-The median salary is ${stats['median']:,.0f}, meaning half of workers
-earn more and half earn less.
-
-The average salary is ${stats['mean']:,.0f}, which is
-{'higher' if stats['mean'] > stats['median'] else 'lower'} than the median,
-indicating the distribution is {'right-skewed (pulled up by high earners)'
-if stats['skewness'] > 0 else 'left-skewed'}.
-
-The top 10% of earners make at least ${stats['90th_percentile']:,.0f}.
-The top 1% make at least ${stats['99th_percentile']:,.0f}.
-""")
-```
-
-### Comparisons and context
-
-```python
-# Year-over-year change
-def calculate_change(current, previous):
-    """Calculate change with multiple metrics."""
-    absolute = current - previous
-    if previous != 0:
-        percent = (current - previous) / previous * 100
-    else:
-        percent = float('inf') if current > 0 else 0
-
-    return {
-        'current': current,
-        'previous': previous,
-        'absolute_change': absolute,
-        'percent_change': percent,
-        'direction': 'increased' if absolute > 0 else 'decreased' if absolute < 0 else 'unchanged'
-    }
-
-# Per capita calculations (essential for fair comparisons)
-def per_capita(value, population):
-    """Calculate per capita rate."""
-    return (value / population) * 100000  # Per 100,000 is standard
-
-# Example: Crime rates
-city_a = {'crimes': 5000, 'population': 100000}
-city_b = {'crimes': 8000, 'population': 500000}
-
-rate_a = per_capita(city_a['crimes'], city_a['population'])
-rate_b = per_capita(city_b['crimes'], city_b['population'])
-
-print(f"City A: {rate_a:.1f} crimes per 100,000 residents")
-print(f"City B: {rate_b:.1f} crimes per 100,000 residents")
-# City A actually has higher crime rate despite fewer total crimes!
-
-
-# Inflation adjustment
-def adjust_for_inflation(amount, from_year, to_year, cpi_data):
-    """Adjust dollar amounts for inflation."""
-    from_cpi = cpi_data[from_year]
-    to_cpi = cpi_data[to_year]
-    return amount * (to_cpi / from_cpi)
-
-# Always adjust when comparing dollars across years!
-```
-
-### Correlation vs causation
-
-```markdown
-## Reporting correlations responsibly
-
-### What you CAN say
-- "X and Y are correlated"
-- "As X increases, Y tends to increase"
-- "Areas with higher X also tend to have higher Y"
-- "X is associated with Y"
-
-### What you CANNOT say (without more evidence)
-- "X causes Y"
-- "X leads to Y"
-- "Y happens because of X"
-
-### Questions to ask before implying causation
-1. Is there a plausible mechanism?
-2. Does the timing make sense (cause before effect)?
-3. Is there a dose-response relationship?
-4. Has the finding been replicated?
-5. Have confounding variables been controlled?
-6. Are there alternative explanations?
-
-### Red flags for spurious correlations
-- Extremely high correlation (r > 0.95) with unrelated things
-- No logical connection between variables
-- Third variable could explain both
-- Small sample size with high variance
-```
-
-## Data visualization
-
-### Chart selection guide
-
-```markdown
-## Choosing the right chart
-
-### Comparison
-- **Bar chart**: Compare categories
-- **Grouped bar**: Compare categories across groups
-- **Bullet chart**: Actual vs target
-
-### Change over time
-- **Line chart**: Trends over time
-- **Area chart**: Cumulative totals over time
-- **Slope chart**: Change between two points
-
-### Distribution
-- **Histogram**: Distribution of one variable
-- **Box plot**: Compare distributions across groups
-- **Violin plot**: Detailed distribution shape
-
-### Relationship
-- **Scatter plot**: Relationship between two variables
-- **Bubble chart**: Three variables (x, y, size)
-- **Connected scatter**: Change in relationship over time
-
-### Composition
-- **Pie chart**: Parts of a whole (use sparingly, max 5 slices)
-- **Stacked bar**: Parts of whole across categories
-- **Treemap**: Hierarchical composition
-
-### Geographic
-- **Choropleth**: Values by region (use normalized data!)
-- **Dot map**: Individual locations
-- **Proportional symbol**: Magnitude at locations
-```
-
-### Visualization best practices
-
-```python
-import matplotlib.pyplot as plt
-import seaborn as sns
-
-# Journalist-friendly chart defaults
-plt.rcParams.update({
-    'figure.figsize': (10, 6),
-    'font.size': 12,
-    'axes.titlesize': 16,
-    'axes.labelsize': 12,
-    'axes.spines.top': False,
-    'axes.spines.right': False,
-})
-
-def create_bar_chart(data, title, source, xlabel='', ylabel=''):
-    """Create a publication-ready bar chart."""
-    fig, ax = plt.subplots()
-
-    # Create bars
-    bars = ax.bar(data.keys(), data.values(), color='#2c7bb6')
-
-    # Add value labels on bars
-    for bar in bars:
-        height = bar.get_height()
-        ax.annotate(f'{height:,.0f}',
-                    xy=(bar.get_x() + bar.get_width() / 2, height),
-                    ha='center', va='bottom',
-                    fontsize=10)
-
-    # Labels and title
-    ax.set_title(title, fontweight='bold', pad=20)
-    ax.set_xlabel(xlabel)
-    ax.set_ylabel(ylabel)
-
-    # Add source annotation
-    fig.text(0.99, 0.01, f'Source: {source}',
-             ha='right', va='bottom', fontsize=9, color='gray')
-
-    plt.tight_layout()
-    return fig
-
-# Example
-data = {'2020': 1200, '2021': 1450, '2022': 1380, '2023': 1620}
-fig = create_bar_chart(data,
-                       'Annual Widget Production',
-                       'Department of Widgets, 2024',
-                       ylabel='Units produced')
-fig.savefig('chart.png', dpi=150, bbox_inches='tight')
-```
-
-### Avoiding misleading visualizations
-
-```markdown
-## Chart integrity checklist
-
-### Axes
-- [ ] Y-axis starts at zero (for bar charts)
-- [ ] Axis labels are clear
-- [ ] Scale is appropriate (not truncated to exaggerate)
-- [ ] Both axes labeled with units
-
-### Data representation
-- [ ] All data points visible
-- [ ] Colors are distinguishable (including colorblind)
-- [ ] Proportions are accurate
-- [ ] 3D effects not distorting perception
-
-### Context
-- [ ] Title describes what's shown, not conclusion
-- [ ] Time period clearly stated
-- [ ] Source cited
-- [ ] Sample size/methodology noted if relevant
-- [ ] Uncertainty shown where appropriate
-
-### Honesty
-- [ ] Cherry-picking dates avoided
-- [ ] Outliers explained, not hidden
-- [ ] Dual axes justified (usually avoid)
-- [ ] Annotations don't mislead
-```
+Systematic approaches for finding, analyzing and presenting data in journalism.
 
 ## Story structure for data journalism
 
-### Data story framework
+### Data journalism framework
 
 ```markdown
+
+The framework for data journalism was established by Philip Meyer, a journalist for Knight-Ridder, Harvard Nieman Fellow and professor at UNC-Chapel Hill. In his book <i>The New Precision Journalism</i>, which outlines his ideas, Meyer encourages journalists to treat journalism "as if it were a science" by adopting the scientific method:
+- Making observation(s) / formulating a questiom
+- Researching the question / Collect, store and retrieve data
+- Formulate a hypothesis
+- Test the hypothesis, using both qualitative (interviews, documents etc.) and quantitative (data analysis etc.) methods
+- Analyze the results and reduce them to the most important findings
+- Present them to the audience
+
+This process should be thought of as iterative, rather than sequential.
+
 ## The data story arc
 
 ### 1. The hook (nut graf)
-- What's the key finding?
+- What's the key finding(s)?
 - Why should readers care?
 - What's the human impact?
 
@@ -550,20 +93,895 @@ fig.savefig('chart.png', dpi=150, bbox_inches='tight')
 [How readers can reach you with questions]
 ```
 
-## Tools and resources
+## Data acquisition
 
-### Essential tools
+### Public data sources
 
-| Tool | Purpose | Cost |
-|------|---------|------|
-| Python + pandas | Data analysis | Free |
-| R + tidyverse | Statistical analysis | Free |
-| Excel/Sheets | Quick analysis | Free/Low |
-| Datawrapper | Charts for web | Free tier |
-| Flourish | Interactive viz | Free tier |
-| QGIS | Mapping | Free |
-| Tabula | PDF table extraction | Free |
-| OpenRefine | Data cleaning | Free |
+```markdown
+## Federal data sources
+
+### General
+- Data.gov - Federal open data portal
+- Census Bureau (census.gov) - Demographics, economic data
+- BLS (bls.gov) - Employment, inflation, wages
+- BEA (bea.gov) - GDP, economic accounts
+- Federal Reserve (federalreserve.gov) - Financial data
+- SEC EDGAR - Corporate filings
+
+### Specific domains
+- EPA (epa.gov/data) - Environmental data
+- FDA (fda.gov/data) - Drug approvals, recalls, adverse events
+- CDC WONDER - Health statistics
+- NHTSA - Vehicle safety data
+- DOT - Transportation statistics
+- FEC - Campaign finance
+- USASpending.gov - Federal contracts and grants
+
+### State and local
+- State open data portals (search: "[state] open data")
+- Socrata-powered sites (many cities/states)
+- OpenStreets, municipal GIS portals
+- State comptroller/auditor reports
+```
+
+### Data request strategies
+
+```markdown
+## Getting data that isn't public
+
+### Public records request (ie. FOIA) for datasets
+- Request databases, not just documents
+- Ask for data dictionary/schema
+- Request in native format (CSV, SQL dump)
+- Specify field-level needs
+
+### Building your own dataset
+- Scraping public information
+- Crowdsourcing from readers
+- Systematic document review
+- Surveys (with proper methodology)
+
+### Commercial data sources (for newsrooms)
+- LexisNexis
+- Refinitiv
+- Bloomberg
+- Industry-specific databases
+```
+
+## Data cleaning and preparation
+
+### Common data problems
+
+```python
+from typing import Any
+
+import pandas as pd
+import numpy as np
+from rapidfuzz import fuzz
+from itertools import combinations
+
+# Inflation adjustment
+import cpi
+import wbdata
+
+def standardize_name(name: Any) -> str | None:
+    """Standardize name format to 'First Last'."""
+    if pd.isna(name):
+        return None
+    name = str(name).strip().upper()
+    # Handle "LAST, FIRST" format
+    if ',' in name:
+        parts = name.split(',')
+        name = f"{parts[1].strip()} {parts[0].strip()}"
+    return name
+
+def parse_date(date_str: Any) -> pd.Timestamp | None:
+    """Parse dates in various formats."""
+    if pd.isna(date_str):
+        return None
+
+    formats = [
+        '%m/%d/%Y', '%Y-%m-%d', '%B %d, %Y',
+        '%d-%b-%y', '%m-%d-%Y', '%Y/%m/%d'
+    ]
+
+    for fmt in formats:
+        try:
+            return pd.to_datetime(date_str, format=fmt)
+        except:
+            continue
+
+    # Fall back to pandas parser
+    try:
+        return pd.to_datetime(date_str)
+    except:
+        return None
+
+
+def handle_missing(df:pd.DataFrame, thresh:int | None, per_thresh:float | None, required_col:str | None) -> pd.DataFrame:
+    '''Handles Dataframes with too many missing values, defined by the user.''' 
+    if thresh and data_clean.isna().sum() >= thresh:
+        return df.dropna(subset=[required_col]).reset_index(drop=True).copy()
+    
+    elif per_thresh and (data_clean.isna().sum() / len(data_clean) * 100) >= per_thresh:
+        return df.dropna(subset=[required_col]).reset_index(drop=True).copy()
+    
+    else:
+        return df
+
+
+def handle_duplicates(df:pd.DataFrame, thresh=int | None)
+    '''Handle duplicate rows of data.'''
+    if thresh and df.duplicated().sum() >= thresh:
+        return df.drop_duplicates().reset_index(drop=True).copy()
+    else:
+        return df
+
+
+def flag_similar_names(df: pd.DataFrame, name_col: str, threshold: int = 85) -> pd.DataFrame:
+    """Flag rows that have potential duplicate names using vectorized comparison."""
+    
+    names = df[name_col].dropna().unique()
+    
+    # Use combinations() to avoid nested loop and duplicate comparisons
+    dup_names: set[Any] = {
+        name
+        for name1, name2 in combinations(names, 2)
+        if fuzz.ratio(str(name1).lower(), str(name2).lower()) >= threshold
+        for name in (name1, name2)
+    }
+    
+    df['has_similar_name'] = df[name_col].isin(dup_names)
+    return df
+
+
+def flag_outliers(series: pd.Series, method: str = 'iqr', threshold: float = 1.5) -> pd.Series:
+    """Flag statistical outliers."""
+    if method == 'iqr':
+        Q1 = series.quantile(0.25)
+        Q3 = series.quantile(0.75)
+        IQR = Q3 - Q1
+        lower = Q1 - threshold * IQR
+        upper = Q3 + threshold * IQR
+        return (series < lower) | (series > upper)
+    elif method == 'zscore':
+        z_scores = np.abs((series - series.mean()) / series.std())
+        return z_scores > threshold
+
+
+
+# use descriptive variable names and chain methods
+data_clean = (pd
+
+            # Load messy data — raw_data is a placeholder
+            # Be sure to use the right reader for the filetype
+            .read_csv('..data/raw/raw_data.csv')
+
+            # DATA TYPE CORRECTIONS
+            # Ensure proper types for analysis
+            .assign(# Convert to numeric (handling errors)
+                    amount = lambda x: pd.to_numeric(x['amount'], errors='coerce'),
+                    
+                    # Convert to categorical (saves memory, enables ordering)
+                    status = lambda x: pd.to_Categorical(x['status'])) 
+            
+            .assign(
+                    # INCONSISTENT FORMATTING
+                    # Problem: Names in different formats
+                    # ie. "SMITH, JOHN" vs "John Smith" vs "smith john"
+                    name_clean = lambda x: standaridize_name(x['name']),
+                    
+                    # DATE INCONSISTENCIES
+                    # Problem: Dates in multiple formats
+                    # ie. "01/15/2024", "2024-01-15", "January 15, 2024", "15-Jan-24"
+                    parse_date = lambda x: parse_date(x['date']),
+                    
+                    # OUTLIERS
+                    # Identify potential data entry errors
+                    amount_outlier = lambda x: flag_outliers(x['amount']),
+                    
+                    )
+            
+            # Fuzzy duplicates (similar but not identical)
+            # Use record linkage or manual review
+            .pipe(find_similar_names, name_col='name_clean', threshold=85)
+
+            # MISSING VALUES
+            # Strategy depends on context
+            # First check missing value patterns
+            .pipe(handle_missing, thresh=None, per_thresh=None)
+
+            # DUPLICATES — Find and handle duplicates
+            .pipe(handle_duplicates, thresh=None)
+            
+            .reset_index(drop=True)
+            .copy())
+
+
+```
+
+### Data validation checklist
+
+```markdown
+## Pre-analysis data validation
+
+### Structural checks
+- [ ] Row count matches expected
+- [ ] Column count and names correct
+- [ ] Data types appropriate
+- [ ] No unexpected null columns
+
+### Content checks
+- [ ] Date ranges make sense
+- [ ] Numeric values within expected bounds
+- [ ] Categorical values match expected options
+- [ ] Geographic data resolves correctly
+- [ ] IDs are unique where expected
+
+### Consistency checks
+- [ ] Totals add up to expected values
+- [ ] Cross-tabulations balance
+- [ ] Related fields are consistent
+- [ ] Time series is continuous
+
+### Source verification
+- [ ] Can trace back to original source
+- [ ] Methodology documented
+- [ ] Known limitations noted
+- [ ] Update frequency understood
+```
+
+## Statistical analysis for journalism
+
+### Basic statistics with context
+
+```python
+# Essential statistics for any dataset
+def describe_for_journalism(df: pd.DataFrame, col: str) -> pd.DataFrame:
+    """Generate journalist-friendly statistics."""
+    stats = df[col].describe(percentiles=[0.25, 0.5, 0.75, 0.9, 0.99])
+    
+    # Add skewness to the describe() output
+    stats['skewness'] = df[col].skew()
+    
+    return stats.to_frame(name=col)
+
+# Example interpretation
+stats = describe_for_journalism(salaries, 'salary')
+
+print(f"""
+ANALYSIS
+---------------
+We analyzed {stats['count']:,} salary records.
+
+The median salary is ${stats['median']:,.0f}, meaning half of workers
+earn more and half earn less.
+
+The average salary is ${stats['mean']:,.0f}, which is
+{'higher' if stats['mean'] > stats['median'] else 'lower'} than the median,
+indicating the distribution is {'right-skewed (pulled up by high earners)'
+if stats['skewness'] > 0 else 'left-skewed'}.
+
+The top 10% of earners make at least ${stats['90th_percentile']:,.0f}.
+The top 1% make at least ${stats['99th_percentile']:,.0f}.
+""")
+```
+
+### Comparisons and context
+
+```python
+# Calculate change metrics for a column
+def calculate_change(df: pd.DataFrame, col: str, periods: int = 1) -> pd.DataFrame:
+    """Add change metrics to a DataFrame using built-in pandas methods.
+    
+    Args:
+        df: Input DataFrame
+        col: Column to calculate changes for
+        periods: Number of rows to look back (1=previous row, 12=year-over-year for monthly)
+    """
+    return df.assign(
+        absolute_change=df[col].diff(periods),
+        percent_change=df[col].pct_change(periods) * 100,
+        direction=np.sign(df[col].diff(periods)).map({1: 'increased', -1: 'decreased', 0: 'unchanged'})
+    )
+
+# Usage:
+# changes = data_clean.pipe(calculate_change, 'revenue', periods=12) # Year-over-year for monthly data
+
+# Per capita calculations (essential for fair comparisons)
+def per_capita(value: float, population: float, multiplier: int = 100000) -> float:
+    """Calculate per capita rate."""
+    return (value / population) * multiplier  # Per 100,000 is standard
+
+# Example: Crime rates
+city_a = {'crimes': 5000, 'population': 100000}
+city_b = {'crimes': 8000, 'population': 500000}
+
+rate_a = per_capita(city_a['crimes'], city_a['population'])
+rate_b = per_capita(city_b['crimes'], city_b['population'])
+
+print(f"City A: {rate_a:.1f} crimes per 100,000 residents")
+print(f"City B: {rate_b:.1f} crimes per 100,000 residents")
+# City A actually has higher crime rate despite fewer total crimes!
+
+
+def adjust_for_inflation(
+    amount: float | pd.Series, 
+    from_year: int | pd.Series, 
+    to_year: int,
+    country: str = 'US'
+) -> float | pd.Series:
+    """Adjust dollar amounts for inflation. Works with scalars or Series for .assign().
+    
+    Args:
+        amount: Value(s) to adjust
+        from_year: Original year(s) of the amount
+        to_year: Target year to adjust to
+        country: ISO 2-letter country code (default 'US'). US uses BLS data via cpi package,
+                 others use World Bank CPI data (FP.CPI.TOTL indicator)
+    """
+    if country == 'US':
+        # Use cpi package for US (more accurate, from BLS)
+        if isinstance(from_year, pd.Series):
+            return pd.Series([cpi.inflate(amt, yr, to=to_year) 
+                            for amt, yr in zip(amount, from_year)], index=amount.index)
+        return cpi.inflate(amount, from_year, to=to_year)
+    else:
+        # Use World Bank data for other countries
+        cpi_data = wbdata.get_dataframe(
+            {'FP.CPI.TOTL': 'cpi'}, 
+            country=country
+        )['cpi'].to_dict()
+        
+        from_cpi = pd.Series(from_year).map(cpi_data) if isinstance(from_year, pd.Series) else cpi_data[from_year]
+        to_cpi = cpi_data[to_year]
+        return amount * (to_cpi / from_cpi)
+
+# Usage:
+# adjust_for_inflation(100, 2020, 2024)  # US by default
+# adjust_for_inflation(100, 2020, 2024, country='GB')  # UK
+# df.assign(inf_adjust24=lambda x: adjust_for_inflation(x['amount'], x['year'], 2024, country='DE'))
+
+# Always adjust when comparing dollars across years!
+```
+
+### Correlation vs causation
+
+```markdown
+## Reporting correlations responsibly
+
+### What you CAN say
+- "X and Y are correlated"
+- "As X increases, Y tends to increase"
+- "Areas with higher X also tend to have higher Y"
+- "X is associated with Y"
+
+### What you CANNOT say (without more evidence)
+- "X causes Y"
+- "X leads to Y"
+- "Y happens because of X"
+
+### Questions to ask before implying causation
+1. Is there a plausible mechanism?
+2. Does the timing make sense (cause before effect)?
+3. Is there a dose-response relationship?
+4. Has the finding been replicated?
+5. Have confounding variables been controlled?
+6. Are there alternative explanations?
+
+### Red flags for spurious correlations
+- Extremely high correlation (r > 0.95) with unrelated things
+- No logical connection between variables
+- Third variable could explain both
+- Small sample size with high variance
+```
+
+## Data visualization
+
+### Chart selection guide
+
+```markdown
+## Choosing the right chart
+
+### Comparison
+- **Bar chart**: Compare categories
+- **Grouped bar**: Compare categories across groups
+- **Bullet chart**: Actual vs target
+
+### Change over time
+- **Line chart**: Trends over time
+- **Area chart**: Cumulative totals over time
+- **Slope chart**: Change between two points
+
+### Distribution
+- **Histogram**: Distribution of one variable
+- **Box plot**: Compare distributions across groups
+- **Violin plot**: Detailed distribution shape
+
+### Relationship
+- **Scatter plot**: Relationship between two variables
+- **Bubble chart**: Three variables (x, y, size)
+- **Connected scatter**: Change in relationship over time
+
+### Composition
+- **Pie chart**: Parts of a whole (almost never use, max 5 slices, prefer donut charts)
+- **Donut chart**: Parts of a whole
+- **Stacked bar**: Parts of whole across categories
+- **Treemap**: Hierarchical composition
+
+### Geographic
+- **Choropleth**: Values by region (use normalized data!)
+- **Dot map**: Individual locations
+- **Proportional symbol**: Magnitude at locations
+```
+
+### Exploratory interactive visualizations with Plotly Express
+
+```python
+import plotly.express as px
+
+# Set default template for all charts
+px.defaults.template = 'simple_white'
+
+def create_bar_chart(
+    data: pd.DataFrame, 
+    title: str, 
+    source: str,
+    desc: str  = '', 
+    x_val: str, 
+    y_val: str,
+    x_lab: str | None,
+    y_lab: str | None
+) -> px.bar:
+    """Create a bar chart."""
+    
+    fig = px.bar(
+        data, 
+        x=x_val, 
+        y=y_val,
+        text=desc,
+        title=title,
+        labels={'category': (x_lab if x_lab else x_val), 'value': (y_lab if y_lab else y_val)}
+    )
+    
+    return fig
+
+# Example
+fig = create_bar_chart(
+    data,
+    title='Annual Widget Production',
+    source='Department of Widgets, 2024',
+    desc='The widget department increased its production dramatically starting in 2014.',
+    x_val='year',
+    y_val='widgets_prod',
+    x_lab='Year',
+    y_label='Units produced'
+)
+
+fig.show()  # Interactive display
+```
+
+### Publication-ready automated data visualizations with Datawrapper
+```python
+import pandas as pd
+import datawrapper as dw
+
+# Authentication: Set DATAWRAPPER_ACCESS_TOKEN environment variable, 
+# or read from file and pass to create()
+with open('datawrapper_api_key.txt', 'r') as f:
+    api_key = f.read().strip()
+
+# read in your data
+data = pd.read_csv('../data/raw/data.csv')
+
+# Create a bar chart using the new OOP API
+chart = dw.BarChart(
+    title='My Bar Chart Title',
+    intro='Subtitle or description text',
+    data=data,
+
+    # Formatting options
+    value_label_format=dw.NumberFormat.ONE_DECIMAL,
+    show_value_labels=True,
+    value_label_alignment='left',
+    sort_bars=True,  # sort by value
+    reverse_order=False,
+
+    # Source attribution
+    source_name='Your Data Source',
+    source_url='https://example.com',
+    byline='Your Name',
+
+    # Optional: custom base color
+    base_color='#1d81a2'
+)
+
+# Create and publish (uses DATAWRAPPER_ACCESS_TOKEN env var, or pass token)
+chart.create(access_token=api_key)
+chart.publish()
+
+# Get chart URL and embed code
+print(f"Chart ID: {chart.chart_id}")
+print(f"Chart URL: https://datawrapper.dwcdn.net/{chart.chart_id}")
+iframe_code = chart.get_iframe_code(responsive=True)
+
+# Update existing chart with new data (for live-updating charts)
+existing_chart = dw.get_chart('YOUR_CHART_ID')  # retrieve by ID
+existing_chart.data = new_df  # assign new DataFrame
+existing_chart.title = 'Updated Title'  # modify properties
+existing_chart.update()  # push changes to Datawrapper
+existing_chart.publish()  # republish to make live
+
+# Optional — Export chart as image
+chart.export(filepath='chart.png', width=800, height=600)
+
+#view chart
+chart
+```
+
+### Avoiding misleading visualizations
+
+```markdown
+## Chart integrity checklist
+
+### Axes
+- [ ] Y-axis starts at zero (for bar charts)
+- [ ] Axis labels are clear
+- [ ] Scale is appropriate (not truncated to exaggerate)
+- [ ] Both axes labeled with units
+
+### Data representation
+- [ ] All data points visible
+- [ ] Colors are distinguishable (including colorblind)
+- [ ] Proportions are accurate
+- [ ] 3D effects not distorting perception
+
+### Context
+- [ ] Title describes what's shown, not conclusion
+- [ ] Time period clearly stated
+- [ ] Source cited
+- [ ] Sample size/methodology noted if relevant
+- [ ] Uncertainty shown where appropriate
+
+### Honesty
+- [ ] Cherry-picking dates avoided
+- [ ] Outliers explained, not hidden
+- [ ] Dual axes justified (usually avoid)
+- [ ] Annotations don't mislead
+```
+## Working with geospatial data
+
+### Geocoding data
+
+#### U.S. Census Geocoder
+
+**Best for:** U.S. addresses only. Returns Census geography (tract, block, FIPS codes) along with coordinates—essential for joining with Census demographic data.
+
+**Pros:** Completely free with no API key required. Returns Census geographies (state/county FIPS, tract, block) that let you join with ACS/decennial Census data. Good match rates for standard U.S. addresses.
+
+**Cons:** Limited to 10,000 addresses per batch. U.S. addresses only. Slower than commercial alternatives. Lower match rates for non-standard addresses (PO boxes, rural routes, new construction).
+
+**Use when:** You need to geocode nicely formatted U.S. addresses or you don't have budget for a paid service. 
+
+```python
+# pip install censusbatchgeocoder
+import censusbatchgeocoder
+import pandas as pd
+
+# DataFrame must have columns: id, address, city, state, zipcode
+# (state and zipcode are optional but improve match rates)
+
+def census_geocode(
+    df: pd.DataFrame,
+    id_col: str = 'id',
+    address_col: str = 'address',
+    city_col: str = 'city',
+    state_col: str = 'state',
+    zipcode_col: str = 'zipcode',
+    chunk_size: int = 9999
+) -> pd.DataFrame:
+    """
+    Geocode a DataFrame using the U.S. Census batch geocoder.
+    Automatically handles datasets larger than 10,000 rows by chunking.
+    
+    Returns DataFrame with: latitude, longitude, state_fips, county_fips, 
+    tract, block, is_match, is_exact, returned_address, geocoded_address
+    """
+    # Rename columns to expected format
+    col_map = {id_col: 'id', address_col: 'address', city_col: 'city'}
+    if state_col and state_col in df.columns:
+        col_map[state_col] = 'state'
+    if zipcode_col and zipcode_col in df.columns:
+        col_map[zipcode_col] = 'zipcode'
+    
+    renamed_df = df.rename(columns=col_map)
+    records = renamed_df.to_dict('records')
+    
+    # Small dataset: geocode directly
+    if len(records) <= chunk_size:
+        results = censusbatchgeocoder.geocode(records)
+        return pd.DataFrame(results)
+    
+    # Large dataset: process in chunks to stay under 10,000 limit
+    all_results = []
+    for i in range(0, len(records), chunk_size):
+        chunk = records[i:i + chunk_size]
+        print(f"Geocoding rows {i:,} to {i + len(chunk):,} of {len(records):,}...")
+        
+        try:
+            results = censusbatchgeocoder.geocode(chunk)
+            all_results.extend(results)
+        except Exception as e:
+            print(f"Error on chunk starting at {i}: {e}")
+            for record in chunk:
+                all_results.append({**record, 'is_match': 'No_Match', 'latitude': None, 'longitude': None})
+    
+    return pd.DataFrame(all_results)
+
+# Usage:
+geocoded = (pd
+              .read_csv('../data/raw/addresses.csv')
+              .assign(id=lambda x: x.index)
+              .pipe(census_geocode, 
+                    id_col='id', 
+                    address_col='street', 
+                    city_col='city'.
+                    state_col='state',
+                    zipcode_col='zip'))
+```
+
+#### Google Maps Geocoder
+
+**Best for:** International addresses, high match rates, and messy/non-standard address formats.
+
+**Pros:** Excellent match rates even for poorly formatted addresses. Works worldwide. Fast and reliable. Returns rich metadata (place types, address components, place IDs).
+
+**Cons:** Costs money ($5 per 1,000 requests after free tier). Requires API key and billing account. Does not return Census geography—you'd need to do a separate spatial join.
+
+**Use when:** You need to geocode international addresses, have messy address data that the Census geocoder can't match, or need the highest possible match rate and have budget for it.
+
+```python
+import googlemaps
+from typing import Optional
+
+def geocode_address_google(address: str, api_key: str) -> Optional[dict]:
+    """
+    Geocode address using Google Maps API.
+    Requires API key with Geocoding API enabled.
+    """
+    gmaps = googlemaps.Client(key=api_key)
+    result = gmaps.geocode(address)
+    
+    if result:
+        location = result[0]['geometry']['location']
+        return {
+            'formatted_address': result[0]['formatted_address'],
+            'lat': location['lat'],
+            'lon': location['lng'],
+            'place_id': result[0]['place_id']
+        }
+    return None
+
+# Batch geocode a DataFrame
+def batch_geocode(df: pd.DataFrame, address_col: str, api_key: str) -> pd.DataFrame:
+    gmaps = googlemaps.Client(key=api_key)
+    
+    results = []
+    for address in df[address_col]:
+        try:
+            result = gmaps.geocode(address)
+            if result:
+                loc = result[0]['geometry']['location']
+                results.append({'lat': loc['lat'], 'lon': loc['lng']})
+            else:
+                results.append({'lat': None, 'lon': None})
+        except Exception:
+            results.append({'lat': None, 'lon': None})
+    
+    return pd.concat([df, pd.DataFrame(results)], axis=1)
+```
+
+### Geopandas
+```python
+import geopandas as gpd
+import pandas as pd
+from shapely.geometry import Point
+
+# Read data from various formats
+gdf = gpd.read_file('data.geojson')                    # GeoJSON
+gdf = gpd.read_file('data.shp')                         # Shapefile
+gdf = gpd.read_file('https://example.com/data.geojson') # From URL
+gdf = gpd.read_parquet('data.parquet')                  # GeoParquet (fast!)
+
+# Transform DataFrame with lat/lon to GeoDataFrame
+df = pd.read_csv('locations.csv')
+geometry = [Point(xy) for xy in zip(df['longitude'], df['latitude'])]
+gdf = gpd.GeoDataFrame(df, geometry=geometry)
+
+# Set CRS (Coordinate Reference System)
+# EPSG:4326 = WGS84 (standard latitude, longitude)
+gdf = gdf.set_crs('EPSG:4326')
+
+# Transform to different CRS (for area/distance calculations, use projected CRS)
+gdf_projected = gdf.to_crs('EPSG:3857')  # Web Mercator, for distance in meters
+
+# Basic spatial operations
+
+#Find the area of a shape
+gdf['area'] = gdf_projected.geometry.area 
+
+#Find the center of a shape
+gdf['centroid'] = gdf.geometry.centroid
+
+#Draw a 1km boundary around a point
+gdf['buffer_1km'] = gdf_projected.geometry.buffer(1000) #when set to CRS 3857
+
+# Spatial join: find points within polygons
+points = gpd.read_file('points.geojson')
+polygons = gpd.read_file('boundaries.geojson')
+joined = gpd.sjoin(points, polygons, predicate='within')
+
+# Dissolve: merge geometries by attribute
+dissolved = gdf.dissolve(by='state', aggfunc='sum')
+
+# Export to various formats
+gdf.to_parquet('output.parquet')          # GeoParquet (recommended)
+gdf.to_file('output.geojson', driver='GeoJSON') #for tools that dont support GeoParquet
+```
+
+### Geo-Visualization with `.explore()`, `lonboard` and Datawrapper
+
+#### `.explore()`
+
+**Best for:** Quick exploration and prototyping during data analysis.
+
+**Pros:** Built into GeoPandas—method is available on any GeoDataFrame. Great for exploratory data analysis—checking that your data looks right, exploring spatial patterns, and iterating quickly on map designs.
+
+**Cons:** Becomes slow with large datasets (>100k features). Limited customization compared to dedicated mapping libraries. Requires extra dependencies to be installed.
+
+**Use when:** You're in the middle of analysis and want to quickly visualize your GeoDataFrame without switching tools.
+
+**Required dependencies:**
+```bash
+pip install folium mapclassify matplotlib
+```
+- `folium` - Required for `.explore()` to work at all (renders the interactive map)
+- `mapclassify` - Required when using `scheme=` parameter for classification (e.g., 'naturalbreaks', 'quantiles', 'equalinterval')
+- `matplotlib` - Required for colormap (`cmap=`) support
+
+```python
+import geopandas as gpd
+# folium, mapclassify, and matplotlib must be installed but don't need to be imported
+# geopandas imports them automatically when you call .explore()
+
+# Basic interactive map (uses folium under the hood)
+gdf.explore()
+
+# Choropleth map with customization
+# (requires mapclassify for scheme parameter)
+gdf.explore(
+    column='population',           # Column for color scale
+    cmap='YlOrRd',                 # Matplotlib colormap
+    scheme='naturalbreaks',        # Classification scheme (needs mapclassify)
+    k=5,                           # Number of bins
+    legend=True,
+    tooltip=['name', 'population'],  # Columns to show on hover
+    popup=True,                    # Show all columns on click
+    tiles='CartoDB positron',      # Background tiles
+    style_kwds={'color': 'black', 'weight': 0.5}  # Border style
+)
+```
+
+#### `lonboard`
+
+**Best for:** Large datasets and high-performance visualization in Jupyter notebooks.
+
+**Pros:** GPU-accelerated rendering via deck.gl can handle millions of points smoothly. Excellent interactivity—pan, zoom, and hover work fluidly even with massive datasets. Native support for GeoArrow format for efficient data transfer.
+
+**Cons:** Requires separate installation (`pip install lonboard`). Styling options are more technical (RGBA arrays, deck.gl conventions). 
+
+**Use when:** You have large point datasets (crime incidents, sensor readings, business locations) or need smooth interactivity with 100k+ features.
+
+```python
+import geopandas as gpd
+from lonboard import viz, Map, ScatterplotLayer, PolygonLayer
+
+# Quick visualization (auto-detects geometry type)
+viz(gdf)
+
+# Custom ScatterplotLayer for points
+layer = ScatterplotLayer.from_geopandas(
+    gdf,
+    get_radius=100,
+    get_fill_color=[255, 0, 0, 200],  # RGBA
+    pickable=True
+)
+m = Map(layer)
+m
+
+# PolygonLayer with color based on column
+from lonboard.colormap import apply_continuous_cmap
+import matplotlib.pyplot as plt
+
+colors = apply_continuous_cmap(gdf['value'], plt.cm.viridis)
+layer = PolygonLayer.from_geopandas(
+    gdf,
+    get_fill_color=colors,
+    get_line_color=[0, 0, 0, 100],
+    pickable=True
+)
+Map(layer)
+```
+
+#### Datawrapper
+
+**Best for:** Publication-ready choropleth and proportional symbol maps for articles and reports.
+
+**Pros:** Beautiful, professional defaults out of the box. Generates embeddable, responsive iframes that work in any CMS. Readers can interact (hover, click) without running any code. Accessible and mobile-friendly. Easy to update data programmatically for updating data.
+
+**Cons:** Requires a Datawrapper account (free tier available). Limited to Datawrapper's supported boundary files—you can't bring arbitrary geometries. Less flexibility for custom visualizations.
+
+**Use when:** You need a polished map for publication. Ideal for choropleth maps showing statistics by region (unemployment by state, COVID cases by county, election results by district). Your audience will view the map in a browser, not a notebook.
+
+Unlike `.explore()` or `lonboard`, you don't pass raw geometry—instead you match your data to Datawrapper's built-in boundary files using standard codes (FIPS, ISO, etc.).
+
+```python
+import datawrapper as dw
+import pandas as pd
+
+# Read API key
+with open('datawrapper_api_key.txt', 'r') as f:
+    api_key = f.read().strip()
+
+# Prepare data with location codes that match Datawrapper's boundaries
+# For US states: use 2-letter abbreviations or FIPS codes
+# For countries: use ISO 3166-1 alpha-2 codes
+df = pd.DataFrame({
+    'state': ['AL', 'AK', 'AZ', 'AR', 'CA'],  # State abbreviations
+    'unemployment_rate': [4.9, 3.2, 7.1, 4.2, 5.8]
+})
+
+# Create a choropleth map
+chart = dw.ChoroplethMap(
+    title='Unemployment Rate by State',
+    intro='Percentage of labor force unemployed, 2024',
+    data=df,
+
+    # Map configuration
+    basemap='us-states',           # Built-in US states boundaries
+    basemap_key='state',           # Column in your data with location codes
+    value_column='unemployment_rate',
+
+    # Styling
+    color_palette='YlOrRd',        # Color scheme
+    legend_title='Unemployment %',
+
+    # Attribution
+    source_name='Bureau of Labor Statistics',
+    source_url='https://www.bls.gov/',
+    byline='Your Name'
+)
+
+# Create and publish
+chart.create(access_token=api_key)
+chart.publish()
+
+# Get embed code for your article
+iframe = chart.get_iframe_code(responsive=True)
+print(f"Chart URL: https://datawrapper.dwcdn.net/{chart.chart_id}")
+
+# Update with new data (for live-updating maps)
+new_df = pd.DataFrame({...})  # Updated data
+existing_chart = dw.get_chart('YOUR_CHART_ID')
+existing_chart.data = new_df
+existing_chart.update()
+existing_chart.publish()
+```
+
+**Available Datawrapper basemaps include:**
+- `us-states`, `us-counties`, `us-congressional-districts`
+- `world`, `europe`, `africa`, `asia`
+- Country-specific maps (e.g., `germany-states`, `uk-constituencies`)
 
 ### Learning resources
 
@@ -572,3 +990,4 @@ fig.savefig('chart.png', dpi=150, bbox_inches='tight')
 - Data Journalism Handbook (datajournalism.com)
 - Flowing Data (flowingdata.com)
 - The Pudding (pudding.cool) - examples
+- Sigma Awards (https://www.sigmaawards.org/) - examples

--- a/foia-requests/SKILL.md
+++ b/foia-requests/SKILL.md
@@ -17,10 +17,10 @@ Comprehensive guide for obtaining government records through freedom of informat
 | State | Varies by state (e.g., OPRA in NJ, FOIL in NY) | State and local agencies |
 | Local | Often covered by state law | Municipal, county, school boards |
 
-### Key federal exemptions (FOIA)
+### Key federal exemptions (U.S. Federal FOIA)
 
 ```markdown
-## The 9 FOIA exemptions
+## The 9 federal FOIA exemptions
 
 1. **National security** - Classified information
 2. **Internal personnel rules** - Agency housekeeping matters
@@ -35,59 +35,216 @@ Comprehensive guide for obtaining government records through freedom of informat
 Note: Agencies must segregate and release non-exempt portions
 ```
 
+## State public records laws
+
+All 50 states have enacted laws requiring certain government records to be open to the public. 
+
+### State-specific resources
+
+```markdown
+### State public records resources
+
+#### Reporters Committee for Freedom of the Press
+- Open Government Guide: rcfp.org/open-government-guide
+- State-by-state analysis of public records laws
+- Sample request letters by state
+
+#### National Freedom of Information Coalition
+- nfoic.org/state-freedom-of-information-laws
+- State FOI organization contacts
+- Training and resources
+
+#### MuckRock
+- muckrock.com
+- File requests through platform
+- Search previous requests/responses
+- Agency response time data
+```
+
+### Common state examptions
+State legislatures may be subject to different rules than the rest of their governing bodies:
+
+1. **Exempt from public records statute** (e.g., Massachusetts, Oklahoma, Oregon, Wyoming)
+2. **Excluded from definition of public body** (e.g., Georgia, Minnesota)
+3. **Covered by separate statute** (e.g., California)
+4. **Allowed to set own policies** (e.g., Mississippi, New York)
+
+Court decisions and attorneys general opinions in some states have held that the separation of powers doctrine prevents courts from enforcing public records statutes against the legislature.
+
+### State-by-state reference
+
+| State | Public Records Law | Legislative Exemptions/Notes |
+|-------|-------------------|------------------------------|
+| Alabama | AL Code § 36-12-40 et seq. | AL Code § 29-6-7.1 Legislative confidential communication |
+| Alaska | AK Stat. § 40.25.110 | AK Stat. § 24.20.100 Research and drafting services confidential |
+| Arizona | AZ Rev. Stat. § 39-121.01 | AZ Rev. Stat. § 41-1279.05 Confidential records of auditor general |
+| Arkansas | AR Code Ann. § 25-19-101 et seq. | AR Code Ann. § 10-2-129; § 10-4-422; § 25-19-105(b)(7) |
+| California | CA Govt. Code § 7920 et seq. | CA Govt. Code § 9070 et seq. Legislative Open Records Act |
+| Colorado | CO Rev. Stat. Ann. § 24-72-200 et seq. | CO Rev. Stat. Ann. § 24-72-202(6); § 2-3-505(2) |
+| Connecticut | CT Gen. Stat. § 1-200 et seq. | CT Gen. Stat. § 1-210(b)(19); § 52-146r |
+| Delaware | 29 Del. Laws, c. 100 § 10001 et seq. | § 10002(o)(16 & 19) Exempt records; GA emails |
+| Florida | FL Stat. § 119.01 et seq. | FL Stat. § 11.0431(2); § 11.26; § 15.07 |
+| Georgia | O.C.G.A. § 50-18-70 et seq. | General Assembly not included in definitions |
+| Hawaii | HI Rev. Stat. § 92F-1 et seq. | HI Rev. Stat. § 84-12; § 92F-13(5); § 23G-4 |
+| Idaho | ID Stat. § 74-101 et seq. | ID Stat. § 74-109 Draft legislation exempt |
+| Illinois | 5 ILCS 140/1 | 5 ILCS 140/7(1)(f) Legislative documents exempt |
+| Indiana | IN Code § 5-14-3-1 et seq. | IN Code § 5-14-3-4(b)(13) & (14) Staff work products exempt |
+| Iowa | IA Code § 22.1 et seq. | IA Code § 2A.1(3); § 23.12 |
+| Kansas | K.S.A. § 45-215 et seq. | K.S.A. § 45-217(l)(3)(B); § 45-221(a)(20)-(22) |
+| Kentucky | KRS § 61.870 et seq. | KRS § 7.117; § 7.119; § 7.120 |
+| Louisiana | LA Rev. Stat. § 44:1 et seq. | LA Rev. Stat. § 44:4(6); § 44:4.1; § 44:2 |
+| Maine | ME Rev. Stat. Tit. 1 § 400 et seq. | ME Rev. Stat. Tit. 1 § 402(3)(C) Legislative exception |
+| Maryland | MD General Provisions Code § 4-101 et seq. | MD State Govt. Code § 2–1226 |
+| Massachusetts | MA Gen. Laws Ch. 66 § 1 et seq. | Ch. 66 § 18 General Court exempt |
+| Michigan | MI Comp. Laws § 15.231 | MI Comp. Laws § 4.1109 LSB confidentiality |
+| Minnesota | MN Stat. § 13.03 | MN Stat. § 3C.05; § 10.46; § 3.098 |
+| Mississippi | MS Code Ann. § 25-61-1 et seq. | MS Code Ann. § 25-61-17 Legislature regulates own records |
+| Missouri | MO Rev. Stat. § 610.010 et seq. | MO Rev. Stat. § 610.010(6); § 610.021 |
+| Montana | MT Code Ann. § 2-6-1001 et seq. | N/A |
+| Nebraska | NE Rev. Stat. § 84-712 et seq. | NE Rev. Stat. § 84-712.05(14) |
+| Nevada | NV Rev. Stat. § 239.001 et seq. | NV Rev. Stat. § 41.071; § 218F.150 |
+| New Hampshire | NH Rev. Stat. § 91-A:1 et seq. | NH Rev. Stat. § 91-A:5(IX) |
+| New Jersey | NJ Rev. Stat. § 47:1A-1 et seq. | NJ Rev. Stat. § 47:1A-1.1; § 52:13D-22(d) |
+| New Mexico | NM Stat. § 14-2-1 et seq. | NM Stat. § 2-3-13 Services confidential |
+| New York | NY PBO Article 6 § 84 et seq. | NY PBO Article 6 § 88; Article 4 § 74(c) |
+| North Carolina | NC G.S. § 132-1 et seq. | NC G.S. § 120 et seq. Confidentiality of communications |
+| North Dakota | ND Cent. Code § 44-04-18 et seq. | ND Cent. Code § 44-04-18.6 |
+| Ohio | OH Rev. Code § 149.43 | OH Rev. Code § 101.30 Staff confidentiality |
+| Oklahoma | OK Stat. Tit. 51 § 24A.1 et seq. | Legislature not a public body under OORA |
+| Oregon | ORS § 192.001 et seq. | ORS § 192.311(6); § 192.355; § 171.405 |
+| Pennsylvania | 65 Pa. Stat. § 67.101 et seq. | 101 Pa. Code § 3.6 |
+| Rhode Island | R.I. Gen. Laws § 38-2-1 et seq. | R.I. Gen. Laws § 38-2-2(4)(K & M) |
+| South Carolina | SC Code § 30-4-10 et seq. | SC Code § 30-4-40(a)(7 & 8) |
+| South Dakota | SD Cod. Laws § 1-27-1 et seq. | SD Cod. Laws § 1-27-1.5(12 & 19); § 19-19-508 |
+| Tennessee | Tenn. Code Ann. § 10-7-503 et seq. | Tenn. Code Ann. § 3-12-105; § 3-12-106 |
+| Texas | TX Stat. Gov. Code § 552.001 et seq. | § 306.003; § 323.017-018; § 325.0195; § 552.106; § 552.111; § 552.146 |
+| Utah | UT Code § 63G-2-101 | UT Code § 63G-2-305(19-22); § 63G-2-703; § 63G-2-208 |
+| Vermont | 1 V.S.A. § 315 et seq. | 2 V.S.A. 403(b)(1) Legislative council requests confidential |
+| Virginia | VA Code § 2.2-3700 et seq. | VA Code § 30-28.18; § 2.2-3705.7(2) |
+| Washington | RCW 42.56 | RCW 1.08.027; RCW 40.14.180; RCW 42.56.280 |
+| West Virginia | WV Code § 29B | WV Code § 4-1A-6; § 4-1A-7; § 4-1A-12 |
+| Wisconsin | WI Stat. § 19.21 et seq. | WI Stat. § 13.91 et seq.; § 16.61(2)(b)(1) |
+| Wyoming | WY Stat. Ann. § 16-4-201 et seq. | WY Stat. Ann. § 28-8-116 |
+
+*Source: [National Conference of State Legislatures](https://www.ncsl.org/center-for-legislative-strengthening/public-records-law-and-state-legislatures), Updated April 2025*
+
 ## Drafting effective requests
 
 ### Request template (Federal FOIA)
 
 ```markdown
-[Your Name]
-[Your Address]
-[City, State ZIP]
-[Email]
-[Phone]
+[NAMES]
+[ADDRESS]
+[CITY],[STATE] [ZIPCODE]
+[EMAIL]
+[PHONE]
 
-[Date]
+[DATE]
 
 FOIA Officer
-[Agency Name]
-[Agency Address]
+[AGENCY]
+[AGENCY_ADDRESS]
 
-RE: Freedom of Information Act Request
+[STATUTE] Request
 
 Dear FOIA Officer:
 
-Pursuant to the Freedom of Information Act, 5 U.S.C. § 552, I request access to and copies of:
+My name is [NAME] and I am a [TITLE] for [OUTLET]. Pursuant to the [STATUTE], I am writing to request the following:
 
-[DESCRIBE RECORDS SPECIFICALLY]
+- [RECORDS_REQUESTED1] between [START_DATE] to [END_DATE] from [SPECIFIC_OFFICES] including the following words/phrases [KEYWORD1], [KEYWORD2], [KEYWORD3], [KEYWORD4] 
+- [RECORDS_REQUESTED2] between [START_DATE] to [END_DATE] from [SPECIFIC_OFFICES] including the following words/phrases [KEYWORD1], [KEYWORD2], [KEYWORD3], [KEYWORD4] 
+- [RECORDS_REQUESTED3] between [START_DATE] to [END_DATE] from [SPECIFIC_OFFICES] including the following words/phrases [KEYWORD1], [KEYWORD2], [KEYWORD3], [KEYWORD4] 
 
-**Scope and timeframe:**
-- Date range: [START DATE] to [END DATE]
-- Offices/divisions: [SPECIFIC OFFICES if known]
-- Keywords: [RELEVANT SEARCH TERMS]
+**INSTRUCTIONS REGARDING SEARCH:**
+1. Instructions Regarding "Leads":
+As required by the relevant case law, [AGENCY] should follow any leads it discovers during the conduct of its searches and perform additional searches when said leads indicate that records may be located in another system. Failure to follow clear leads is a violation of [STATUTE].
+
+2. Request for Public Records:
+Please search for any records even if they are already publicly available.
+
+3. Request Regarding Attachments, Photographs and Other Visual Materials:
+I request that any photographs or other visual materials responsive to my request be released to me in their original or comparable forms, quality and resolution. For example, if a photograph was taken digitally, or if [AGENCY] maintains a photograph digitally, I request disclosure of the original digital image file, not a reduced resolution version of that image file nor a printout and scan of that image file.
+
+Likewise, if a photograph was originally taken as a color photograph, I request disclosure of that photograph as a color image, not a black and white image. 
+
+For video and audio files I request that they be provided in their complete, original and unedited format. 
+
+Please contact me at the number or email listed below for any clarification on these points.
+
+4. Request for Duplicate Pages:
+l request disclosure of any and all supposedly "duplicate" pages. Scholars analyze records not only for the information available on any given page, but also for the relationships between that information and information on pages surrounding it. As such, though certain pages may have been previously released to me, the existence of those pages within new context renders them functionally new pages. As such, the only way to properly analyze released information is to analyze that information within its proper context. Therefore, I request disclosure of all "duplicate" pages.
+
+5. Request for Search of Records Transferred to Other Agencies:
+I request that in conducting its search, [AGENCY] should disclose releasable records even if they are available publicly through other sources outside the [AGENCY] office. If [AGENCY] is unable to do so, it should disclose where specifically the relevant records are available.
+
+6. Regarding Destroyed Records
+If any records responsive or potentially responsive to my request have been destroyed, my request includes, but is not limited to, any and all records relating or referring to the destruction of those records. This includes, but is not limited to, any and all records relating or referring to the events leading to the destruction of those records.
+
+INSTRUCTIONS REGARDING SCOPE AND BREADTH OF REQUESTS
+Please interpret the scope of this request broadly. [AGENCY] is instructed to interpret the scope of this request in the most liberal manner possible short of an interpretation that would lead to a conclusion that the request does not reasonably describe the records sought.
+
+EXEMPTIONS AND SEGREGABILITY
+I call your attention to a 21 January 2009 Memorandum concerning the Freedom of Information Act, in which the President states: 
+All agencies should adopt a presumption in favor of disclosure, in order to renew their commitment to the principles embodied in FOIA 
+[ .... ] The presumption of disclosure should be applied to all decisions involving FOIA.
+
+In the same Memorandum, he added that government information should not be kept confidential "merely because public officials might be embarrassed by disclosure, because errors and failures might be revealed, or because of speculative or abstract fears.''
+
+Finally, the President ordered that "The Freedom of Information Act should be administered with a clear presumption: In the case of doubt, openness prevails."
+
+Nonetheless, if any responsive record or portion thereof is claimed to be exempt from production, FOIA statutes provide that even if some of the requested material is properly exempt from mandatory disclosure, all segregable portions must be released. If documents are denied in part or in whole, please specify which exemption(s) is (are) claimed for each passage or whole document denied. 
+
+Please provide a complete itemized inventory and a detailed factual justification of total or partial denial of documents. Specify the number of pages in each document and the total number of pages pertaining to this request. For "classified" material denied, please include the following
+information: the classification (confidential, secret or top secret); identity of the classifier; date or event for automatic declassification or classification review or downgrading; if applicable, identity of official authorizing extension of automatic declassification or review past six years; and, if applicable, the reason for extended classification beyond six years.
+
+In excising material, please "black out" the material rather than "white out" or "cut out." I expect, as provided by FOIA, that the remaining non-exempt portions of documents will be released.
+
+Please release all pages regardless of the extent of excising, even if all that remains are the stationary headings or administrative markings.
+
+In addition, I ask that your agency exercise its discretion to release records which may be technically exempt, but where withholding serves no important public interest.
+
 
 **Format requested:**
-I request records in electronic format (PDF, native format) delivered via email to [your email] or via an online portal.
+I request that any releases stemming from this request be provided to me in its original digital format (soft-copy), ideally through an online file transfer or digital portal system. Should this be impossible, material may be provided on a compact disk, flash drive, hard drive or other like media.
 
-**Fee waiver request:**
-I request a waiver of all fees associated with this request. Disclosure is in the public interest because:
-- [Explain how information contributes to public understanding]
-- [Explain why you are positioned to disseminate information]
-- [State if affiliated with news organization or research institution]
+I request that you provide records as they become available, rather than all at once.
 
-Alternatively, if fees cannot be waived, I am willing to pay up to $[AMOUNT] for processing. Please contact me before exceeding this amount.
+Please produce all records with administrative markings and pagination included.
+
+Please send a memo (copy to me) to the appropriate units in your office to assure that no records related to this request are destroyed. Please advise of any destruction of records and include the date of and authority for such destruction.
+
+
+**Fee waiver request (for U.S. federal FOIA):**
+I am an [JOB_TITLE] for [CURRENT_OUTLET] covering a wide-range of issues. My reporting has been published in [PRIOR_OUTLETS] and other outlets.
+
+I am willing to pay any reasonable expenses, up to $[AMOUNT], associated with this request, however, as the purpose of the requested disclosure is in full conformity with the statutory requirements for a waiver of fees, I formally request such a waiver. I request a waiver of all costs pursuant to 5 U.S.C. §552(a }( 4 HA)( iii l ("Documents shall be furnished without any charge ... if disclosure of the information is in the public interest because it is likely to contribute significantly to public understanding of the operations or activities of the government and is not primarily in the commercial interest of the requester ... ). Disclosure in this case meets the statutory criteria. and a foe waiver would fulfill Congress’s legislative intent in amending FOIA. Sec Judicial Watch. Inc. v. Rossotti. 326 F.3d 1309. 1312 (D.C. Cir. 2003) ("Congress amended FOIA to ensure that it be liberally construed in favor of waivers for noncommercial requesters.""). I incorporate by reference the explanation and attached materials in the above sections which demonstrates why the requested information is in the public interest.
+
+Should my request for a fee waiver be denied, I request that I be categorized as a member of the news media for fee purposes pursuant to DoJ 5400.7-R C6.l.5.7. According to 5 U.S.C. § 552(a)(4l(A)(ii), which codified the ruling of Nat'I Security Archive v. Dept of Defense, 880 F.2d 1381 (D.C. Cir. 1989). the term "a representative of the news media" means any person or entity that gathers information of potential interest to a segment of the public. Uses its editorial skills to turn the raw materials into a distinct work, and distributes that work to an audience. 
+
+If the fee waiver is denied, I also request that all charges be itemized in writing.
+
+As the legislative history of FOIA reveals, it is critical that the phrase 'representative of the news media' be broadly interpreted if the act is to work as expected .... In fact, any person or organization which regularly publishes or disseminates information to the public … should qualit:y for waivers as a ·representative of the news media."' 132 Cong. Rec. SI 4298 ( daily ed. Sept. 30. 1986) (emphasis in original quotation); and 2) ''A request by a reporter or other person affiliated with a newspaper. magazine. television or radio station, or other entity that is in the business of publishing or otherwise disseminating information to the public qualifies under this provision.'' 132 Cong. Rec. I 19463 ( Oct. 8. I 986) ( emphasis in original quotation) J. Therefore, in accordance with the Freedom of Information Act and relevant case law, I, Arijit Sen, should be considered a representative of the news media.
+
+I have the intent and ability to disseminate this significant expansion of public understanding of government operations. The public interest presented in this case far outweighs any commercial interest of my own in the requested release. For these reasons and based upon their extensive elaboration above, I request a full waiver of fees be granted. 
+
+I will appeal any denial of my request for a waiver administratively and to the courts if necessary.
 
 **Expedited processing request (if applicable):**
 I request expedited processing because:
 - [Urgent need to inform the public about actual or alleged government activity]
 - [Imminent threat to life or physical safety]
 
-**Contact information:**
-Please contact me at [email] or [phone] if you have questions or need clarification about this request.
+As a reminder [TIME_LIMIT_STATUTE] requries a response with [DAYS_NUMBER] days.
 
-I expect a response within 20 business days as required by law.
+**Contact information:**
+Please do not hesitate to contact me at [EMAIL] or [PHONE] if you have questions or need clarification about this request.
+
+Thank you. I appreciate your time and attention to this matter.
 
 Sincerely,
 [Your Name]
+
+*Template Source: [Jason Leopold](https://www.dni.gov/files/documents/FOIA/DF_2023_00079_15_Oldest_Appeal_FOIA_Cases_cont.pdf)*
 ```
 
 ### Request drafting best practices
@@ -113,13 +270,15 @@ GOOD: "Emails between [Office] and [External Party] regarding [Topic] from [Date
 
 ### Request specific record types
 - Emails and email attachments
-- Calendar entries and meeting invites
 - Text messages and messaging apps
-- Memoranda and briefing papers
-- Contracts and invoices
+- Printed Correspondence (letters, faxes)
+- Calendar entries and meeting invites
+- Memoranda, briefing papers and presentations
+- Contracts, purchase orders and invoices
 - Meeting minutes and notes
 - Policies and procedures
-- Correspondence (letters, faxes)
+- Databases and datasets; schema for databases/datsets
+
 ```
 
 ## Tracking and managing requests
@@ -463,26 +622,4 @@ For each document, track:
 - Follow-up needed?
 ```
 
-## State-specific resources
 
-### Finding your state's law
-
-```markdown
-## State public records resources
-
-### Reporters Committee for Freedom of the Press
-- Open Government Guide: rcfp.org/open-government-guide
-- State-by-state analysis of public records laws
-- Sample request letters by state
-
-### National Freedom of Information Coalition
-- nfoic.org/state-freedom-of-information-laws
-- State FOI organization contacts
-- Training and resources
-
-### MuckRock
-- muckrock.com
-- File requests through platform
-- Search previous requests/responses
-- Agency response time data
-```

--- a/web-scraping/SKILL.md
+++ b/web-scraping/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: web-scraping
-description: Web scraping with anti-bot bypass, content extraction, and poison pill detection. Use when extracting content from websites, handling paywalls, implementing scraping cascades, or processing social media. Covers trafilatura, Playwright with stealth mode, yt-dlp, and instaloader patterns.
+description: Web scraping with anti-bot bypass, content extraction, undocumented APIs and poison pill detection. Use when extracting content from websites, handling paywalls, implementing scraping cascades or processing social media. Covers requests, trafilatura, Playwright with stealth mode, yt-dlp and instaloader patterns.
 ---
 
 # Web scraping methodology
@@ -17,8 +17,14 @@ from typing import Optional
 import requests
 from bs4 import BeautifulSoup
 import trafilatura
+
+#for .py files
 from playwright.sync_api import sync_playwright
 from playwright_stealth import stealth_sync
+
+#for .ipynb files
+import asyncio
+from playwright.async_api import async_playwright
 
 class ScrapingResult:
     def __init__(self, content: str, title: str, method: str):
@@ -138,6 +144,53 @@ class PlaywrightScraper(Scraper):
         except Exception:
             return None
 
+class PlaywrightScraperAsync:
+    """Async Playwright scraper for Jupyter notebooks (.ipynb files).
+    
+    Jupyter notebooks run their own event loop, so sync Playwright won't work.
+    Use this async version with `await` in notebook cells.
+    """
+
+    async def fetch(self, url: str) -> Optional[ScrapingResult]:
+        try:
+            async with async_playwright() as p:
+                browser = await p.chromium.launch(headless=True)
+                context = await browser.new_context(
+                    viewport={'width': 1920, 'height': 1080},
+                    user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+                )
+                page = await context.new_page()
+
+                # Note: playwright-stealth async version
+                # from playwright_stealth import stealth_async
+                # await stealth_async(page)
+
+                await page.goto(url, wait_until='networkidle', timeout=60000)
+
+                # Wait for content to load
+                await page.wait_for_timeout(2000)
+
+                # Extract content
+                content = await page.evaluate('''() => {
+                    const article = document.querySelector('article, main, .content, #content');
+                    return article ? article.innerText : document.body.innerText;
+                }''')
+
+                title = await page.title()
+
+                await browser.close()
+
+                if len(content) < 100:
+                    return None
+
+                return ScrapingResult(content, title, 'playwright_async')
+        except Exception:
+            return None
+
+# Usage in Jupyter notebook cells:
+# scraper = PlaywrightScraperAsync()
+# result = await scraper.fetch('https://example.com')
+
 class ScrapingCascade:
     """Try multiple scrapers in order until one succeeds."""
 
@@ -155,6 +208,72 @@ class ScrapingCascade:
                 return result
         return None
 ```
+
+## Undocumented APIs
+
+### Finding undocumented APIs
+
+Use browser developer tools to discover APIs:
+
+1. **Open developer tools** (right-click → Inspect, or F12)
+2. **Go to the Network tab** to monitor all requests
+3. **Filter by Fetch/XHR** to show only API calls
+4. **Trigger the action** you want to capture (search, scroll, click)
+5. **Analyze the response** — usually JSON with key-value pairs
+6. **Copy as cURL** (right-click the request)
+7. **Convert to code** using [curlconverter.com](https://curlconverter.com/)
+
+### Stripping down API requests
+
+When you copy a cURL from dev tools, it includes many parameters. Strip it down by:
+
+1. **Remove unnecessary cookies** — test without them first
+2. **Keep authentication tokens** if required
+3. **Identify the input parameters** you can modify (like `prefix` for search terms)
+4. **Test parameter values** — some expire, so periodically verify
+
+### Example: Reverse-engineering an autocomplete API
+
+```python
+import requests
+import time
+
+def search_suggestions(keyword: str) -> dict:
+    """
+    Get autocompleted search suggestions from an undocumented API.
+    Stripped down from browser dev tools capture.
+    """
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:100.0) Gecko/20100101 Firefox/100.0',
+        'Accept': 'application/json, text/javascript, */*; q=0.01',
+        'Accept-Language': 'en-US,en;q=0.5',
+    }
+
+    params = {
+        'prefix': keyword,
+        'suggestion-type': ['WIDGET', 'KEYWORD'],
+        'alias': 'aps',
+        'plain-mid': '1',
+    }
+
+    response = requests.get(
+        'https://completion.amazon.com/api/2017/suggestions',
+        params=params,
+        headers=headers
+    )
+    return response.json()
+
+# Collect suggestions for multiple keywords
+keywords = ['a', 'b', 'cookie', 'sock']
+data = []
+
+for keyword in keywords:
+    suggestions = search_suggestions(keyword)
+    suggestions['search_word'] = keyword  # track seed keyword
+    time.sleep(1)  # rate limit yourself
+    data.extend(suggestions.get('suggestions', []))
+```
+*Source: [Leon Yin, "Finding Undocumented APIs," Inspect Element](https://inspectelement.org/apis.html), 2023*
 
 ## Poison pill detection
 


### PR DESCRIPTION
I added to the skills for FOIA, web scraping and data journalism drawing on my experience as a practicing data journalist.

In Data Journalism I did the following:

- Moved the framework to the top; IMHO story should first, tools second
- Added some background/history for data journalism
- Convert code to method chains, descriptive variable names
- Added types to functions
- Converted functions to use Pandas methods and outputs to Pandas DataFrames
- Added donut chart type
- Converted visualizations to Plotly Express for interactive support
- Added Datawrapper section for publication-ready visuals
- Added a whole section on working with geospatial data covering geocoder options (censusbatchgeocoder and googlemaps), basics of geopandas and geovisualization with explore(), lonboard and Datawrapper.
- Added the Sigma Awards to the resources list 

In web scraping I did the following: 
- Added implementations for async playwright for Jupyter Notebooks (the preferred format for many data journalists, including myself)
- Added a section on Undocumented APIs

In FOIA I did the following:
- Moved the state section and added a table with the relevant state laws for each
- Reworked the FOIA template with lessons from my own reporting + a template from FOIA-God Jason Leopold