### PR TITLE
feature visual-explainer card on main docs index

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -430,12 +430,12 @@
                         <p class="text-sm text-mist leading-relaxed">Standalone skill for PDF reports and proposals with print-ready CSS patterns and layout guidance.</p>
                     </a>
 
-                    <a href="visual-explainer/" class="skill-card deckle-card p-6 transition-all duration-300 block group">
+                    <a href="visual-explainer/" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
                         <div class="flex items-start justify-between mb-3">
-                            <i data-lucide="layout-dashboard" class="w-5 h-5 text-accent"></i>
-                            <span class="text-[9px] font-bold tracking-widest text-mist uppercase">Diagrams</span>
+                            <i data-lucide="layout-dashboard" class="w-5 h-5 text-[#2a9a90]"></i>
+                            <span class="featured-badge">Featured</span>
                         </div>
-                        <h3 class="font-display text-lg font-bold mb-2 group-hover:text-accent transition-colors">visual-explainer</h3>
+                        <h3 class="font-display text-lg font-bold mb-2 group-hover:text-[#2a9a90] transition-colors">visual-explainer</h3>
                         <p class="text-sm text-mist leading-relaxed">Turn complex data into styled HTML pages with diagrams, data tables, flowcharts, timelines, and dashboards.</p>
                     </a>
                 </div>


### PR DESCRIPTION
This pull request updates the appearance and highlighting of the "visual-explainer" skill card on the `docs/index.html` page to make it more visually prominent and to indicate it as a featured skill.

Visual design and highlighting improvements:

* Added the `skill-card-featured` class to the "visual-explainer" card and replaced the "Diagrams" label with a "Featured" badge for increased emphasis.
* Changed the icon and hover text color for the "visual-explainer" card to a custom teal (`#2a9a90`) for better visual distinction.