### PR TITLE
Add 26 skill pages for all remaining skills

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,55 +1,94 @@
 # Handoff note: Skill pages creation
 
-## Current status
+## Current status: COMPLETE
 
-**Completed:** 7 flagship skill pages with rich design matching the pdf-playground template exactly:
-1. `docs/pdf-playground/index.html` - Original template (red accent)
+**All skill pages have been created.** 34 total pages in the `docs/` directory.
+
+---
+
+## Completed pages
+
+### Flagship pages (rich design with SVG grid patterns)
+8 pages with full flagship treatment:
+1. `docs/pdf-playground/index.html` - Red accent (#CA3553) - Original template
 2. `docs/foia-requests/index.html` - Purple accent (#7c3aed)
 3. `docs/vibe-coding/index.html` - Indigo accent (#4f46e5)
 4. `docs/project-retrospective/index.html` - Orange accent (#d97706)
 5. `docs/ai-writing-detox/index.html` - Slate accent (#475569)
 6. `docs/accessibility-compliance/index.html` - Cyan accent (#0891b2)
-7. `docs/source-verification/index.html` - May need review (noted as having simpler issues)
-8. `docs/data-journalism/index.html` - May need review (noted as having simpler issues)
+7. `docs/source-verification/index.html` - Teal accent
+8. `docs/data-journalism/index.html` - Blue accent
 
-**Pending:** Create pages for remaining ~25 non-featured skills
+### Standard pages (simpler template)
+26 pages with simpler, professional template:
+
+**Journalism skills (teal #0d9488):**
+- interview-prep
+- interview-transcription
+- editorial-workflow
+- fact-check-workflow
+- newsroom-style
+- story-pitch
+- social-media-intelligence
+
+**Communications skills (amber #d97706):**
+- newsletter-publishing
+
+**Crisis skills (orange #ea580c):**
+- crisis-communications
+
+**Academic/Research skills (emerald #059669):**
+- academic-writing
+- content-access
+- digital-archive
+- page-monitoring
+- web-archiving
+
+**Development skills (indigo #4f46e5):**
+- electron-dev
+- mobile-debugging
+- python-pipeline
+- test-first-bugs
+- web-scraping
+- zero-build-frontend
+
+**Security skills (red #dc2626):**
+- api-hardening
+- secure-auth
+- security-checklist
+
+**Design skills (rose #e11d48):**
+- pdf-design
+
+**Documentation skills (purple #7c3aed):**
+- project-memory
+- template-selector
 
 ---
 
-## What needs to be done
+## Not included
 
-Create individual GitHub Pages for each remaining skill. These can be **simpler template pages** (not the full flagship treatment) but should still look professional and consistent.
-
-### Skills needing pages
-
-Check the skill directories in the repo root to find all skills. Featured skills (already done) are listed in the main site's "Featured skills" section. Everything else needs a simpler page.
-
-Skill directories are at: `C:\Users\Joe Amditis\Desktop\Crimes\sandbox\claude-skills-journalism\`
-
-Each skill has a `SKILL.md` file with the content to use.
+The `research/` folder in the repo root is not a skill - it contains research notes and documentation files, not a SKILL.md. No page was created for it.
 
 ---
 
-## Template details (for reference)
+## Template details
 
-### Flagship template key elements
+### Flagship template
+- Full SVG grid pattern in hero
+- More elaborate sections and cards
+- Used for "Featured skills" on main site
 
-- **Fonts:** Fraunces (display) + Plus Jakarta Sans (body)
-- **Background:** Canvas #ede6d4
-- **Paper overlay:** Natural paper texture + radial gradient, opacity 0.5
-- **Hero:** SVG grid pattern (40x40) + linear-gradient with accent colors
-- **Cards:** White bg, subtle border, hover lift effect
-- **Dark sections:** bg-ink #121212
-- **Nav:** Fixed, backdrop-blur-md, bg-canvas/90
-
-### Simpler template suggestion
-
-For non-featured skills, consider a lighter version:
-- Same fonts and canvas background
-- Paper overlay
-- Simpler hero (just gradient, no SVG grid)
-- Basic content sections without all the fancy cards
-- Footer with link back to main site
+### Standard template
+- Same fonts: Fraunces (display) + Plus Jakarta Sans (body)
+- Same paper overlay texture
+- Simpler gradient hero (no SVG grid)
+- Clean "When to use" section with checkmarks
+- "What's included" feature cards (2x2 grid)
+- Reference tables where applicable
+- Installation section
+- Related skills links
+- CTA footer
 
 ---
 
@@ -58,44 +97,56 @@ For non-featured skills, consider a lighter version:
 ```
 docs/
 ├── index.html                    # Main site
-├── pdf-playground/index.html     # Template reference
-├── foia-requests/index.html      # ✅ Complete
-├── vibe-coding/index.html        # ✅ Complete
-├── project-retrospective/        # ✅ Complete
-├── ai-writing-detox/             # ✅ Complete
-├── accessibility-compliance/     # ✅ Complete
-├── source-verification/          # May need review
-├── data-journalism/              # May need review
-└── [remaining-skills]/           # TO CREATE
+├── HANDOFF.md                    # This file
+│
+├── # Flagship pages (8)
+├── pdf-playground/index.html
+├── foia-requests/index.html
+├── vibe-coding/index.html
+├── project-retrospective/index.html
+├── ai-writing-detox/index.html
+├── accessibility-compliance/index.html
+├── source-verification/index.html
+├── data-journalism/index.html
+│
+├── # Standard pages (26)
+├── academic-writing/index.html
+├── api-hardening/index.html
+├── content-access/index.html
+├── crisis-communications/index.html
+├── digital-archive/index.html
+├── editorial-workflow/index.html
+├── electron-dev/index.html
+├── fact-check-workflow/index.html
+├── interview-prep/index.html
+├── interview-transcription/index.html
+├── mobile-debugging/index.html
+├── newsletter-publishing/index.html
+├── newsroom-style/index.html
+├── page-monitoring/index.html
+├── pdf-design/index.html
+├── project-memory/index.html
+├── python-pipeline/index.html
+├── secure-auth/index.html
+├── security-checklist/index.html
+├── social-media-intelligence/index.html
+├── story-pitch/index.html
+├── template-selector/index.html
+├── test-first-bugs/index.html
+├── web-archiving/index.html
+├── web-scraping/index.html
+└── zero-build-frontend/index.html
 ```
 
 ---
 
-## Key files to read
+## Next steps (optional)
 
-1. `docs/pdf-playground/index.html` - The canonical template
-2. Any skill's `SKILL.md` - Content source for each page
-3. `docs/index.html` - Main site, shows which skills are featured
-
----
-
-## Git info
-
-- Repo: `claude-skills-journalism`
-- Branch: `master`
-- Last commit: 03ac2b2 "Rewrite 5 flagship skill pages to match pdf-playground template"
-- Remote is up to date
+1. Update `docs/index.html` main site to link to all skill pages
+2. Add skill pages to site navigation or skills grid
+3. Review pages for any content adjustments
+4. Push changes to GitHub
 
 ---
 
-## Suggested next steps
-
-1. List all skill directories in the repo
-2. Compare against `docs/` to find which skills don't have pages yet
-3. Create a simpler template for non-featured skills
-4. Generate pages for all remaining skills
-5. Push changes
-
----
-
-*Created: 2026-02-04*
+*Updated: 2026-02-04*

--- a/docs/academic-writing/index.html
+++ b/docs/academic-writing/index.html
@@ -1,0 +1,326 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Academic writing - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#059669',
+                        'accentDark': '#047857',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
+                </svg>
+                Academic skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Academic writing</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Research methodology, scholarly communication, and academic writing workflows for papers, literature reviews, and grant proposals.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Writing research papers, dissertations, or journal articles
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Conducting systematic literature reviews
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Preparing grant proposals (NSF/NIH style)
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Responding to peer review feedback
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Managing citations and reference libraries
+                </li>
+            </ul>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Research question development</h3>
+                    <p class="text-sm text-clay/70">FINER criteria (Feasible, Interesting, Novel, Ethical, Relevant) and question refinement workflows from broad to specific.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Literature review strategy</h3>
+                    <p class="text-sm text-clay/70">Systematic search templates, database selection by field, Boolean operators, and inclusion/exclusion criteria documentation.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">IMRaD paper structure</h3>
+                    <p class="text-sm text-clay/70">Section-by-section guidance for Introduction, Methods, Results, and Discussion with funnel/reverse-funnel patterns.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Peer review responses</h3>
+                    <p class="text-sm text-clay/70">Templates for response letters, strategies for handling criticism, and guidelines for revisions that satisfy reviewers.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Grant proposals</h3>
+                    <p class="text-sm text-clay/70">NSF/NIH-style proposal structure including Specific Aims, Significance, Innovation, Approach, and budget justification.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Research ethics</h3>
+                    <p class="text-sm text-clay/70">IRB checklists, authorship criteria, data management plans, and guidance on avoiding research misconduct.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Research question types -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Research question types</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Type</th>
+                            <th class="text-left px-5 py-3 font-semibold">Purpose</th>
+                            <th class="text-left px-5 py-3 font-semibold hidden md:table-cell">Example</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Descriptive</td>
+                            <td class="px-5 py-3 text-clay/70">Document phenomena</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">"What are the characteristics of X?"</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Comparative</td>
+                            <td class="px-5 py-3 text-clay/70">Compare groups/conditions</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">"How does X differ between groups?"</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Correlational</td>
+                            <td class="px-5 py-3 text-clay/70">Examine relationships</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">"Is there a relationship between X and Y?"</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Causal</td>
+                            <td class="px-5 py-3 text-clay/70">Establish causation</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">"Does X cause Y?"</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Exploratory</td>
+                            <td class="px-5 py-3 text-clay/70">Generate hypotheses</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">"What factors might explain X?"</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Academic tools -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Academic tools reference</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Purpose</th>
+                            <th class="text-left px-5 py-3 font-semibold">Tools</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Reference management</td>
+                            <td class="px-5 py-3 text-clay/70">Zotero, Mendeley, EndNote</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Writing</td>
+                            <td class="px-5 py-3 text-clay/70">Scrivener, Overleaf, Word</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Collaboration</td>
+                            <td class="px-5 py-3 text-clay/70">Google Docs, Overleaf</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Analysis</td>
+                            <td class="px-5 py-3 text-clay/70">R, Python, SPSS, Stata, NVivo</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Visualization</td>
+                            <td class="px-5 py-3 text-clay/70">R/ggplot2, Python/matplotlib, Tableau</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/academic-writing ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/academic-writing" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../content-access/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Content access</a>
+                <a href="../digital-archive/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Digital archive</a>
+                <a href="../ai-writing-detox/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">AI writing detox</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">Write with scholarly rigor</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    Research design, paper structure, peer review, and grant writing in one skill.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/academic-writing" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/api-hardening/index.html
+++ b/docs/api-hardening/index.html
@@ -1,0 +1,342 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>API hardening - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#dc2626',
+                        'accentDark': '#b91c1c',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
+                </svg>
+                Security skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">API hardening</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Defense-in-depth patterns for protecting APIs from abuse, injection attacks, and data leakage.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Implementing rate limiting to prevent abuse
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Adding input validation and sanitization
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Configuring CORS for specific origins
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Managing API keys securely (generation, hashing, revocation)
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Protecting endpoints from SQL injection and XSS
+                </li>
+            </ul>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Rate limiting</h3>
+                    <p class="text-sm text-clay/70">Express.js middleware patterns, sliding window implementation, per-user limits with API key tiers (free/pro/enterprise).</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Input validation</h3>
+                    <p class="text-sm text-clay/70">Zod schema validation, sanitization helpers for HTML/strings/filenames, parameterized queries for SQL injection prevention.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">CORS configuration</h3>
+                    <p class="text-sm text-clay/70">Allowlist patterns for development and production, common mistakes to avoid, credential handling best practices.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">API key management</h3>
+                    <p class="text-sm text-clay/70">Secure generation with prefixes, SHA-256 hashing for storage, verification middleware, and revocation patterns.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Response security</h3>
+                    <p class="text-sm text-clay/70">Error handling that doesn't leak info, security headers with Helmet, preventing stack trace exposure in production.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Timeout protection</h3>
+                    <p class="text-sm text-clay/70">Request timeout middleware, external API call timeouts with AbortController, database query timeout patterns.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Security checklist -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Security checklist</h2>
+            <div class="bg-white rounded-xl p-6 border border-mist/30">
+                <ul class="space-y-3 text-clay/80">
+                    <li class="flex items-start gap-3">
+                        <span class="w-5 h-5 border-2 border-mist rounded flex-shrink-0 mt-0.5"></span>
+                        Rate limiting on all endpoints
+                    </li>
+                    <li class="flex items-start gap-3">
+                        <span class="w-5 h-5 border-2 border-mist rounded flex-shrink-0 mt-0.5"></span>
+                        Stricter limits on auth endpoints
+                    </li>
+                    <li class="flex items-start gap-3">
+                        <span class="w-5 h-5 border-2 border-mist rounded flex-shrink-0 mt-0.5"></span>
+                        Input validation with schema library
+                    </li>
+                    <li class="flex items-start gap-3">
+                        <span class="w-5 h-5 border-2 border-mist rounded flex-shrink-0 mt-0.5"></span>
+                        Parameterized database queries
+                    </li>
+                    <li class="flex items-start gap-3">
+                        <span class="w-5 h-5 border-2 border-mist rounded flex-shrink-0 mt-0.5"></span>
+                        CORS configured for specific origins
+                    </li>
+                    <li class="flex items-start gap-3">
+                        <span class="w-5 h-5 border-2 border-mist rounded flex-shrink-0 mt-0.5"></span>
+                        API keys hashed before storage
+                    </li>
+                    <li class="flex items-start gap-3">
+                        <span class="w-5 h-5 border-2 border-mist rounded flex-shrink-0 mt-0.5"></span>
+                        Request size limits configured
+                    </li>
+                    <li class="flex items-start gap-3">
+                        <span class="w-5 h-5 border-2 border-mist rounded flex-shrink-0 mt-0.5"></span>
+                        Timeouts on all external calls
+                    </li>
+                    <li class="flex items-start gap-3">
+                        <span class="w-5 h-5 border-2 border-mist rounded flex-shrink-0 mt-0.5"></span>
+                        Security headers via Helmet
+                    </li>
+                    <li class="flex items-start gap-3">
+                        <span class="w-5 h-5 border-2 border-mist rounded flex-shrink-0 mt-0.5"></span>
+                        Error messages don't leak system info
+                    </li>
+                    <li class="flex items-start gap-3">
+                        <span class="w-5 h-5 border-2 border-mist rounded flex-shrink-0 mt-0.5"></span>
+                        All auth via HTTPS only
+                    </li>
+                </ul>
+            </div>
+        </section>
+
+        <!-- Rate limit tiers -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Rate limit tiers</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Tier</th>
+                            <th class="text-left px-5 py-3 font-semibold">Window</th>
+                            <th class="text-left px-5 py-3 font-semibold">Max requests</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Free</td>
+                            <td class="px-5 py-3 text-clay/70">1 minute</td>
+                            <td class="px-5 py-3 text-clay/70">10</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Pro</td>
+                            <td class="px-5 py-3 text-clay/70">1 minute</td>
+                            <td class="px-5 py-3 text-clay/70">100</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Enterprise</td>
+                            <td class="px-5 py-3 text-clay/70">1 minute</td>
+                            <td class="px-5 py-3 text-clay/70">1,000</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Auth endpoints</td>
+                            <td class="px-5 py-3 text-clay/70">15 minutes</td>
+                            <td class="px-5 py-3 text-clay/70">5</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Password reset</td>
+                            <td class="px-5 py-3 text-clay/70">1 hour</td>
+                            <td class="px-5 py-3 text-clay/70">3</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/api-hardening ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/api-hardening" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../security-checklist/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Security checklist</a>
+                <a href="../secure-auth/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Secure auth</a>
+                <a href="../python-pipeline/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Python pipeline</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">Protect your APIs from abuse</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    Rate limiting, input validation, CORS, and API key management patterns for Express.js and FastAPI.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/api-hardening" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/content-access/index.html
+++ b/docs/content-access/index.html
@@ -1,0 +1,327 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Content access - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#059669',
+                        'accentDark': '#047857',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+                </svg>
+                Research skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Content access</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Ethical and legal approaches for accessing paywalled and geo-blocked content for journalism and research.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Researching behind paywalls for journalism
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Accessing academic papers without institutional subscription
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Finding open access alternatives to paywalled content
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Bypassing geographic restrictions for research purposes
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Contacting authors directly for paper requests
+                </li>
+            </ul>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Open access tools</h3>
+                    <p class="text-sm text-clay/70">Unpaywall API integration (20M+ papers), CORE API (295M papers), Semantic Scholar API (214M papers) with code examples.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Library database access</h3>
+                    <p class="text-sm text-clay/70">PressReader, ProQuest, JSTOR, and Nexis access methods. Interlibrary loan (ILL) request templates.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Browser reader mode</h3>
+                    <p class="text-sm text-clay/70">Bookmarklet for soft paywall bypass, reader mode activation by browser (Safari, Firefox, Edge, Chrome).</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Archive-based access</h3>
+                    <p class="text-sm text-clay/70">Wayback Machine and Archive.today integration for historical access to paywalled content.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Author contact</h3>
+                    <p class="text-sm text-clay/70">Professional email template for requesting papers directly from authors. 70-90% success rate.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Legal framework</h3>
+                    <p class="text-sm text-clay/70">Fair use considerations (US), ethical guidelines, and the access hierarchy from fully legal to not recommended.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Access hierarchy -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Access hierarchy</h2>
+            <div class="space-y-3">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-green-100 text-green-800 text-xs font-semibold px-2.5 py-1 rounded">Fully legal</span>
+                        <div>
+                            <h3 class="font-semibold">Library databases and open access</h3>
+                            <p class="text-sm text-clay/70 mt-1">PressReader, ProQuest, JSTOR, Unpaywall, CORE, PubMed Central, author contact, interlibrary loan.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-blue-100 text-blue-800 text-xs font-semibold px-2.5 py-1 rounded">Legal</span>
+                        <div>
+                            <h3 class="font-semibold">Browser features</h3>
+                            <p class="text-sm text-clay/70 mt-1">Reader Mode (Safari, Firefox, Edge), Wayback Machine archives, Google Scholar "All versions".</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-yellow-100 text-yellow-800 text-xs font-semibold px-2.5 py-1 rounded">Grey area</span>
+                        <div>
+                            <h3 class="font-semibold">Use with caution</h3>
+                            <p class="text-sm text-clay/70 mt-1">Archive.is for individual articles, disable JavaScript, VPNs for geo-blocked content.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-red-100 text-red-800 text-xs font-semibold px-2.5 py-1 rounded">Not recommended</span>
+                        <div>
+                            <h3 class="font-semibold">Avoid these methods</h3>
+                            <p class="text-sm text-clay/70 mt-1">Credential sharing, systematic scraping, commercial use of bypassed content.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Reader mode reference -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Reader mode by browser</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Browser</th>
+                            <th class="text-left px-5 py-3 font-semibold">How to activate</th>
+                            <th class="text-left px-5 py-3 font-semibold hidden md:table-cell">Effectiveness</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Safari</td>
+                            <td class="px-5 py-3 text-clay/70">Click Reader icon in URL bar</td>
+                            <td class="px-5 py-3 text-clay/70 hidden md:table-cell">High for soft paywalls</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Firefox</td>
+                            <td class="px-5 py-3 text-clay/70">Click Reader View icon (or F9)</td>
+                            <td class="px-5 py-3 text-clay/70 hidden md:table-cell">High</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Edge</td>
+                            <td class="px-5 py-3 text-clay/70">Click Immersive Reader icon</td>
+                            <td class="px-5 py-3 text-clay/70 hidden md:table-cell">Highest</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Chrome</td>
+                            <td class="px-5 py-3 text-clay/70">Requires flag: chrome://flags/#enable-reader-mode</td>
+                            <td class="px-5 py-3 text-clay/70 hidden md:table-cell">Medium</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/content-access ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/content-access" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../academic-writing/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Academic writing</a>
+                <a href="../web-archiving/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Web archiving</a>
+                <a href="../source-verification/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Source verification</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">Access research ethically</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    Open access tools, library databases, and legal strategies for journalists and researchers.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/content-access" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/crisis-communications/index.html
+++ b/docs/crisis-communications/index.html
@@ -1,0 +1,366 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Crisis communications - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#ea580c',
+                        'accentDark': '#c2410c',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
+                </svg>
+                Journalism skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Crisis communications</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Frameworks for accurate, rapid communication during breaking news and high-pressure situations.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Breaking news requires immediate coverage
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Organization faces public crisis or controversy
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Misinformation is spreading rapidly and needs countering
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Emergency situation requires coordinated communication
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Preparing crisis response plans before incidents occur
+                </li>
+            </ul>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Breaking news protocol</h3>
+                    <p class="text-sm text-clay/70">First 30 minutes checklist, verification phase workflow, newsroom escalation matrix with crisis levels 1-4.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Rapid verification</h3>
+                    <p class="text-sm text-clay/70">5-minute verification checklist, verification triage system with priority queues, claim tracking workflow.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Communication templates</h3>
+                    <p class="text-sm text-clay/70">Holding statements, corrections, clarifications, retractions, and status update templates for stakeholders.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Social media response</h3>
+                    <p class="text-sm text-clay/70">Crisis monitoring dashboard, response decision tree, guidelines for when to engage vs. when to ignore.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Misinformation response</h3>
+                    <p class="text-sm text-clay/70">Counter-messaging framework: lead with truth, avoid repeating myths, provide authoritative sources.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Post-crisis review</h3>
+                    <p class="text-sm text-clay/70">After-action checklist, timeline reconstruction, process improvement documentation.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Crisis levels -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Escalation levels</h2>
+            <div class="space-y-3">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-green-100 text-green-800 text-xs font-semibold px-2.5 py-1 rounded">Level 1</span>
+                        <div>
+                            <h3 class="font-semibold">Routine</h3>
+                            <p class="text-sm text-clay/70 mt-1">Single reporter can handle. Standard verification and publication workflow.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-yellow-100 text-yellow-800 text-xs font-semibold px-2.5 py-1 rounded">Level 2</span>
+                        <div>
+                            <h3 class="font-semibold">Elevated</h3>
+                            <p class="text-sm text-clay/70 mt-1">Editor involvement needed. Triggers: multiple fatalities, major public figure, legal concerns, significant local impact.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-orange-100 text-orange-800 text-xs font-semibold px-2.5 py-1 rounded">Level 3</span>
+                        <div>
+                            <h3 class="font-semibold">Major</h3>
+                            <p class="text-sm text-clay/70 mt-1">Multiple reporters, editor oversight. Triggers: national news potential, active public danger, major institution affected, coordinated misinformation.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-red-100 text-red-800 text-xs font-semibold px-2.5 py-1 rounded">Level 4</span>
+                        <div>
+                            <h3 class="font-semibold">Critical</h3>
+                            <p class="text-sm text-clay/70 mt-1">All hands, executive involvement. Triggers: mass casualty event, government/democracy implications, organization directly involved, imminent physical threat.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- 5-minute verification -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">5-minute verification checklist</h2>
+            <div class="bg-white rounded-xl p-6 border border-mist/30">
+                <div class="space-y-4">
+                    <div>
+                        <h3 class="font-semibold text-sm text-clay/60 mb-2">Source check (1 min)</h3>
+                        <ul class="space-y-1.5 text-clay/80 text-sm">
+                            <li class="flex items-start gap-2">
+                                <span class="w-4 h-4 border-2 border-mist rounded flex-shrink-0 mt-0.5"></span>
+                                Who is claiming this?
+                            </li>
+                            <li class="flex items-start gap-2">
+                                <span class="w-4 h-4 border-2 border-mist rounded flex-shrink-0 mt-0.5"></span>
+                                Are they in position to know?
+                            </li>
+                            <li class="flex items-start gap-2">
+                                <span class="w-4 h-4 border-2 border-mist rounded flex-shrink-0 mt-0.5"></span>
+                                Have they been reliable before?
+                            </li>
+                        </ul>
+                    </div>
+                    <div>
+                        <h3 class="font-semibold text-sm text-clay/60 mb-2">Corroboration (2 min)</h3>
+                        <ul class="space-y-1.5 text-clay/80 text-sm">
+                            <li class="flex items-start gap-2">
+                                <span class="w-4 h-4 border-2 border-mist rounded flex-shrink-0 mt-0.5"></span>
+                                Does anyone else confirm?
+                            </li>
+                            <li class="flex items-start gap-2">
+                                <span class="w-4 h-4 border-2 border-mist rounded flex-shrink-0 mt-0.5"></span>
+                                Check wire services
+                            </li>
+                            <li class="flex items-start gap-2">
+                                <span class="w-4 h-4 border-2 border-mist rounded flex-shrink-0 mt-0.5"></span>
+                                Check official sources
+                            </li>
+                        </ul>
+                    </div>
+                    <div>
+                        <h3 class="font-semibold text-sm text-clay/60 mb-2">Red flags (1 min)</h3>
+                        <ul class="space-y-1.5 text-clay/80 text-sm">
+                            <li class="flex items-start gap-2">
+                                <span class="w-4 h-4 border-2 border-mist rounded flex-shrink-0 mt-0.5"></span>
+                                Too perfect/dramatic?
+                            </li>
+                            <li class="flex items-start gap-2">
+                                <span class="w-4 h-4 border-2 border-mist rounded flex-shrink-0 mt-0.5"></span>
+                                Matches known false narratives?
+                            </li>
+                            <li class="flex items-start gap-2">
+                                <span class="w-4 h-4 border-2 border-mist rounded flex-shrink-0 mt-0.5"></span>
+                                Single source only?
+                            </li>
+                        </ul>
+                    </div>
+                    <div>
+                        <h3 class="font-semibold text-sm text-clay/60 mb-2">Decision (1 min)</h3>
+                        <ul class="space-y-1.5 text-clay/80 text-sm">
+                            <li class="flex items-start gap-2">
+                                <span class="w-3 h-3 bg-green-500 rounded-full flex-shrink-0 mt-1"></span>
+                                PUBLISH: Multiple credible sources, no red flags
+                            </li>
+                            <li class="flex items-start gap-2">
+                                <span class="w-3 h-3 bg-yellow-500 rounded-full flex-shrink-0 mt-1"></span>
+                                HOLD: Needs more verification
+                            </li>
+                            <li class="flex items-start gap-2">
+                                <span class="w-3 h-3 bg-red-500 rounded-full flex-shrink-0 mt-1"></span>
+                                MONITOR: Developing, don't publish yet
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/crisis-communications ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/crisis-communications" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../source-verification/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Source verification</a>
+                <a href="../social-media-intelligence/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Social media intelligence</a>
+                <a href="../fact-check-workflow/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Fact-check workflow</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">Stay accurate under pressure</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    Breaking news protocols, verification checklists, and communication templates for crisis situations.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/crisis-communications" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/digital-archive/index.html
+++ b/docs/digital-archive/index.html
@@ -1,0 +1,380 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Digital archive - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#059669',
+                        'accentDark': '#047857',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"/>
+                </svg>
+                Archive skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Digital archive</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Build production-quality digital archives with AI-powered categorization, entity extraction, and knowledge graph construction.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Building content archives from multiple sources
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Implementing AI-powered categorization and tagging
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Extracting entities and relationships for knowledge graphs
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Integrating OCR, web scraping, and social media sources
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Generating accessible PDFs for archival preservation
+                </li>
+            </ul>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Multi-source integration</h3>
+                    <p class="text-sm text-clay/70">OCR pipeline for newspapers, web scraping for articles, social media transcripts. Unified schema with 35+ fields.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">AI categorization</h3>
+                    <p class="text-sm text-clay/70">Taxonomy-based classification with Gemini API. Thematic categories, key concepts, tags, eras, and scope types.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Entity extraction</h3>
+                    <p class="text-sm text-clay/70">Extract Person, Organization, Work, Concept, Event, Location entities. Build relationship graphs with deduplication.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">PDF generation</h3>
+                    <p class="text-sm text-clay/70">WCAG 2.1 accessible PDFs with ReportLab. Metadata, summaries, and full text for archival preservation.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Data validation</h3>
+                    <p class="text-sm text-clay/70">Required/critical/optional field validation. Hallucination detection for AI responses. Quality scoring.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Frontend export</h3>
+                    <p class="text-sm text-clay/70">JSON/CSV exports for frontend consumption. Entity and relationship data for visualization and search.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Entity types -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Entity types</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Type</th>
+                            <th class="text-left px-5 py-3 font-semibold">ID prefix</th>
+                            <th class="text-left px-5 py-3 font-semibold hidden md:table-cell">Examples</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Person</td>
+                            <td class="px-5 py-3 text-clay/70">P-0001</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Journalists, politicians, academics, media figures</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Organization</td>
+                            <td class="px-5 py-3 text-clay/70">O-0001</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">News outlets, media companies, academic institutions</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Work</td>
+                            <td class="px-5 py-3 text-clay/70">W-0001</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Articles, books, blog posts, studies, reports</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Concept</td>
+                            <td class="px-5 py-3 text-clay/70">C-0001</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Journalism theories, media criticism frameworks</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Event</td>
+                            <td class="px-5 py-3 text-clay/70">E-0001</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Conferences, elections, media crises</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Location</td>
+                            <td class="px-5 py-3 text-clay/70">L-0001</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Geographic locations relevant to media context</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Relationship types -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Relationship types</h2>
+            <div class="bg-white rounded-xl p-6 border border-mist/30">
+                <div class="grid md:grid-cols-3 gap-4">
+                    <div>
+                        <h3 class="font-semibold text-sm text-clay/60 mb-2">Content relationships</h3>
+                        <ul class="space-y-1 text-sm text-clay/80">
+                            <li>Mentions</li>
+                            <li>Criticizes</li>
+                            <li>Cites</li>
+                            <li>Discusses</li>
+                            <li>Expands On</li>
+                            <li>Supports</li>
+                        </ul>
+                    </div>
+                    <div>
+                        <h3 class="font-semibold text-sm text-clay/60 mb-2">Historical relationships</h3>
+                        <ul class="space-y-1 text-sm text-clay/80">
+                            <li>Founded By</li>
+                            <li>Pioneered</li>
+                            <li>Inspired By</li>
+                        </ul>
+                    </div>
+                    <div>
+                        <h3 class="font-semibold text-sm text-clay/60 mb-2">Structural relationships</h3>
+                        <ul class="space-y-1 text-sm text-clay/80">
+                            <li>Affiliated With</li>
+                            <li>Published In</li>
+                            <li>Originated By</li>
+                            <li>Occurred At</li>
+                            <li>Owns / Owned By</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Record ID prefixes -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Record ID prefixes</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Source</th>
+                            <th class="text-left px-5 py-3 font-semibold">Prefix</th>
+                            <th class="text-left px-5 py-3 font-semibold hidden md:table-cell">Example ID</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 font-medium">New York Times</td>
+                            <td class="px-5 py-3 text-clay/70">NYT</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">NYT-00001</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Columbia Journalism Review</td>
+                            <td class="px-5 py-3 text-clay/70">CJR</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">CJR-00001</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">PressThink</td>
+                            <td class="px-5 py-3 text-clay/70">PT</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">PT-00001</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Twitter</td>
+                            <td class="px-5 py-3 text-clay/70">TW</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">TW-00001</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">YouTube</td>
+                            <td class="px-5 py-3 text-clay/70">YT</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">YT-00001</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Newspaper (OCR)</td>
+                            <td class="px-5 py-3 text-clay/70">NEWS</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">NEWS-00001</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/digital-archive ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/digital-archive" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../web-archiving/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Web archiving</a>
+                <a href="../python-pipeline/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Python pipeline</a>
+                <a href="../web-scraping/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Web scraping</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">Build archives that scale</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    Multi-source integration, AI categorization, entity extraction, and knowledge graph patterns.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/digital-archive" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/editorial-workflow/index.html
+++ b/docs/editorial-workflow/index.html
@@ -1,0 +1,329 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Editorial workflow - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#0d9488',
+                        'accentDark': '#0f766e',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"/>
+                </svg>
+                Journalism skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Editorial workflow</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Manage editorial workflows for newsrooms and publications with story tracking, deadline management, and handoff protocols.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Setting up story tracking systems
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Creating editorial calendars
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Establishing assignment and handoff protocols
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Managing multiple stories and deadlines
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Training new editors on workflow
+                </li>
+            </ul>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Story status taxonomy</h3>
+                    <p class="text-sm text-clay/70">Standard statuses from Pitch to Published with clear ownership at each stage.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Assignment tracking</h3>
+                    <p class="text-sm text-clay/70">Templates for assignment records, handoff checklists, and status history.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Editorial calendar</h3>
+                    <p class="text-sm text-clay/70">Weekly planning templates, evergreen queues, and editorial meeting agendas.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Publication checklists</h3>
+                    <p class="text-sm text-clay/70">Pre-publish and post-publish checklists covering content, style, legal, and metadata.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Story status reference -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Story status taxonomy</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Status</th>
+                            <th class="text-left px-5 py-3 font-semibold">Meaning</th>
+                            <th class="text-left px-5 py-3 font-semibold hidden md:table-cell">Owner</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Pitch</td>
+                            <td class="px-5 py-3 text-clay/70">Idea submitted, awaiting approval</td>
+                            <td class="px-5 py-3 text-clay/70 hidden md:table-cell">Reporter</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Assigned</td>
+                            <td class="px-5 py-3 text-clay/70">Approved, reporter working</td>
+                            <td class="px-5 py-3 text-clay/70 hidden md:table-cell">Reporter</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Draft</td>
+                            <td class="px-5 py-3 text-clay/70">First draft submitted</td>
+                            <td class="px-5 py-3 text-clay/70 hidden md:table-cell">Editor</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Edit</td>
+                            <td class="px-5 py-3 text-clay/70">Editor making changes</td>
+                            <td class="px-5 py-3 text-clay/70 hidden md:table-cell">Editor</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Copy</td>
+                            <td class="px-5 py-3 text-clay/70">Copy editing stage</td>
+                            <td class="px-5 py-3 text-clay/70 hidden md:table-cell">Copy editor</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Final</td>
+                            <td class="px-5 py-3 text-clay/70">Ready for publication</td>
+                            <td class="px-5 py-3 text-clay/70 hidden md:table-cell">Editor</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Deadline types -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Deadline types</h2>
+            <div class="space-y-3">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-blue-100 text-blue-800 text-xs font-semibold px-2.5 py-1 rounded">2-5 days</span>
+                        <div>
+                            <h3 class="font-semibold">Reporting deadline</h3>
+                            <p class="text-sm text-clay/70 mt-1">Complete interviews and research before first draft.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-yellow-100 text-yellow-800 text-xs font-semibold px-2.5 py-1 rounded">24-48 hrs</span>
+                        <div>
+                            <h3 class="font-semibold">First draft deadline</h3>
+                            <p class="text-sm text-clay/70 mt-1">Submit to editor before edit cycle begins.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-orange-100 text-orange-800 text-xs font-semibold px-2.5 py-1 rounded">4-8 hrs</span>
+                        <div>
+                            <h3 class="font-semibold">Copy edit deadline</h3>
+                            <p class="text-sm text-clay/70 mt-1">Language and style review before publish.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-green-100 text-green-800 text-xs font-semibold px-2.5 py-1 rounded">Set time</span>
+                        <div>
+                            <h3 class="font-semibold">Publish deadline</h3>
+                            <p class="text-sm text-clay/70 mt-1">Story goes live at scheduled time.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/editorial-workflow ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/editorial-workflow" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../fact-check-workflow/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Fact-check workflow</a>
+                <a href="../interview-prep/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Interview prep</a>
+                <a href="../newsroom-style/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Newsroom style</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">Good workflows disappear</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    You only notice them when they break. Set up systems that work.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/editorial-workflow" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/electron-dev/index.html
+++ b/docs/electron-dev/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Electron dev - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#4f46e5',
+                        'accentDark': '#4338ca',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
+                </svg>
+                Development skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Electron dev</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Build production-quality Electron desktop applications with React, TypeScript, and Vite.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Building desktop apps with web technologies
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Implementing IPC communication between main and renderer
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Managing windows, system tray, and global shortcuts
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Handling PTY terminals with node-pty
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Integrating WebRTC and audio recording
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Packaging apps with electron-builder
+                </li>
+            </ul>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Project structure</h3>
+                    <p class="text-sm text-clay/70">Standard layout with electron/, src/, and assets/ directories. CommonJS for main process, ESM for renderer.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">IPC patterns</h3>
+                    <p class="text-sm text-clay/70">Secure context bridge setup with ipcMain.handle() for async requests and event-based communication.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">System integration</h3>
+                    <p class="text-sm text-clay/70">System tray with context menus, global shortcuts, and hide-to-tray behavior.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Build configuration</h3>
+                    <p class="text-sm text-clay/70">Complete electron-builder.yml for Windows, Mac, and Linux with code signing and auto-update.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Architecture reference -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Project structure</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <pre class="text-white/90"><code>app/
+├── electron/
+│   ├── main.cjs              # Main process (CommonJS)
+│   ├── preload.cjs           # Context bridge for IPC
+│   └── server.cjs            # Optional: WebSocket server
+├── src/
+│   ├── components/           # React components
+│   ├── services/             # Business logic
+│   ├── utils/                # Utilities
+│   └── App.tsx               # Root component
+├── assets/                   # Icons, sounds, images
+├── package.json
+├── vite.config.ts
+└── electron-builder.yml</code></pre>
+            </div>
+        </section>
+
+        <!-- Common pitfalls -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Common pitfalls</h2>
+            <div class="space-y-3">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-red-100 text-red-800 text-xs font-semibold px-2.5 py-1 rounded">Avoid</span>
+                        <div>
+                            <h3 class="font-semibold">Stale closures in callbacks</h3>
+                            <p class="text-sm text-clay/70 mt-1">Use refs for async callback access. State variables capture initial values in event handlers.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-red-100 text-red-800 text-xs font-semibold px-2.5 py-1 rounded">Avoid</span>
+                        <div>
+                            <h3 class="font-semibold">Exposing ipcRenderer directly</h3>
+                            <p class="text-sm text-clay/70 mt-1">Always use contextBridge.exposeInMainWorld() and validate all IPC arguments in main process.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-yellow-100 text-yellow-800 text-xs font-semibold px-2.5 py-1 rounded">Note</span>
+                        <div>
+                            <h3 class="font-semibold">Cross-platform shell detection</h3>
+                            <p class="text-sm text-clay/70 mt-1">Check process.platform for Windows (powershell.exe) vs Unix (process.env.SHELL).</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/electron-dev ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/electron-dev" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../zero-build-frontend/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Zero-build frontend</a>
+                <a href="../python-pipeline/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Python pipeline</a>
+                <a href="../mobile-debugging/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Mobile debugging</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">Desktop apps with web technologies</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    IPC patterns, system tray integration, and electron-builder configuration.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/electron-dev" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/fact-check-workflow/index.html
+++ b/docs/fact-check-workflow/index.html
@@ -1,0 +1,343 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Fact-check workflow - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#0d9488',
+                        'accentDark': '#0f766e',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                </svg>
+                Journalism skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Fact-check workflow</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Structured workflow for claim verification, evidence gathering, rating scales, and correction protocols.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Pre-publication fact-checking of articles
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Dedicated fact-check stories (rating claims)
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Verifying source statements during reporting
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Building fact-checking protocols for a newsroom
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Training staff on verification standards
+                </li>
+            </ul>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Claim extraction</h3>
+                    <p class="text-sm text-clay/70">Templates for logging claims, prioritizing by importance, and distinguishing facts from opinions.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Evidence gathering</h3>
+                    <p class="text-sm text-clay/70">Checklists for documentary, human, and data sources. Evidence strength ratings.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Rating scales</h3>
+                    <p class="text-sm text-clay/70">Binary (verified/false) and graduated scales (true to pants on fire) with clear criteria.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Correction protocols</h3>
+                    <p class="text-sm text-clay/70">Templates for corrections, updates, and maintaining correction logs.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Process flow -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">The fact-check process</h2>
+            <div class="bg-white rounded-xl border border-mist/30 p-6">
+                <div class="flex flex-wrap items-center gap-2 text-sm">
+                    <span class="bg-accent/10 text-accent font-medium px-3 py-1.5 rounded-full">1. Identify claim</span>
+                    <svg class="w-4 h-4 text-mist" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+                    </svg>
+                    <span class="bg-accent/10 text-accent font-medium px-3 py-1.5 rounded-full">2. Research</span>
+                    <svg class="w-4 h-4 text-mist" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+                    </svg>
+                    <span class="bg-accent/10 text-accent font-medium px-3 py-1.5 rounded-full">3. Gather evidence</span>
+                    <svg class="w-4 h-4 text-mist" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+                    </svg>
+                    <span class="bg-accent/10 text-accent font-medium px-3 py-1.5 rounded-full">4. Contact sources</span>
+                    <svg class="w-4 h-4 text-mist" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+                    </svg>
+                    <span class="bg-accent/10 text-accent font-medium px-3 py-1.5 rounded-full">5. Rate</span>
+                    <svg class="w-4 h-4 text-mist" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+                    </svg>
+                    <span class="bg-accent/10 text-accent font-medium px-3 py-1.5 rounded-full">6. Document</span>
+                    <svg class="w-4 h-4 text-mist" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+                    </svg>
+                    <span class="bg-accent/10 text-accent font-medium px-3 py-1.5 rounded-full">7. Publish/correct</span>
+                </div>
+            </div>
+        </section>
+
+        <!-- Rating scale -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Rating scale</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Rating</th>
+                            <th class="text-left px-5 py-3 font-semibold">Criteria</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3"><span class="bg-green-100 text-green-800 text-xs font-semibold px-2 py-1 rounded">True</span></td>
+                            <td class="px-5 py-3 text-clay/70">Accurate and complete, nothing significant omitted</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3"><span class="bg-lime-100 text-lime-800 text-xs font-semibold px-2 py-1 rounded">Mostly true</span></td>
+                            <td class="px-5 py-3 text-clay/70">Accurate but needs context or minor clarification</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3"><span class="bg-yellow-100 text-yellow-800 text-xs font-semibold px-2 py-1 rounded">Half true</span></td>
+                            <td class="px-5 py-3 text-clay/70">Partially accurate but leaves out critical context</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3"><span class="bg-orange-100 text-orange-800 text-xs font-semibold px-2 py-1 rounded">Mostly false</span></td>
+                            <td class="px-5 py-3 text-clay/70">Contains some truth but overall misleading</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3"><span class="bg-red-100 text-red-800 text-xs font-semibold px-2 py-1 rounded">False</span></td>
+                            <td class="px-5 py-3 text-clay/70">Not accurate; contradicted by evidence</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Evidence strength -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Evidence strength</h2>
+            <div class="space-y-3">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-green-100 text-green-800 text-xs font-semibold px-2.5 py-1 rounded">Strong</span>
+                        <div>
+                            <h3 class="font-semibold">Official documents</h3>
+                            <p class="text-sm text-clay/70 mt-1">Court records, government reports, official filings, peer-reviewed research.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-yellow-100 text-yellow-800 text-xs font-semibold px-2.5 py-1 rounded">Medium</span>
+                        <div>
+                            <h3 class="font-semibold">On-record sources</h3>
+                            <p class="text-sm text-clay/70 mt-1">Named sources with direct knowledge, contemporary news accounts.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-red-100 text-red-800 text-xs font-semibold px-2.5 py-1 rounded">Weak</span>
+                        <div>
+                            <h3 class="font-semibold">Off-record and social media</h3>
+                            <p class="text-sm text-clay/70 mt-1">Use to guide reporting only. Posts can be deleted, context matters.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/fact-check-workflow ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/fact-check-workflow" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../source-verification/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Source verification</a>
+                <a href="../interview-prep/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Interview prep</a>
+                <a href="../editorial-workflow/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Editorial workflow</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">The goal is truth, not points</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    Fact-checking is systematic, not intuitive. Get the structure right.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/fact-check-workflow" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/interview-prep/index.html
+++ b/docs/interview-prep/index.html
@@ -1,0 +1,318 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Interview prep - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#0d9488',
+                        'accentDark': '#0f766e',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/>
+                </svg>
+                Journalism skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Interview prep</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Prepare for journalism interviews with research checklists, question frameworks, and attribution guidelines.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Preparing to interview a source
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Developing question frameworks for recurring interview types
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Managing interview logistics and consent
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Planning follow-up after initial interviews
+                </li>
+            </ul>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Pre-interview research</h3>
+                    <p class="text-sm text-clay/70">Background checks, public records, social media audit, and context preparation checklists.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Question frameworks</h3>
+                    <p class="text-sm text-clay/70">Templates for profile, investigative, expert, and sensitive interviews with specific question types.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Recording and consent</h3>
+                    <p class="text-sm text-clay/70">Recording laws by state, consent templates, and best practices for documentation.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Attribution guidelines</h3>
+                    <p class="text-sm text-clay/70">On the record, background, deep background, and off the record protocols with clarification scripts.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Question types reference -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Question types</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Type</th>
+                            <th class="text-left px-5 py-3 font-semibold">Purpose</th>
+                            <th class="text-left px-5 py-3 font-semibold hidden md:table-cell">Example</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Open-ended</td>
+                            <td class="px-5 py-3 text-clay/70">Get the full story</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">"Walk me through what happened."</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Clarifying</td>
+                            <td class="px-5 py-3 text-clay/70">Pin down details</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">"When you say 'soon,' do you mean minutes or hours?"</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Probing</td>
+                            <td class="px-5 py-3 text-clay/70">Go deeper</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">"Why do you think that happened?"</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Confrontational</td>
+                            <td class="px-5 py-3 text-clay/70">Challenge statements</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">"Documents show [fact]. How do you respond?"</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Closing</td>
+                            <td class="px-5 py-3 text-clay/70">Ensure completeness</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">"Is there anything I didn't ask that I should know?"</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Attribution quick reference -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Attribution levels</h2>
+            <div class="space-y-3">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-green-100 text-green-800 text-xs font-semibold px-2.5 py-1 rounded">Default</span>
+                        <div>
+                            <h3 class="font-semibold">On the record</h3>
+                            <p class="text-sm text-clay/70 mt-1">Everything can be published with full name and title.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-yellow-100 text-yellow-800 text-xs font-semibold px-2.5 py-1 rounded">Common</span>
+                        <div>
+                            <h3 class="font-semibold">On background</h3>
+                            <p class="text-sm text-clay/70 mt-1">Information can be used, but source not identified by name. Agree on description beforehand.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-orange-100 text-orange-800 text-xs font-semibold px-2.5 py-1 rounded">Rare</span>
+                        <div>
+                            <h3 class="font-semibold">Deep background</h3>
+                            <p class="text-sm text-clay/70 mt-1">Information guides reporting but cannot be attributed. Verify independently before publishing.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-red-100 text-red-800 text-xs font-semibold px-2.5 py-1 rounded">Restricted</span>
+                        <div>
+                            <h3 class="font-semibold">Off the record</h3>
+                            <p class="text-sm text-clay/70 mt-1">For your knowledge only. Cannot be published or used to seek confirmation. Agree BEFORE they share.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/interview-prep ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/interview-prep" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../interview-transcription/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Interview transcription</a>
+                <a href="../source-verification/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Source verification</a>
+                <a href="../fact-check-workflow/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Fact-check workflow</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">Good interviews start with good preparation</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    Research, question design, and consent protocols in one skill.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/interview-prep" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/interview-transcription/index.html
+++ b/docs/interview-transcription/index.html
@@ -1,0 +1,324 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Interview transcription - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#0d9488',
+                        'accentDark': '#0f766e',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z"/>
+                </svg>
+                Journalism skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Interview transcription</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Interview management, transcription workflows, and source note-taking from preparation through publication.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Preparing questions for an interview
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Processing audio/video recordings
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Creating and managing transcripts
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Building a source relationship database
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Generating timestamped quotes for fact-checking
+                </li>
+            </ul>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Pre-interview prep</h3>
+                    <p class="text-sm text-clay/70">Research checklists, prioritized questions, recording setup with two-device rule.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Transcription pipelines</h3>
+                    <p class="text-sm text-clay/70">Automated Whisper workflows with timestamps, manual transcription templates.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Quote management</h3>
+                    <p class="text-sm text-clay/70">Quote extraction, verification checklists, and bank for reuse across stories.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Source database</h3>
+                    <p class="text-sm text-clay/70">Track sources, interviews, trust levels, and relationship history.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Tools reference -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Transcription tools</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Tool</th>
+                            <th class="text-left px-5 py-3 font-semibold">Purpose</th>
+                            <th class="text-left px-5 py-3 font-semibold hidden md:table-cell">Notes</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Whisper</td>
+                            <td class="px-5 py-3 text-clay/70">Local transcription</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Free, accurate, private</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Otter.ai</td>
+                            <td class="px-5 py-3 text-clay/70">Cloud transcription</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Real-time, speaker ID</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Descript</td>
+                            <td class="px-5 py-3 text-clay/70">Edit audio like text</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Good for pulling clips</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Rev</td>
+                            <td class="px-5 py-3 text-clay/70">Human transcription</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">For sensitive/legal work</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">oTranscribe</td>
+                            <td class="px-5 py-3 text-clay/70">Free web player</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Manual transcription aid</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Two-party consent states -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Recording consent</h2>
+            <div class="bg-white rounded-xl p-5 border border-mist/30">
+                <h3 class="font-semibold mb-3">Two-party consent states (US)</h3>
+                <p class="text-sm text-clay/70 mb-4">
+                    California, Connecticut, Florida, Illinois, Maryland, Massachusetts, Michigan, Montana, Nevada, New Hampshire, Pennsylvania, and Washington require all-party consent.
+                </p>
+                <div class="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+                    <p class="text-sm text-yellow-800 font-medium">Always get explicit consent on recording regardless of jurisdiction.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Quote checklist -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Quote accuracy checklist</h2>
+            <div class="bg-white rounded-xl p-5 border border-mist/30">
+                <ul class="space-y-3">
+                    <li class="flex items-center gap-3 text-clay/80">
+                        <div class="w-5 h-5 rounded border-2 border-mist flex-shrink-0"></div>
+                        Listened to original recording at timestamp
+                    </li>
+                    <li class="flex items-center gap-3 text-clay/80">
+                        <div class="w-5 h-5 rounded border-2 border-mist flex-shrink-0"></div>
+                        Quote is verbatim (or clearly marked as paraphrased)
+                    </li>
+                    <li class="flex items-center gap-3 text-clay/80">
+                        <div class="w-5 h-5 rounded border-2 border-mist flex-shrink-0"></div>
+                        Context preserved (not cherry-picked to change meaning)
+                    </li>
+                    <li class="flex items-center gap-3 text-clay/80">
+                        <div class="w-5 h-5 rounded border-2 border-mist flex-shrink-0"></div>
+                        Speaker identified correctly
+                    </li>
+                    <li class="flex items-center gap-3 text-clay/80">
+                        <div class="w-5 h-5 rounded border-2 border-mist flex-shrink-0"></div>
+                        Timestamp documented for fact-checker
+                    </li>
+                </ul>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/interview-transcription ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/interview-transcription" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../interview-prep/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Interview prep</a>
+                <a href="../source-verification/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Source verification</a>
+                <a href="../fact-check-workflow/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Fact-check workflow</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">From recording to publication</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    Transcription workflows, quote verification, and source management in one skill.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/interview-transcription" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/mobile-debugging/index.html
+++ b/docs/mobile-debugging/index.html
@@ -1,0 +1,338 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mobile debugging - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#4f46e5',
+                        'accentDark': '#4338ca',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"/>
+                </svg>
+                Development skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Mobile debugging</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Remote JavaScript console access and debugging on mobile devices without desktop DevTools.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Debugging web pages on phones and tablets
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Accessing console errors without desktop DevTools
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Testing responsive designs on real devices
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Diagnosing mobile-specific issues (touch events, viewport)
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Setting up error monitoring for production
+                </li>
+            </ul>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Eruda and vConsole</h3>
+                    <p class="text-sm text-clay/70">In-page DevTools with console, elements, network, and storage panels. Bookmarklet injection.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Native remote debugging</h3>
+                    <p class="text-sm text-clay/70">Chrome DevTools for Android, Safari Web Inspector for iOS, Firefox remote debugging.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Cloud testing platforms</h3>
+                    <p class="text-sm text-clay/70">LambdaTest, BrowserStack integration with Playwright/Puppeteer console capture.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Error monitoring</h3>
+                    <p class="text-sm text-clay/70">Sentry and LogRocket setup for production error capture and session replay.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Quick start -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Quick start: Eruda bookmarklet</h2>
+            <p class="text-clay/80 mb-4">Add this as a bookmark on your mobile browser, then tap it on any page to inject a DevTools panel:</p>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <code class="text-white">javascript:(function(){var script=document.createElement('script');script.src='https://cdn.jsdelivr.net/npm/eruda';document.body.append(script);script.onload=function(){eruda.init();}})();</code>
+            </div>
+        </section>
+
+        <!-- Tool comparison -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Tool comparison</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Tool</th>
+                            <th class="text-left px-5 py-3 font-semibold">Cost</th>
+                            <th class="text-left px-5 py-3 font-semibold hidden md:table-cell">Best for</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Eruda</td>
+                            <td class="px-5 py-3 text-clay/70">Free</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Quick debugging with full features</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">vConsole</td>
+                            <td class="px-5 py-3 text-clay/70">Free</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Lightweight logging, WeChat apps</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Chrome Remote</td>
+                            <td class="px-5 py-3 text-clay/70">Free</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Full DevTools on Android</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Safari Inspector</td>
+                            <td class="px-5 py-3 text-clay/70">Free</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Full DevTools on iOS (Mac required)</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Inspect.dev</td>
+                            <td class="px-5 py-3 text-clay/70">Paid</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">iOS debugging without Mac</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">LambdaTest</td>
+                            <td class="px-5 py-3 text-clay/70">Freemium</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Cloud testing, real devices</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Decision tree -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Decision guide</h2>
+            <div class="space-y-3">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-green-100 text-green-800 text-xs font-semibold px-2.5 py-1 rounded">USB</span>
+                        <div>
+                            <h3 class="font-semibold">Physical device with USB?</h3>
+                            <p class="text-sm text-clay/70 mt-1">Android: Chrome DevTools at chrome://inspect. iOS with Mac: Safari Web Inspector. iOS without Mac: Inspect.dev.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-yellow-100 text-yellow-800 text-xs font-semibold px-2.5 py-1 rounded">No USB</span>
+                        <div>
+                            <h3 class="font-semibold">Physical device, no cable?</h3>
+                            <p class="text-sm text-clay/70 mt-1">Inject Eruda or vConsole via bookmarklet on any page.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-blue-100 text-blue-800 text-xs font-semibold px-2.5 py-1 rounded">Remote</span>
+                        <div>
+                            <h3 class="font-semibold">Production or remote debugging?</h3>
+                            <p class="text-sm text-clay/70 mt-1">Add conditional Eruda loading (?eruda=true) or set up Sentry/LogRocket for error monitoring.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-purple-100 text-purple-800 text-xs font-semibold px-2.5 py-1 rounded">Automated</span>
+                        <div>
+                            <h3 class="font-semibold">Automated testing?</h3>
+                            <p class="text-sm text-clay/70 mt-1">Playwright/Puppeteer with mobile emulation, or cloud platforms (LambdaTest, BrowserStack).</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/mobile-debugging ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/mobile-debugging" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../electron-dev/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Electron dev</a>
+                <a href="../accessibility-compliance/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Accessibility compliance</a>
+                <a href="../web-scraping/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Web scraping</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">Debug anywhere</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    In-page consoles, remote debugging, and cloud testing for mobile web.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/mobile-debugging" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/newsletter-publishing/index.html
+++ b/docs/newsletter-publishing/index.html
@@ -1,0 +1,315 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Newsletter publishing - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#d97706',
+                        'accentDark': '#b45309',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                </svg>
+                Communications skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Newsletter publishing</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Email newsletter workflows for journalists and researchers building direct audience relationships.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Creating a new newsletter from scratch
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Designing email templates for journalism content
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Building and segmenting subscriber lists
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Analyzing newsletter performance metrics
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Migrating between newsletter platforms
+                </li>
+            </ul>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Content strategy framework</h3>
+                    <p class="text-sm text-clay/70">Templates for defining newsletter identity, target audience, content pillars, and success metrics.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">HTML email templates</h3>
+                    <p class="text-sm text-clay/70">Responsive email templates with dark mode support and mobile-friendly layouts.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Subscriber management</h3>
+                    <p class="text-sm text-clay/70">List hygiene workflows, segmentation strategies, and re-engagement campaigns.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Deliverability best practices</h3>
+                    <p class="text-sm text-clay/70">SPF, DKIM, DMARC setup, spam score checklists, and authentication guidance.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Platform comparison -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Platform comparison</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Platform</th>
+                            <th class="text-left px-5 py-3 font-semibold">Best for</th>
+                            <th class="text-left px-5 py-3 font-semibold hidden md:table-cell">Key feature</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Substack</td>
+                            <td class="px-5 py-3 text-clay/70">Writer-first, paid subs</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Built-in payments</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Buttondown</td>
+                            <td class="px-5 py-3 text-clay/70">Developers, minimal</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Markdown native</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Ghost</td>
+                            <td class="px-5 py-3 text-clay/70">Publishers, memberships</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Full CMS included</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">beehiiv</td>
+                            <td class="px-5 py-3 text-clay/70">Growth-focused</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Referral tools</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">ConvertKit</td>
+                            <td class="px-5 py-3 text-clay/70">Creators</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Automation</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Engagement benchmarks -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Engagement benchmarks</h2>
+            <div class="space-y-3">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-green-100 text-green-800 text-xs font-semibold px-2.5 py-1 rounded">Excellent</span>
+                        <div>
+                            <h3 class="font-semibold">Open rate 55%+</h3>
+                            <p class="text-sm text-clay/70 mt-1">Top-performing journalism newsletters. Indicates strong subject lines and engaged audience.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-yellow-100 text-yellow-800 text-xs font-semibold px-2.5 py-1 rounded">Good</span>
+                        <div>
+                            <h3 class="font-semibold">Open rate 40%+</h3>
+                            <p class="text-sm text-clay/70 mt-1">Healthy engagement for most newsletters. Click rate of 4%+ is also good.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-red-100 text-red-800 text-xs font-semibold px-2.5 py-1 rounded">Concerning</span>
+                        <div>
+                            <h3 class="font-semibold">Unsubscribe rate 1%+</h3>
+                            <p class="text-sm text-clay/70 mt-1">High unsubscribe rates suggest content mismatch or list quality issues.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/newsletter-publishing ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/newsletter-publishing" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../web-scraping/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Web scraping</a>
+                <a href="../data-journalism/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Data journalism</a>
+                <a href="../academic-writing/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Academic writing</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">Build direct audience relationships</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    Strategy frameworks, templates, and deliverability guidance in one skill.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/newsletter-publishing" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/newsroom-style/index.html
+++ b/docs/newsroom-style/index.html
@@ -1,0 +1,357 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Newsroom style - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#0d9488',
+                        'accentDark': '#0f766e',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z"/>
+                </svg>
+                Journalism skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Newsroom style</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Enforce AP Style and newsroom conventions for professional journalism writing.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Writing news articles, briefs, or headlines
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Editing drafts for publication
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Converting interview notes into publishable copy
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Writing press releases or media advisories
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Creating social media posts for news content
+                </li>
+            </ul>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Number rules</h3>
+                    <p class="text-sm text-clay/70">When to spell out vs. use numerals for ages, percentages, money, and addresses.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Attribution guidelines</h3>
+                    <p class="text-sm text-clay/70">Use "said" not "stated." Attribution after quotes, at natural pauses.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Dates and times</h3>
+                    <p class="text-sm text-clay/70">Month abbreviations, time formatting (9 a.m. not 9:00 AM), and day references.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Lede construction</h3>
+                    <p class="text-sm text-clay/70">Inverted pyramid, 35-word limit, and types of ledes for different story formats.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Numbers quick reference -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Numbers quick reference</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Rule</th>
+                            <th class="text-left px-5 py-3 font-semibold">Example</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Spell out one through nine</td>
+                            <td class="px-5 py-3 text-clay/70">"three witnesses" not "3 witnesses"</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Numerals for 10 and above</td>
+                            <td class="px-5 py-3 text-clay/70">"15 people attended"</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Always numerals for ages</td>
+                            <td class="px-5 py-3 text-clay/70">"a 5-year-old girl"</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Always numerals for percentages</td>
+                            <td class="px-5 py-3 text-clay/70">"5 percent" (spell out "percent")</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Always numerals for money</td>
+                            <td class="px-5 py-3 text-clay/70">"$5 million" not "five million dollars"</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Word choices -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Common word choices</h2>
+            <div class="space-y-3">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-green-100 text-green-800 text-xs font-semibold px-2.5 py-1 rounded">Use</span>
+                        <div>
+                            <h3 class="font-semibold">more than</h3>
+                            <p class="text-sm text-clay/70 mt-1">Instead of "over" for quantities. "More than 100 people attended."</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-green-100 text-green-800 text-xs font-semibold px-2.5 py-1 rounded">Use</span>
+                        <div>
+                            <h3 class="font-semibold">said</h3>
+                            <p class="text-sm text-clay/70 mt-1">Instead of "stated," "remarked," or "noted." Keep attribution simple.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-green-100 text-green-800 text-xs font-semibold px-2.5 py-1 rounded">Use</span>
+                        <div>
+                            <h3 class="font-semibold">fewer</h3>
+                            <p class="text-sm text-clay/70 mt-1">For countable items. Use "less" for mass nouns. "Fewer people" vs. "less water."</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-green-100 text-green-800 text-xs font-semibold px-2.5 py-1 rounded">Use</span>
+                        <div>
+                            <h3 class="font-semibold">that / which</h3>
+                            <p class="text-sm text-clay/70 mt-1">"That" for restrictive clauses (essential). "Which" with comma for nonrestrictive (extra info).</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Red flags -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Red flags to avoid</h2>
+            <div class="bg-white rounded-xl p-5 border border-mist/30">
+                <ul class="space-y-2 text-clay/80">
+                    <li class="flex items-start gap-3">
+                        <svg class="w-5 h-5 text-red-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                        </svg>
+                        "Very" or "extremely" in news copy
+                    </li>
+                    <li class="flex items-start gap-3">
+                        <svg class="w-5 h-5 text-red-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                        </svg>
+                        Exclamation points in hard news
+                    </li>
+                    <li class="flex items-start gap-3">
+                        <svg class="w-5 h-5 text-red-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                        </svg>
+                        Unattributed opinions
+                    </li>
+                    <li class="flex items-start gap-3">
+                        <svg class="w-5 h-5 text-red-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                        </svg>
+                        Passive voice hiding who did what
+                    </li>
+                    <li class="flex items-start gap-3">
+                        <svg class="w-5 h-5 text-red-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                        </svg>
+                        Starting sentences with "There is" or "There are"
+                    </li>
+                </ul>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/newsroom-style ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/newsroom-style" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../interview-prep/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Interview prep</a>
+                <a href="../fact-check-workflow/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Fact-check workflow</a>
+                <a href="../ai-writing-detox/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">AI writing detox</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">Write like a pro</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    AP Style rules, attribution guidelines, and formatting standards in one skill.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/newsroom-style" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/page-monitoring/index.html
+++ b/docs/page-monitoring/index.html
@@ -1,0 +1,316 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Page monitoring - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#059669',
+                        'accentDark': '#047857',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
+                </svg>
+                Research skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Page monitoring</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Track web page changes, detect content removal, and preserve important pages before they disappear.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Tracking content changes on news sites or government pages
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Detecting when pages go down or content is removed
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Preserving content before deletion
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Generating RSS feeds for pages without them
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Monitoring for updates on specific topics
+                </li>
+            </ul>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Change detection scripts</h3>
+                    <p class="text-sm text-clay/70">Python monitoring scripts with hash-based change detection, element selectors, and local storage.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Uptime monitoring</h3>
+                    <p class="text-sm text-clay/70">UptimeRobot API integration for availability tracking and downtime alerts.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">RSS feed generation</h3>
+                    <p class="text-sm text-clay/70">Create RSS feeds from pages that don't have them using feedgen and BeautifulSoup.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Webhook notifications</h3>
+                    <p class="text-sm text-clay/70">Alert manager for Slack, Discord, and email notifications when changes are detected.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Service comparison -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Monitoring services</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Service</th>
+                            <th class="text-left px-5 py-3 font-semibold">Free tier</th>
+                            <th class="text-left px-5 py-3 font-semibold hidden md:table-cell">Best for</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Visualping</td>
+                            <td class="px-5 py-3 text-clay/70">5 pages</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Visual changes</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">ChangeTower</td>
+                            <td class="px-5 py-3 text-clay/70">Yes</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Compliance, archiving</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Distill.io</td>
+                            <td class="px-5 py-3 text-clay/70">25 pages</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Element-level tracking</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">UptimeRobot</td>
+                            <td class="px-5 py-3 text-clay/70">50 monitors</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Uptime only</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Wachete</td>
+                            <td class="px-5 py-3 text-clay/70">Limited</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Login-protected pages</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Monitoring strategy -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Monitoring strategy by use case</h2>
+            <div class="space-y-3">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-blue-100 text-blue-800 text-xs font-semibold px-2.5 py-1 rounded">News</span>
+                        <div>
+                            <h3 class="font-semibold">Breaking news sections</h3>
+                            <p class="text-sm text-clay/70 mt-1">Check every 5 minutes. Archive immediately on detection. Monitor press release pages and government announcements.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-purple-100 text-purple-800 text-xs font-semibold px-2.5 py-1 rounded">Research</span>
+                        <div>
+                            <h3 class="font-semibold">Academic monitoring</h3>
+                            <p class="text-sm text-clay/70 mt-1">Daily for active topics, weekly for general. Monitor preprint servers, journal TOCs, and researcher profiles.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-amber-100 text-amber-800 text-xs font-semibold px-2.5 py-1 rounded">Competitive</span>
+                        <div>
+                            <h3 class="font-semibold">Competitor intelligence</h3>
+                            <p class="text-sm text-clay/70 mt-1">Pricing pages daily, products daily, job postings weekly. Public pages only; respect terms of service.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/page-monitoring ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/page-monitoring" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../web-archiving/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Web archiving</a>
+                <a href="../web-scraping/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Web scraping</a>
+                <a href="../social-media-intelligence/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Social media intelligence</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">Never miss a change</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    Change detection, uptime monitoring, and RSS generation in one skill.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/page-monitoring" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/pdf-design/index.html
+++ b/docs/pdf-design/index.html
@@ -1,0 +1,320 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PDF design - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#e11d48',
+                        'accentDark': '#be123c',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>
+                </svg>
+                Design skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">PDF design</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Create professional PDF reports and funding proposals with live preview and iterative design.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Creating funding proposals and grant requests
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Designing program reports and initiative updates
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Building impact reports with metrics and outcomes
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Creating budget summaries and financial breakdowns
+                </li>
+            </ul>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">HTML templates</h3>
+                    <p class="text-sm text-clay/70">Print-ready templates for cover pages, content pages, and budget tables at 8.5" x 11" letter size.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Brand systems</h3>
+                    <p class="text-sm text-clay/70">CCM standard colors and program-specific palettes with Montserrat and Source Sans Pro typography.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Interactive editing</h3>
+                    <p class="text-sm text-clay/70">Commands for preview, regenerate, and upload during design sessions.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">PDF generation</h3>
+                    <p class="text-sm text-clay/70">Chromium headless printing with proper margin handling and page breaks.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Interactive commands -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Interactive commands</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Command</th>
+                            <th class="text-left px-5 py-3 font-semibold">Action</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 font-mono text-sm">preview</td>
+                            <td class="px-5 py-3 text-clay/70">Screenshot current state</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-mono text-sm">preview page N</td>
+                            <td class="px-5 py-3 text-clay/70">Screenshot specific page</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-mono text-sm">show cover</td>
+                            <td class="px-5 py-3 text-clay/70">Preview cover page</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-mono text-sm">show budget</td>
+                            <td class="px-5 py-3 text-clay/70">Preview budget section</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-mono text-sm">regenerate</td>
+                            <td class="px-5 py-3 text-clay/70">Create new PDF</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-mono text-sm">upload</td>
+                            <td class="px-5 py-3 text-clay/70">Upload to Google Drive</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-mono text-sm">done</td>
+                            <td class="px-5 py-3 text-clay/70">Finish session</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Key principles -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Key principles</h2>
+            <div class="space-y-3">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-green-100 text-green-800 text-xs font-semibold px-2.5 py-1 rounded">Required</span>
+                        <div>
+                            <h3 class="font-semibold">Sentence case</h3>
+                            <p class="text-sm text-clay/70 mt-1">Never Title Case. All headings use sentence case formatting.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-green-100 text-green-800 text-xs font-semibold px-2.5 py-1 rounded">Required</span>
+                        <div>
+                            <h3 class="font-semibold">Left-aligned</h3>
+                            <p class="text-sm text-clay/70 mt-1">Never justified text. Keep paragraphs left-aligned for readability.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-blue-100 text-blue-800 text-xs font-semibold px-2.5 py-1 rounded">Standard</span>
+                        <div>
+                            <h3 class="font-semibold">Print-ready</h3>
+                            <p class="text-sm text-clay/70 mt-1">8.5" x 11" letter size with proper margins (0.5" top/bottom, 0.65" sides).</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-blue-100 text-blue-800 text-xs font-semibold px-2.5 py-1 rounded">Standard</span>
+                        <div>
+                            <h3 class="font-semibold">Brand consistent</h3>
+                            <p class="text-sm text-clay/70 mt-1">CCM red (#CA3553) or program-specific palettes.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/pdf-design ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/pdf-design" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../project-memory/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Project memory</a>
+                <a href="../data-journalism/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Data journalism</a>
+                <a href="../accessibility-compliance/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Accessibility compliance</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">Professional reports, fast</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    HTML templates, brand systems, and iterative preview in one skill.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/pdf-design" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/project-memory/index.html
+++ b/docs/project-memory/index.html
@@ -1,0 +1,339 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Project memory - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#7c3aed',
+                        'accentDark': '#6d28d9',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+                </svg>
+                Documentation skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Project memory</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Generate CLAUDE.md files that transfer tribal knowledge, not obvious information.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Setting up new journalism projects
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Onboarding collaborators to existing projects
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Documenting project-specific quirks and gotchas
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Creating context for AI assistants working on your code
+                </li>
+            </ul>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Deletion test</h3>
+                    <p class="text-sm text-clay/70">Guidelines for cutting obvious information. If an experienced journalist already knows it, delete it.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">6 project templates</h3>
+                    <p class="text-sm text-clay/70">Editorial tools, event websites, publications, research projects, content pipelines, and digital archives.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Voice guidelines</h3>
+                    <p class="text-sm text-clay/70">Direct, terse notes. No marketing language. No "Welcome to..." introductions.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Good vs. bad examples</h3>
+                    <p class="text-sm text-clay/70">Side-by-side comparisons of verbose documentation vs. tribal knowledge only.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- What to include -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">What belongs in CLAUDE.md</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Include</th>
+                            <th class="text-left px-5 py-3 font-semibold">Don't include</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 text-clay/70">Project-specific quirks</td>
+                            <td class="px-5 py-3 text-clay/70">How journalism works generally</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 text-clay/70">YOUR naming conventions</td>
+                            <td class="px-5 py-3 text-clay/70">Standard file organization</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 text-clay/70">Commands with YOUR flags</td>
+                            <td class="px-5 py-3 text-clay/70">Generic commands like "npm install"</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 text-clay/70">Non-obvious architecture</td>
+                            <td class="px-5 py-3 text-clay/70">Framework documentation</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 text-clay/70">Common mistakes in THIS project</td>
+                            <td class="px-5 py-3 text-clay/70">General best practices</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Template selector -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Template selector</h2>
+            <div class="space-y-3">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-blue-100 text-blue-800 text-xs font-semibold px-2.5 py-1 rounded">Tool</span>
+                        <div>
+                            <h3 class="font-semibold">editorial-tool.md</h3>
+                            <p class="text-sm text-clay/70 mt-1">Newsroom tools, fact-checkers, AI assistants</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-green-100 text-green-800 text-xs font-semibold px-2.5 py-1 rounded">Event</span>
+                        <div>
+                            <h3 class="font-semibold">event-website.md</h3>
+                            <p class="text-sm text-clay/70 mt-1">Conferences, workshops, campaign sites</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-amber-100 text-amber-800 text-xs font-semibold px-2.5 py-1 rounded">Content</span>
+                        <div>
+                            <h3 class="font-semibold">publication.md</h3>
+                            <p class="text-sm text-clay/70 mt-1">Newsletters, podcasts, ongoing content series</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-purple-100 text-purple-800 text-xs font-semibold px-2.5 py-1 rounded">Research</span>
+                        <div>
+                            <h3 class="font-semibold">research-project.md</h3>
+                            <p class="text-sm text-clay/70 mt-1">Investigations, data journalism with defined scope</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-red-100 text-red-800 text-xs font-semibold px-2.5 py-1 rounded">Pipeline</span>
+                        <div>
+                            <h3 class="font-semibold">content-pipeline.md</h3>
+                            <p class="text-sm text-clay/70 mt-1">CMS workflows, publishing automation</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-gray-100 text-gray-800 text-xs font-semibold px-2.5 py-1 rounded">Archive</span>
+                        <div>
+                            <h3 class="font-semibold">digital-archive.md</h3>
+                            <p class="text-sm text-clay/70 mt-1">Historical collections, document repositories</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Length guideline -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Length guideline</h2>
+            <div class="bg-white rounded-xl p-5 border border-mist/30">
+                <p class="text-clay/80">A good CLAUDE.md is <strong>50-150 lines</strong>. If it's longer, you're explaining too much. If it's shorter, you might be missing critical quirks.</p>
+                <p class="text-clay/70 text-sm mt-3 italic">The best CLAUDE.md files are written by people who've been burned by the quirks they're documenting.</p>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/project-memory ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/project-memory" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../project-retrospective/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Project retrospective</a>
+                <a href="../template-selector/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Template selector</a>
+                <a href="../editorial-workflow/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Editorial workflow</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">Document what matters</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    Templates for tribal knowledge, not generic documentation.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/project-memory" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/python-pipeline/index.html
+++ b/docs/python-pipeline/index.html
@@ -1,0 +1,319 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Python pipeline - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#4f46e5',
+                        'accentDark': '#4338ca',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
+                </svg>
+                Development skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Python pipeline</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Python data processing pipelines with modular architecture for content processing workflows, dispatcher patterns, and batch processing systems.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Building content processing workflows
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Implementing dispatcher patterns for routing content types
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Integrating Google Sheets and Drive APIs
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Creating batch processing systems with resume capability
+                </li>
+            </ul>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Modular architecture</h3>
+                    <p class="text-sm text-clay/70">Project structure with workflow orchestrators, dispatchers, processor classes, and service integrations.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Dispatcher pattern</h3>
+                    <p class="text-sm text-clay/70">Route content to appropriate processors based on URL patterns and content types using Protocol classes.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Google Sheets integration</h3>
+                    <p class="text-sm text-clay/70">Complete gspread patterns for reading, writing, batch updates, and finding rows by ID.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Progress tracking</h3>
+                    <p class="text-sm text-clay/70">Resume capability with JSON-based state persistence, processed ID tracking, and error logging.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Gemini AI integration</h3>
+                    <p class="text-sm text-clay/70">Entity extraction, categorization, and image classification with cost tracking.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Rate limiting</h3>
+                    <p class="text-sm text-clay/70">Decorators and custom rate limiters with backoff for API calls.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Architecture reference -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Project structure</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">File</th>
+                            <th class="text-left px-5 py-3 font-semibold">Purpose</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 font-mono text-sm">workflow.py</td>
+                            <td class="px-5 py-3 text-clay/70">Main orchestrator</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-mono text-sm">dispatcher.py</td>
+                            <td class="px-5 py-3 text-clay/70">Content-type router</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-mono text-sm">processors/base.py</td>
+                            <td class="px-5 py-3 text-clay/70">Abstract base class</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-mono text-sm">services/sheets_service.py</td>
+                            <td class="px-5 py-3 text-clay/70">Google Sheets integration</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-mono text-sm">services/ai_service.py</td>
+                            <td class="px-5 py-3 text-clay/70">Gemini API wrapper</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-mono text-sm">utils/rate_limiter.py</td>
+                            <td class="px-5 py-3 text-clay/70">API rate limiting</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-mono text-sm">config.py</td>
+                            <td class="px-5 py-3 text-clay/70">Environment configuration</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Common pitfalls -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Common pitfalls</h2>
+            <div class="space-y-3">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-red-100 text-red-800 text-xs font-semibold px-2.5 py-1 rounded">Watch out</span>
+                        <div>
+                            <h3 class="font-semibold">Google Sheets cell limits</h3>
+                            <p class="text-sm text-clay/70 mt-1">Max cell length is 50,000 characters. Truncate long content before writing.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-red-100 text-red-800 text-xs font-semibold px-2.5 py-1 rounded">Watch out</span>
+                        <div>
+                            <h3 class="font-semibold">CSV encoding issues</h3>
+                            <p class="text-sm text-clay/70 mt-1">Always use <code>encoding='utf-8-sig'</code> for BOM handling when reading CSV files.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-yellow-100 text-yellow-800 text-xs font-semibold px-2.5 py-1 rounded">Best practice</span>
+                        <div>
+                            <h3 class="font-semibold">Cache API responses</h3>
+                            <p class="text-sm text-clay/70 mt-1">Use <code>@lru_cache</code> to avoid redundant API calls and reduce costs.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/python-pipeline ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/python-pipeline" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../web-scraping/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Web scraping</a>
+                <a href="../data-journalism/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Data journalism</a>
+                <a href="../digital-archive/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Digital archive</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">Build data pipelines that don't break</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    Modular architecture, rate limiting, and progress tracking in one skill.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/python-pipeline" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/secure-auth/index.html
+++ b/docs/secure-auth/index.html
@@ -1,0 +1,316 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Secure auth - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#dc2626',
+                        'accentDark': '#b91c1c',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
+                </svg>
+                Security skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Secure auth</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Production-ready authentication patterns. These aren't the simplest implementations - they're the ones that won't get you sued.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Implementing user login and registration
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Building password reset flows
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Setting up session management or JWT authentication
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Integrating OAuth providers (Google, etc.)
+                </li>
+            </ul>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Session-based auth</h3>
+                    <p class="text-sm text-clay/70">Complete Express.js implementation with Redis storage, regeneration on login, and proper cookie settings.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">JWT with refresh tokens</h3>
+                    <p class="text-sm text-clay/70">Short-lived access tokens, httpOnly refresh cookies, token revocation, and frontend handling patterns.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Password reset flow</h3>
+                    <p class="text-sm text-clay/70">Secure token generation, hashed storage, expiration, and email enumeration prevention.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">OAuth integration</h3>
+                    <p class="text-sm text-clay/70">Server-side Google OAuth with CSRF state parameter, token exchange, and user creation.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Multi-factor auth (TOTP)</h3>
+                    <p class="text-sm text-clay/70">QR code generation, secret storage, verification with time window tolerance.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Rate limiting</h3>
+                    <p class="text-sm text-clay/70">Per-IP login attempt tracking with cooldown windows and timing attack prevention.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Decision guide -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Sessions vs JWTs</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Use sessions when</th>
+                            <th class="text-left px-5 py-3 font-semibold">Use JWTs when</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 text-clay/70">Server-rendered application</td>
+                            <td class="px-5 py-3 text-clay/70">Multiple services need to verify auth</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 text-clay/70">Need immediate logout/revocation</td>
+                            <td class="px-5 py-3 text-clay/70">Stateless architecture required</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 text-clay/70">Single domain</td>
+                            <td class="px-5 py-3 text-clay/70">Mobile app + API</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 text-clay/70">Simpler to implement correctly</td>
+                            <td class="px-5 py-3 text-clay/70">Third-party integrations</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                <strong>Common mistake:</strong> Using JWTs because a tutorial did, then storing them in localStorage (XSS vulnerable) and having no revocation strategy.
+            </p>
+        </section>
+
+        <!-- Security checklist -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Security checklist</h2>
+            <div class="space-y-3">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-3">Password storage</h3>
+                    <ul class="text-sm text-clay/70 space-y-1">
+                        <li>Using bcrypt/scrypt/Argon2 with cost factor 12+</li>
+                        <li>Never storing plain text passwords</li>
+                        <li>Never logging passwords</li>
+                    </ul>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-3">Session management</h3>
+                    <ul class="text-sm text-clay/70 space-y-1">
+                        <li>Sessions stored server-side (not just in cookies)</li>
+                        <li>Session IDs are cryptographically random</li>
+                        <li>Sessions regenerated on login (prevent fixation)</li>
+                        <li>Sessions invalidated on logout</li>
+                    </ul>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-3">JWT security</h3>
+                    <ul class="text-sm text-clay/70 space-y-1">
+                        <li>Short access token lifetime (15 min or less)</li>
+                        <li>Refresh tokens stored as httpOnly cookies</li>
+                        <li>Token revocation mechanism exists</li>
+                        <li>Secrets are at least 256 bits</li>
+                    </ul>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-3">Information disclosure</h3>
+                    <ul class="text-sm text-clay/70 space-y-1">
+                        <li>Same error messages for valid/invalid users</li>
+                        <li>Timing attacks mitigated</li>
+                        <li>No user enumeration via registration/reset</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/secure-auth ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/secure-auth" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../security-checklist/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Security checklist</a>
+                <a href="../api-hardening/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">API hardening</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">Authentication that doesn't embarrass you</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    Sessions, JWTs, password reset, OAuth, and MFA - all production-ready.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/secure-auth" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/security-checklist/index.html
+++ b/docs/security-checklist/index.html
@@ -1,0 +1,337 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Security checklist - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#dc2626',
+                        'accentDark': '#b91c1c',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/>
+                </svg>
+                Security skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Security checklist</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Minimum viable security before shipping any web application. This is the baseline that prevents obvious disasters.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Reviewing code before shipping to production
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Auditing an existing application
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    When you mention "security review" or "going to production"
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Concerned about vulnerabilities in your app
+                </li>
+            </ul>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Authentication checks</h3>
+                    <p class="text-sm text-clay/70">Password hashing, session expiration, rate limiting, and credential handling.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Input validation</h3>
+                    <p class="text-sm text-clay/70">SQL injection prevention, XSS escaping, file upload safety, and redirect validation.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Secrets management</h3>
+                    <p class="text-sm text-clay/70">Environment variables, .gitignore patterns, and key rotation strategies.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Database security</h3>
+                    <p class="text-sm text-clay/70">Network isolation, minimum permissions, RLS policies, and encrypted connections.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Network and transport</h3>
+                    <p class="text-sm text-clay/70">HTTPS enforcement, TLS configuration, HSTS, secure cookies, and CORS.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Compliance basics</h3>
+                    <p class="text-sm text-clay/70">GDPR, CCPA, PCI DSS, and HIPAA quick reference for common requirements.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Pre-ship checklist categories -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Pre-ship audit categories</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Category</th>
+                            <th class="text-left px-5 py-3 font-semibold">Key items</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Authentication</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm">Password hashing, session expiration, rate limiting, no credentials in logs</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Input validation</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm">Parameterized queries, XSS escaping, file upload checks, URL validation</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Secrets</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm">No secrets in code, environment variables, separate dev/prod secrets</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Database</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm">Not public, dedicated user, minimum permissions, RLS enabled</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Network</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm">HTTPS only, TLS 1.2+, HSTS, secure cookies, specific CORS origins</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Logging</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm">Auth events logged, no sensitive data, retention policy, alerts</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Quick fixes -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Quick fixes for common issues</h2>
+            <div class="space-y-3">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-red-100 text-red-800 text-xs font-semibold px-2.5 py-1 rounded">Critical</span>
+                        <div>
+                            <h3 class="font-semibold">Stored passwords in plain text</h3>
+                            <p class="text-sm text-clay/70 mt-1">Add password hashing immediately, force password reset for all users, invalidate sessions, check for database exposure.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-red-100 text-red-800 text-xs font-semibold px-2.5 py-1 rounded">Critical</span>
+                        <div>
+                            <h3 class="font-semibold">API key in git history</h3>
+                            <p class="text-sm text-clay/70 mt-1">Rotate the key immediately, revoke old key, use BFG Repo-Cleaner to remove from history, force push.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-orange-100 text-orange-800 text-xs font-semibold px-2.5 py-1 rounded">Important</span>
+                        <div>
+                            <h3 class="font-semibold">Database publicly accessible</h3>
+                            <p class="text-sm text-clay/70 mt-1">Change credentials, configure firewall rules, enable SSL/TLS, review access logs.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-yellow-100 text-yellow-800 text-xs font-semibold px-2.5 py-1 rounded">Review</span>
+                        <div>
+                            <h3 class="font-semibold">Unknown logging content</h3>
+                            <p class="text-sm text-clay/70 mt-1">Search for console.log/logger/print, review what's logged, implement structured logging with allowlists.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Resources -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Resources</h2>
+            <div class="bg-white rounded-xl p-5 border border-mist/30">
+                <ul class="space-y-2 text-sm">
+                    <li><a href="https://owasp.org/www-project-top-ten/" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">OWASP Top 10</a> - Most critical web application security risks</li>
+                    <li><a href="https://cheatsheetseries.owasp.org/" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">OWASP Cheat Sheets</a> - Security implementation guides</li>
+                    <li><a href="https://haveibeenpwned.com/" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Have I Been Pwned</a> - Check for credential breaches</li>
+                    <li><a href="https://observatory.mozilla.org/" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Mozilla Observatory</a> - Test your security headers</li>
+                    <li><a href="https://www.ssllabs.com/ssltest/" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">SSL Labs</a> - Test your TLS configuration</li>
+                </ul>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/security-checklist ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/security-checklist" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../secure-auth/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Secure auth</a>
+                <a href="../api-hardening/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">API hardening</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">Don't ship without checking</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    The baseline security audit that prevents obvious disasters.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/security-checklist" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/social-media-intelligence/index.html
+++ b/docs/social-media-intelligence/index.html
@@ -1,0 +1,367 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Social media intelligence - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#0d9488',
+                        'accentDark': '#0f766e',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+                </svg>
+                Journalism skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Social media intelligence</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Systematic approaches for monitoring, analyzing, and investigating social media for journalism and OSINT.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Tracking how a story spreads across platforms
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Investigating potential coordinated inauthentic behavior
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Monitoring breaking news across social platforms
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Detecting bot activity or manipulation campaigns
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Archiving social content before deletion
+                </li>
+            </ul>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Real-time monitoring</h3>
+                    <p class="text-sm text-clay/70">Multi-platform tracker with breaking news detection, keyword spike analysis, and trending topic identification.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Account analysis</h3>
+                    <p class="text-sm text-clay/70">Authenticity scoring, red flag detection, follower ratio analysis, and posting pattern evaluation.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Network mapping</h3>
+                    <p class="text-sm text-clay/70">Account relationship tracking, cluster detection, coordination scoring, and connected component analysis.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Narrative tracking</h3>
+                    <p class="text-sm text-clay/70">Claim propagation tracking, spread timeline visualization, hashtag co-occurrence analysis.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Evidence preservation</h3>
+                    <p class="text-sm text-clay/70">Wayback Machine and archive.today integration for archiving content before deletion.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Coordination detection</h3>
+                    <p class="text-sm text-clay/70">Automated scoring for timing patterns, content duplication, and behavioral signals.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Platform tools reference -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Platform-specific tools</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Platform</th>
+                            <th class="text-left px-5 py-3 font-semibold">Tools</th>
+                            <th class="text-left px-5 py-3 font-semibold hidden md:table-cell">Notes</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Twitter/X</td>
+                            <td class="px-5 py-3 text-clay/70">TweetDeck, Brandwatch</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">API increasingly restricted</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Facebook</td>
+                            <td class="px-5 py-3 text-clay/70">CrowdTangle (limited)</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Academic access only now</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">TikTok</td>
+                            <td class="px-5 py-3 text-clay/70">Exolyt, Pentos</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Limited historical data</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Reddit</td>
+                            <td class="px-5 py-3 text-clay/70">Pushshift, Arctic Shift</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Archive access varies</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">YouTube</td>
+                            <td class="px-5 py-3 text-clay/70">YouTube Data API</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Good metadata access</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Bluesky</td>
+                            <td class="px-5 py-3 text-clay/70">Firehose API</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm hidden md:table-cell">Open, real-time access</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Coordination signals -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Coordinated behavior indicators</h2>
+            <div class="space-y-3">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-3">Timing patterns</h3>
+                    <ul class="text-sm text-clay/70 space-y-1">
+                        <li>Multiple accounts posting same content within minutes</li>
+                        <li>Synchronized posting times across accounts</li>
+                        <li>Burst activity followed by dormancy</li>
+                        <li>Posts appear faster than human typing speed</li>
+                    </ul>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-3">Content patterns</h3>
+                    <ul class="text-sm text-clay/70 space-y-1">
+                        <li>Identical or near-identical text across accounts</li>
+                        <li>Same images/media shared by multiple accounts</li>
+                        <li>Identical typos or formatting errors</li>
+                        <li>Copy-paste artifacts visible</li>
+                    </ul>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-3">Account patterns</h3>
+                    <ul class="text-sm text-clay/70 space-y-1">
+                        <li>Accounts created around same time</li>
+                        <li>Similar naming conventions (name + numbers)</li>
+                        <li>Generic or stock profile photos</li>
+                        <li>Engage with each other disproportionately</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <!-- Ethical guidelines -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Ethical guidelines</h2>
+            <div class="bg-white rounded-xl p-5 border border-mist/30">
+                <ul class="space-y-2 text-clay/80">
+                    <li class="flex items-start gap-3">
+                        <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                        </svg>
+                        Archive public content only
+                    </li>
+                    <li class="flex items-start gap-3">
+                        <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                        </svg>
+                        Don't create fake accounts for monitoring
+                    </li>
+                    <li class="flex items-start gap-3">
+                        <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                        </svg>
+                        Respect platform terms of service
+                    </li>
+                    <li class="flex items-start gap-3">
+                        <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                        </svg>
+                        Protect sources who share social content
+                    </li>
+                    <li class="flex items-start gap-3">
+                        <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                        </svg>
+                        Verify before publishing claims about coordination
+                    </li>
+                </ul>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/social-media-intelligence ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/social-media-intelligence" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../source-verification/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Source verification</a>
+                <a href="../web-scraping/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Web scraping</a>
+                <a href="../data-journalism/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Data journalism</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">Track narratives and detect manipulation</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    Monitoring, analysis, and investigation tools for social media journalism.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/social-media-intelligence" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/story-pitch/index.html
+++ b/docs/story-pitch/index.html
@@ -1,0 +1,316 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Story pitch - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#0d9488',
+                        'accentDark': '#0f766e',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+                </svg>
+                Journalism skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Story pitch</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Craft effective story pitches for different publication types and formats. Good stories die in bad pitches.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Pitching stories to editors (internal or external)
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Developing freelance query letters
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Refining story angles before reporting
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Competing for assignment in a newsroom
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Proposal writing for grants or fellowships
+                </li>
+            </ul>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Pitch fundamentals</h3>
+                    <p class="text-sm text-clay/70">The five essential elements every pitch needs: hook, story, evidence, access, and ask.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Templates by type</h3>
+                    <p class="text-sm text-clay/70">Ready-to-use templates for daily news, features, investigations, op-eds, and freelance queries.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Angle development</h3>
+                    <p class="text-sm text-clay/70">Techniques for finding hooks, the "dinner table" test, and converting topics into angles.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Common mistakes</h3>
+                    <p class="text-sm text-clay/70">Examples of information dumps, missing news hooks, vague access, and no-stakes pitches with fixes.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- The "so what" test -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">The "so what" test</h2>
+            <p class="text-clay/80 mb-4">Before pitching, answer these four questions. If you can't answer all four, you're not ready to pitch.</p>
+            <div class="space-y-3">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-accent/10 text-accent text-xs font-semibold px-2.5 py-1 rounded">1</span>
+                        <div>
+                            <h3 class="font-semibold">Why this story?</h3>
+                            <p class="text-sm text-clay/70 mt-1">What's the significance? Why does it matter?</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-accent/10 text-accent text-xs font-semibold px-2.5 py-1 rounded">2</span>
+                        <div>
+                            <h3 class="font-semibold">Why now?</h3>
+                            <p class="text-sm text-clay/70 mt-1">What's the timeliness or news hook?</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-accent/10 text-accent text-xs font-semibold px-2.5 py-1 rounded">3</span>
+                        <div>
+                            <h3 class="font-semibold">Why you?</h3>
+                            <p class="text-sm text-clay/70 mt-1">What access, expertise, or unique angle do you bring?</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-accent/10 text-accent text-xs font-semibold px-2.5 py-1 rounded">4</span>
+                        <div>
+                            <h3 class="font-semibold">Why this outlet?</h3>
+                            <p class="text-sm text-clay/70 mt-1">How does this fit the publication's audience?</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Angle vs topic reference -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Angle versus topic</h2>
+            <p class="text-clay/80 mb-4"><strong>Topic</strong> is what you're covering. <strong>Angle</strong> is how you're covering it.</p>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Topic</th>
+                            <th class="text-left px-5 py-3 font-semibold">Angle</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 text-clay/70">Homelessness</td>
+                            <td class="px-5 py-3">The family that's been on the housing waitlist for 3 years</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 text-clay/70">Climate change</td>
+                            <td class="px-5 py-3">The town that's already moving because of rising seas</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 text-clay/70">Healthcare costs</td>
+                            <td class="px-5 py-3">The insulin price that tripled while the patent was extended</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 text-clay/70">Education</td>
+                            <td class="px-5 py-3">The teacher who's spent $10k of her own money on supplies</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/story-pitch ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/story-pitch" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../interview-prep/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Interview prep</a>
+                <a href="../foia-requests/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">FOIA requests</a>
+                <a href="../data-journalism/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Data journalism</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">The pitch sells the story</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    Templates, angle development, and the "so what" test in one skill.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/story-pitch" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/template-selector/index.html
+++ b/docs/template-selector/index.html
@@ -1,0 +1,307 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Template selector - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#7c3aed',
+                        'accentDark': '#6d28d9',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+                </svg>
+                Documentation skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Template selector</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Choose the correct CLAUDE.md or LESSONS.md template for journalism projects. Don't guess - use the decision tree.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Starting a new project and need documentation
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Setting up CLAUDE.md for a project
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Unsure which template category fits your project
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Writing project retrospectives (LESSONS.md)
+                </li>
+            </ul>
+        </section>
+
+        <!-- Quick reference table -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Quick reference</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Project type</th>
+                            <th class="text-left px-5 py-3 font-semibold">Template category</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 text-clay/70">Newsroom AI tool, fact-checker</td>
+                            <td class="px-5 py-3 font-medium">editorial-tool</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 text-clay/70">Conference, summit, workshop</td>
+                            <td class="px-5 py-3 font-medium">event-website</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 text-clay/70">Newsletter, podcast, blog</td>
+                            <td class="px-5 py-3 font-medium">publication</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 text-clay/70">Investigation, data journalism</td>
+                            <td class="px-5 py-3 font-medium">research-project</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 text-clay/70">CMS workflow, syndication</td>
+                            <td class="px-5 py-3 font-medium">content-pipeline</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 text-clay/70">Historical collection, archive</td>
+                            <td class="px-5 py-3 font-medium">digital-archive</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Decision tree</h3>
+                    <p class="text-sm text-clay/70">Step-by-step logic for matching projects to the correct template category.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Category descriptions</h3>
+                    <p class="text-sm text-clay/70">Detailed descriptions for each template type: editorial-tool, event-website, publication, research-project, content-pipeline, digital-archive.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Common mistakes</h3>
+                    <p class="text-sm text-clay/70">Examples of wrong template choices and why they're wrong, with the correct alternatives.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">The litmus test</h3>
+                    <p class="text-sm text-clay/70">Three questions to ask when you're still unsure which template to use.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- The litmus test -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">The litmus test</h2>
+            <p class="text-clay/80 mb-4">If you're still unsure, ask these three questions:</p>
+            <div class="space-y-3">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-accent/10 text-accent text-xs font-semibold px-2.5 py-1 rounded">1</span>
+                        <div>
+                            <h3 class="font-semibold">Is this a tool that helps journalists do X, or is this X itself?</h3>
+                            <p class="text-sm text-clay/70 mt-1">Tool = editorial-tool. The thing itself = other categories.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-accent/10 text-accent text-xs font-semibold px-2.5 py-1 rounded">2</span>
+                        <div>
+                            <h3 class="font-semibold">Does it have a specific end date?</h3>
+                            <p class="text-sm text-clay/70 mt-1">Event dates = event-website. Publication date = research-project. Ongoing = publication, content-pipeline, or digital-archive.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-accent/10 text-accent text-xs font-semibold px-2.5 py-1 rounded">3</span>
+                        <div>
+                            <h3 class="font-semibold">Is preservation the primary goal?</h3>
+                            <p class="text-sm text-clay/70 mt-1">Yes = digital-archive. No = other categories.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/template-selector ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/template-selector" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../project-memory/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Project memory</a>
+                <a href="../project-retrospective/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Project retrospective</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">Pick the specific template that fits</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    Decision trees, category descriptions, and common mistakes in one skill.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/template-selector" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/test-first-bugs/index.html
+++ b/docs/test-first-bugs/index.html
@@ -1,0 +1,293 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test-first bugs - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#4f46e5',
+                        'accentDark': '#4338ca',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
+                </svg>
+                Development skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Test-first bugs</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Enforce a disciplined bug-fixing workflow that prevents regression and parallelizes fix attempts.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    User reports a bug or describes unexpected behavior
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Something is "broken", "not working", or "failing"
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    User mentions an "error", "issue", or "problem" in code
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    User asks to "fix" something
+                </li>
+            </ul>
+        </section>
+
+        <!-- Core workflow -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">Core workflow</h2>
+            <div class="space-y-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-yellow-100 text-yellow-800 text-xs font-semibold px-2.5 py-1 rounded">Phase 1</span>
+                        <div>
+                            <h3 class="font-semibold">Reproduce and document</h3>
+                            <ol class="text-sm text-clay/70 mt-2 list-decimal list-inside space-y-1">
+                                <li>Understand the bug - gather details about expected vs actual behavior</li>
+                                <li>Identify the test location - check for tests/, __tests__/, spec/, *.test.*, *.spec.* patterns</li>
+                                <li>Write a failing test that demonstrates the bug</li>
+                            </ol>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-blue-100 text-blue-800 text-xs font-semibold px-2.5 py-1 rounded">Phase 2</span>
+                        <div>
+                            <h3 class="font-semibold">Fix with subagents</h3>
+                            <ol class="text-sm text-clay/70 mt-2 list-decimal list-inside space-y-1">
+                                <li>Launch fix subagents to attempt fixes in parallel</li>
+                                <li>Run the test to verify the fix</li>
+                                <li>Iterate if needed - launch additional subagents with new approaches</li>
+                            </ol>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-green-100 text-green-800 text-xs font-semibold px-2.5 py-1 rounded">Phase 3</span>
+                        <div>
+                            <h3 class="font-semibold">Verify and complete</h3>
+                            <ol class="text-sm text-clay/70 mt-2 list-decimal list-inside space-y-1">
+                                <li>Run full test suite to ensure no regressions were introduced</li>
+                                <li>Report success with passing test as proof</li>
+                            </ol>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Test naming conventions</h3>
+                    <p class="text-sm text-clay/70">Patterns for Python (pytest, unittest), JavaScript (Jest, Vitest), and TypeScript test names that describe the bug.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Test structure</h3>
+                    <p class="text-sm text-clay/70">Arrange-Act-Assert pattern for bug reproduction tests that fail initially and pass after the fix.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Parallel fix strategies</h3>
+                    <p class="text-sm text-clay/70">Direct fix agent, root cause agent, and edge case agent approaches for parallelized debugging.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Quick test setup</h3>
+                    <p class="text-sm text-clay/70">Commands for setting up minimal test frameworks when projects lack test infrastructure.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Test structure example -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Test structure</h2>
+            <p class="text-clay/80 mb-4">Every bug reproduction test follows the Arrange-Act-Assert pattern:</p>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <pre class="text-white"><code>def test_bug_description():
+    # 1. ARRANGE - Set up the conditions that trigger the bug
+    input_data = create_problematic_input()
+
+    # 2. ACT - Perform the action that causes the bug
+    result = function_under_test(input_data)
+
+    # 3. ASSERT - Verify the expected (correct) behavior
+    assert result == expected_value  # This should FAIL initially</code></pre>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/test-first-bugs ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/test-first-bugs" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../vibe-coding/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Vibe coding</a>
+                <a href="../python-pipeline/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Python pipeline</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">A passing test proves the bug is fixed</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    Test-driven bug fixing, parallel subagents, and regression prevention in one skill.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/test-first-bugs" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/web-archiving/index.html
+++ b/docs/web-archiving/index.html
@@ -1,0 +1,334 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Web archiving - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#059669',
+                        'accentDark': '#047857',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"/>
+                </svg>
+                Archive skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Web archiving</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Access inaccessible web pages and preserve web content for journalism, research, and legal purposes.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Accessing unavailable or deleted pages
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Preserving web content before it changes or disappears
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Creating legal evidence archives with chain of custody
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Building redundant archival workflows for research
+                </li>
+            </ul>
+        </section>
+
+        <!-- Archive service comparison -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Archive service comparison</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden overflow-x-auto">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Service</th>
+                            <th class="text-left px-5 py-3 font-semibold">Best for</th>
+                            <th class="text-left px-5 py-3 font-semibold hidden md:table-cell">API</th>
+                            <th class="text-left px-5 py-3 font-semibold hidden md:table-cell">Deletions</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Wayback Machine</td>
+                            <td class="px-5 py-3 text-clay/70">Historical research</td>
+                            <td class="px-5 py-3 text-clay/70 hidden md:table-cell">Yes (free)</td>
+                            <td class="px-5 py-3 text-clay/70 hidden md:table-cell">On request</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Archive.today</td>
+                            <td class="px-5 py-3 text-clay/70">Paywall bypass, quick saves</td>
+                            <td class="px-5 py-3 text-clay/70 hidden md:table-cell">No</td>
+                            <td class="px-5 py-3 text-clay/70 hidden md:table-cell">Never</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Perma.cc</td>
+                            <td class="px-5 py-3 text-clay/70">Legal citations</td>
+                            <td class="px-5 py-3 text-clay/70 hidden md:table-cell">Yes (free tier)</td>
+                            <td class="px-5 py-3 text-clay/70 hidden md:table-cell">By creator</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">ArchiveBox</td>
+                            <td class="px-5 py-3 text-clay/70">Self-hosted, privacy</td>
+                            <td class="px-5 py-3 text-clay/70 hidden md:table-cell">Local</td>
+                            <td class="px-5 py-3 text-clay/70 hidden md:table-cell">Never</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Conifer</td>
+                            <td class="px-5 py-3 text-clay/70">Interactive content</td>
+                            <td class="px-5 py-3 text-clay/70 hidden md:table-cell">Yes</td>
+                            <td class="px-5 py-3 text-clay/70 hidden md:table-cell">By creator</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Wayback Machine API</h3>
+                    <p class="text-sm text-clay/70">Python code for checking availability, saving pages, and retrieving historical snapshots via CDX API.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Multi-archive redundancy</h3>
+                    <p class="text-sm text-clay/70">Archive to Wayback, Archive.today, and Perma.cc simultaneously for maximum preservation.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Legal evidence preservation</h3>
+                    <p class="text-sm text-clay/70">Chain of custody documentation, content hashing, and timestamped capture records.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">ArchiveBox integration</h3>
+                    <p class="text-sm text-clay/70">Self-hosted archiving setup, Python integration, and scheduled archiving workflows.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Archive retrieval cascade -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Archive retrieval cascade</h2>
+            <p class="text-clay/80 mb-4">Try services in this order for maximum coverage:</p>
+            <div class="space-y-3">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-accent/10 text-accent text-xs font-semibold px-2.5 py-1 rounded">1</span>
+                        <div>
+                            <h3 class="font-semibold">Wayback Machine (archive.org)</h3>
+                            <p class="text-sm text-clay/70 mt-1">916B+ pages, historical depth, API access</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-accent/10 text-accent text-xs font-semibold px-2.5 py-1 rounded">2</span>
+                        <div>
+                            <h3 class="font-semibold">Archive.today (archive.is/archive.ph)</h3>
+                            <p class="text-sm text-clay/70 mt-1">On-demand snapshots, paywall bypass</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-accent/10 text-accent text-xs font-semibold px-2.5 py-1 rounded">3</span>
+                        <div>
+                            <h3 class="font-semibold">Google Cache</h3>
+                            <p class="text-sm text-clay/70 mt-1">Recent pages, search: cache:url</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-accent/10 text-accent text-xs font-semibold px-2.5 py-1 rounded">4</span>
+                        <div>
+                            <h3 class="font-semibold">Bing Cache</h3>
+                            <p class="text-sm text-clay/70 mt-1">Click dropdown arrow in search results</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-accent/10 text-accent text-xs font-semibold px-2.5 py-1 rounded">5</span>
+                        <div>
+                            <h3 class="font-semibold">Memento Time Travel (aggregator)</h3>
+                            <p class="text-sm text-clay/70 mt-1">Searches multiple archives simultaneously</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/web-archiving ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/web-archiving" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../source-verification/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Source verification</a>
+                <a href="../web-scraping/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Web scraping</a>
+                <a href="../digital-archive/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Digital archive</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">Archive before it disappears</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    Wayback Machine API, multi-archive redundancy, and legal evidence preservation in one skill.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/web-archiving" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/web-scraping/index.html
+++ b/docs/web-scraping/index.html
@@ -1,0 +1,310 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Web scraping - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#4f46e5',
+                        'accentDark': '#4338ca',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
+                </svg>
+                Development skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Web scraping</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Reliable, ethical web scraping with fallback strategies, anti-bot handling, and social media extraction.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Extracting content from websites
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Handling paywalls and anti-bot measures
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Implementing scraping cascades with fallbacks
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Processing social media (YouTube, Instagram, TikTok)
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Finding and using undocumented APIs
+                </li>
+            </ul>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Scraping cascade</h3>
+                    <p class="text-sm text-clay/70">Three-tier fallback: Trafilatura (fast) to Requests (HTTP) to Playwright (JavaScript rendering with stealth).</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Poison pill detection</h3>
+                    <p class="text-sm text-clay/70">Detect paywalls, CAPTCHAs, rate limits, Cloudflare, and login walls with pattern matching.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Undocumented APIs</h3>
+                    <p class="text-sm text-clay/70">Find and use hidden APIs via browser dev tools, with examples for autocomplete endpoints.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Social media tools</h3>
+                    <p class="text-sm text-clay/70">yt-dlp for YouTube/TikTok, instaloader for Instagram, with metadata extraction and download patterns.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Scraping cascade -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Scraping cascade architecture</h2>
+            <p class="text-clay/80 mb-4">Try multiple extraction strategies with automatic fallback:</p>
+            <div class="space-y-3">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-green-100 text-green-800 text-xs font-semibold px-2.5 py-1 rounded">Fast</span>
+                        <div>
+                            <h3 class="font-semibold">Trafilatura</h3>
+                            <p class="text-sm text-clay/70 mt-1">Lightweight extraction for standard articles. Best for news sites and blogs.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-yellow-100 text-yellow-800 text-xs font-semibold px-2.5 py-1 rounded">Medium</span>
+                        <div>
+                            <h3 class="font-semibold">Requests + BeautifulSoup</h3>
+                            <p class="text-sm text-clay/70 mt-1">HTTP requests with rotating user agents. Good for static content.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-red-100 text-red-800 text-xs font-semibold px-2.5 py-1 rounded">Heavy</span>
+                        <div>
+                            <h3 class="font-semibold">Playwright with stealth</h3>
+                            <p class="text-sm text-clay/70 mt-1">Full JavaScript rendering with anti-bot bypass. For SPAs and protected sites.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Poison pill types -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Poison pill types</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Type</th>
+                            <th class="text-left px-5 py-3 font-semibold">Detection patterns</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Paywall</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm">"subscribe to continue", "you've reached your limit"</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">CAPTCHA</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm">"verify you are human", "robot verification"</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Rate limit</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm">"too many requests", HTTP 429</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Cloudflare</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm">"checking your browser", "ddos protection"</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Login required</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm">"sign in to continue", "create an account"</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/web-scraping ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/web-scraping" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../web-archiving/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Web archiving</a>
+                <a href="../python-pipeline/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Python pipeline</a>
+                <a href="../social-media-intelligence/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Social media intelligence</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">Extract what you need, ethically</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    Cascade architecture, poison pill detection, and social media tools in one skill.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/web-scraping" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/zero-build-frontend/index.html
+++ b/docs/zero-build-frontend/index.html
@@ -1,0 +1,312 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Zero-build frontend - Claude skills for journalism</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'display': ['Fraunces', 'serif'],
+                        'body': ['Plus Jakarta Sans', 'sans-serif'],
+                    },
+                    colors: {
+                        'canvas': '#ede6d4',
+                        'ink': '#121212',
+                        'clay': '#2d2a26',
+                        'mist': '#c4bfb4',
+                        'accent': '#4f46e5',
+                        'accentDark': '#4338ca',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image:
+                url("https://www.transparenttextures.com/patterns/natural-paper.png"),
+                radial-gradient(circle at 50% 50%, rgba(255,255,255,0.2) 0%, transparent 100%);
+            opacity: 0.5;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .content-section h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+        .content-section h3 { margin-top: 2rem; margin-bottom: 0.75rem; }
+        .content-section p { margin-bottom: 1rem; }
+        .content-section ul, .content-section ol { margin-bottom: 1rem; margin-left: 1.5rem; }
+        .content-section li { margin-bottom: 0.5rem; }
+        .content-section code {
+            background: rgba(0,0,0,0.06);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+        .content-section pre {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+        .content-section pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+        .content-section table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+        .content-section th, .content-section td {
+            border: 1px solid rgba(0,0,0,0.1);
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        .content-section th {
+            background: rgba(0,0,0,0.04);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body class="bg-canvas text-ink">
+    <div class="paper-overlay"></div>
+
+    <!-- Navigation -->
+    <nav class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-mist/30">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../" class="text-clay/70 hover:text-ink flex items-center gap-2 text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+                All skills
+            </a>
+            <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/70 hover:text-ink transition-colors">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                </svg>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="bg-gradient-to-br from-accent to-accentDark text-white pt-24 pb-16">
+        <div class="max-w-4xl mx-auto px-6">
+            <div class="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-full px-3 py-1 text-sm mb-4">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
+                </svg>
+                Development skill
+            </div>
+            <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Zero-build frontend</h1>
+            <p class="text-xl text-white/90 max-w-2xl">
+                Build production-quality web applications without build tools, bundlers, or complex toolchains.
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <!-- When to use -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">When to use</h2>
+            <ul class="space-y-2 text-clay/80">
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Building static web apps without bundlers
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Creating Leaflet.js maps with clustering
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Using Google Sheets as a database
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Developing browser extensions (Manifest V3)
+                </li>
+                <li class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    CDN-loaded React with htm (no JSX, no build)
+                </li>
+            </ul>
+        </section>
+
+        <!-- Key features -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-6">What's included</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">React via CDN (esm.sh)</h3>
+                    <p class="text-sm text-clay/70">Use React 18 with htm template literals instead of JSX. No transpilation needed.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Leaflet.js maps</h3>
+                    <p class="text-sm text-clay/70">Interactive maps with marker clustering, custom icons, popups, and filter controls.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Google Sheets integration</h3>
+                    <p class="text-sm text-clay/70">Fetch published CSV data and merge with localStorage for real-time local state.</p>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Browser extensions</h3>
+                    <p class="text-sm text-clay/70">Manifest V3 patterns with context menus, clipboard access, and options pages.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Tech stack -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Technology stack</h2>
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="text-left px-5 py-3 font-semibold">Component</th>
+                            <th class="text-left px-5 py-3 font-semibold">CDN source</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3 font-medium">React 18</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm">esm.sh/react@18.2.0</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">htm (JSX alternative)</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm">esm.sh/htm@3.1.1</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Tailwind CSS</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm">cdn.tailwindcss.com</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">Leaflet.js</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm">unpkg.com/leaflet@1.9.4</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">MarkerCluster</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm">unpkg.com/leaflet.markercluster@1.4.1</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3 font-medium">PapaParse (CSV)</td>
+                            <td class="px-5 py-3 text-clay/70 text-sm">cdn.jsdelivr.net/npm/papaparse</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Key patterns -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Key patterns</h2>
+            <div class="space-y-3">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-accent/10 text-accent text-xs font-semibold px-2.5 py-1 rounded">Data</span>
+                        <div>
+                            <h3 class="font-semibold">localStorage caching</h3>
+                            <p class="text-sm text-clay/70 mt-1">Cache fetched data with TTL expiration. Merge remote data with local state for offline-capable apps.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-accent/10 text-accent text-xs font-semibold px-2.5 py-1 rounded">Deploy</span>
+                        <div>
+                            <h3 class="font-semibold">Path management</h3>
+                            <p class="text-sm text-clay/70 mt-1">Auto-detect base path from URL for subdirectory deployments (WordPress wp-content, GitHub Pages).</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <div class="flex items-start gap-4">
+                        <span class="bg-accent/10 text-accent text-xs font-semibold px-2.5 py-1 rounded">Perf</span>
+                        <div>
+                            <h3 class="font-semibold">Performance tips</h3>
+                            <p class="text-sm text-clay/70 mt-1">Debounce search inputs, virtualize long lists, preconnect to CDNs, use CSS containment.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Installation -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto">
+                <p class="text-white/50 mb-2"># Clone the repository</p>
+                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white">cp -r claude-skills-journalism/zero-build-frontend ~/.claude/skills/</p>
+            </div>
+            <p class="mt-4 text-clay/70 text-sm">
+                Or download just this skill from the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/zero-build-frontend" class="text-accent hover:text-accentDark underline underline-offset-2" target="_blank">GitHub repository</a>.
+            </p>
+        </section>
+
+        <!-- Related skills -->
+        <section class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Related skills</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="../electron-dev/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Electron dev</a>
+                <a href="../accessibility-compliance/" class="bg-white rounded-full px-4 py-2 text-sm border border-mist/30 hover:border-accent/50 transition-colors">Accessibility compliance</a>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="text-center">
+            <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
+                <h2 class="font-display text-xl font-bold mb-3">Ship without npm install</h2>
+                <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
+                    CDN-loaded React, Leaflet maps, Google Sheets data, and browser extensions in one skill.
+                </p>
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/zero-build-frontend" target="_blank" class="inline-flex items-center gap-2 bg-white text-accent px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors">
+                    View on GitHub
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+                    </svg>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-mist/30 mt-12 relative z-10">
+        <div class="max-w-4xl mx-auto px-6 py-6">
+            <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                <p class="text-clay/60 text-sm">
+                    Built by <a href="https://centerforcooperativemedia.org" target="_blank" class="text-accent hover:text-accentDark underline underline-offset-2">Center for Cooperative Media</a>
+                </p>
+                <div class="flex items-center gap-6">
+                    <a href="../" class="text-clay/60 hover:text-ink text-sm transition-colors">All skills</a>
+                    <a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" class="text-clay/60 hover:text-ink text-sm transition-colors">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Created individual HTML pages for all 26 skills that didn't have dedicated pages
- Uses simpler template matching the flagship design (same fonts, paper overlay, professional styling)
- Total: 34 skill pages now in docs/ (8 flagship + 26 standard)

## Skills added by category

| Category | Skills |
|----------|--------|
| Journalism (teal) | interview-prep, interview-transcription, editorial-workflow, fact-check-workflow, newsroom-style, story-pitch, social-media-intelligence |
| Crisis (orange) | crisis-communications |
| Academic/Research (emerald) | academic-writing, content-access, digital-archive, page-monitoring, web-archiving |
| Development (indigo) | electron-dev, mobile-debugging, python-pipeline, test-first-bugs, web-scraping, zero-build-frontend |
| Security (red) | api-hardening, secure-auth, security-checklist |
| Design (rose) | pdf-design |
| Documentation (purple) | project-memory, template-selector |
| Communications (amber) | newsletter-publishing |

## Template features

Each page includes:
- Fraunces + Plus Jakarta Sans fonts
- Paper overlay texture
- Gradient hero with category badge
- "When to use" section with checkmarks
- "What's included" feature cards
- Reference tables where applicable
- Installation instructions
- Related skills links
- CTA footer

## Test plan

- [ ] Verify pages render correctly on GitHub Pages
- [ ] Check that all links work (related skills, GitHub repo links)
- [ ] Review content accuracy against SKILL.md files

🤖 Generated with [Claude Code](https://claude.ai/code)