### PR TITLE
release: pdf-playground v1.2.0 — footer clearance overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-03-17
+
+### Changed
+- **pdf-playground v1.2.0**: Footer clearance overhaul across all templates
+  - All document templates (one-pager, report, proposal, slides, event) now use CSS Grid `grid-template-rows: auto 1fr auto` instead of absolute-positioned footers
+  - Footers are in normal document flow as the third grid row — no more fragile `calc()` with hardcoded header/footer heights
+  - Content areas have `overflow: hidden` to prevent text bleeding into the footer zone
+  - All 5 document commands updated with footer clearance verification rules
+  - Document-design skill updated with the grid layout pattern and safeguards
+  - Newsletter template unchanged (email table layout, not affected)
+- Updated GitHub Pages docs with v1.2.0 changelog section
+
 ## [1.5.0] - 2026-03-14
 
 ### Added

--- a/docs/pdf-playground/index.html
+++ b/docs/pdf-playground/index.html
@@ -590,6 +590,53 @@ style:
             </div>
         </section>
 
+        <!-- What's new -->
+        <section id="changelog" class="py-24 px-6">
+            <div class="max-w-4xl mx-auto">
+                <h2 class="font-display text-4xl md:text-5xl font-light italic text-center mb-16">What's new</h2>
+
+                <div class="feature-card p-8 rounded-xl mb-8">
+                    <div class="flex items-center gap-3 mb-4">
+                        <span class="bg-accent text-white text-xs font-bold px-3 py-1 rounded-full">v1.2.0</span>
+                        <span class="text-mist text-sm">March 2026</span>
+                    </div>
+                    <h3 class="font-display text-2xl font-bold mb-4">Footer clearance overhaul</h3>
+                    <p class="text-mist mb-6">
+                        All document templates now use a structural CSS Grid layout (<code>grid-template-rows: auto 1fr auto</code>) instead of absolute positioning for footers. This eliminates the recurring issue where content would overlap or touch the footer on print-ready documents.
+                    </p>
+                    <div class="space-y-3">
+                        <div class="flex items-start gap-3">
+                            <i data-lucide="check-circle" class="w-5 h-5 text-accent mt-0.5 flex-shrink-0"></i>
+                            <p class="text-sm"><strong>Structural grid layout</strong> &mdash; Header, content, and footer are now grid rows. The content area automatically fills available space. No more fragile <code>calc()</code> with hardcoded heights.</p>
+                        </div>
+                        <div class="flex items-start gap-3">
+                            <i data-lucide="check-circle" class="w-5 h-5 text-accent mt-0.5 flex-shrink-0"></i>
+                            <p class="text-sm"><strong>Overflow protection</strong> &mdash; Content areas now have <code>overflow: hidden</code> so text can never bleed past the content boundary into the footer zone.</p>
+                        </div>
+                        <div class="flex items-start gap-3">
+                            <i data-lucide="check-circle" class="w-5 h-5 text-accent mt-0.5 flex-shrink-0"></i>
+                            <p class="text-sm"><strong>All templates updated</strong> &mdash; One-pager, report, proposal, slides, and event flyer templates all use the new pattern. Newsletter template unchanged (email table layout).</p>
+                        </div>
+                        <div class="flex items-start gap-3">
+                            <i data-lucide="check-circle" class="w-5 h-5 text-accent mt-0.5 flex-shrink-0"></i>
+                            <p class="text-sm"><strong>Skill guidance added</strong> &mdash; All document commands now include footer clearance rules so Claude verifies page layout before delivering.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="feature-card p-8 rounded-xl opacity-60">
+                    <div class="flex items-center gap-3 mb-4">
+                        <span class="bg-ink/20 text-ink text-xs font-bold px-3 py-1 rounded-full">v1.1.1</span>
+                        <span class="text-mist text-sm">February 2026</span>
+                    </div>
+                    <h3 class="font-display text-xl font-bold mb-2">Interactive control panel + brand system</h3>
+                    <p class="text-mist text-sm">
+                        Live preview with tweakable controls for colors, fonts, and spacing. Brand configuration via <code>.claude/pdf-playground.local.md</code>. Six document templates.
+                    </p>
+                </div>
+            </div>
+        </section>
+
         <!-- Credits -->
         <section class="py-16 px-6 border-t border-ink/10">
             <div class="max-w-6xl mx-auto text-center">

--- a/pdf-playground/.claude-plugin/plugin.json
+++ b/pdf-playground/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-playground",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Interactive playground for creating and testing PDF reports and proposals",
   "author": {
     "name": "Joe Amditis",

--- a/pdf-playground/commands/event.md
+++ b/pdf-playground/commands/event.md
@@ -63,6 +63,16 @@ If not provided, ask for:
 - Registration URL
 - Material type needed
 
+## Footer clearance (critical)
+
+Content MUST NOT touch or overlap the footer. This is a common issue.
+
+- The `.flyer` element MUST use `display: grid; grid-template-rows: auto 1fr auto` so the footer takes its natural height and content fills the rest
+- The content area MUST have `overflow: hidden` to prevent text bleeding past its bounds
+- Never use `position: absolute` for footers — keep them in normal document flow as the third grid row
+- After generating, always take a screenshot and visually verify the bottom of the page
+- If content is too long, **reduce content** rather than shrinking the footer gap
+
 ## Output
 
 Save HTML file in current working directory.

--- a/pdf-playground/commands/event.md
+++ b/pdf-playground/commands/event.md
@@ -65,10 +65,11 @@ If not provided, ask for:
 
 ## Footer clearance (critical)
 
-Content MUST NOT touch or overlap the footer. This is a common issue.
+Content MUST NOT touch or overlap the footer.
 
-- The `.flyer` element MUST use `display: grid; grid-template-rows: auto 1fr auto` so the footer takes its natural height and content fills the rest
-- The content area MUST have `overflow: hidden` to prevent text bleeding past its bounds
+- The `.flyer` element MUST use `display: grid; grid-template-rows: auto 1fr auto`
+- It MUST have exactly 3 direct children: `<header class="flyer-header">`, `<div class="flyer-content">`, `<footer class="flyer-footer">`
+- The content wrapper (`.flyer-content`) MUST have `overflow: hidden` to prevent text bleeding
 - Never use `position: absolute` for footers — keep them in normal document flow as the third grid row
 - After generating, always take a screenshot and visually verify the bottom of the page
 - If content is too long, **reduce content** rather than shrinking the footer gap

--- a/pdf-playground/commands/proposal.md
+++ b/pdf-playground/commands/proposal.md
@@ -313,10 +313,11 @@ Create a multi-page HTML document with:
 
 ## Footer clearance (critical)
 
-Content MUST NOT touch or overlap the page footer. This is a common issue.
+Content MUST NOT touch or overlap the page footer.
 
-- The `.page` element MUST use `display: grid; grid-template-rows: auto 1fr auto` so the footer takes its natural height and content fills the rest
-- The content area MUST have `overflow: hidden` to prevent text bleeding past its bounds
+- The `.page` element MUST use `display: grid; grid-template-rows: auto 1fr auto`
+- It MUST have exactly 3 direct children: `<header class="page-header">`, `<div class="page-body">`, `<footer class="page-footer">`
+- The content wrapper (`.page-body`) MUST have `overflow: hidden` to prevent text bleeding
 - Never use `position: absolute` for footers — keep them in normal document flow as the third grid row
 - After generating, always take a screenshot and visually verify the bottom of each page
 - If content is too long, **reduce content** rather than shrinking the footer gap

--- a/pdf-playground/commands/proposal.md
+++ b/pdf-playground/commands/proposal.md
@@ -311,6 +311,16 @@ Create a multi-page HTML document with:
 - Total row with primary color background
 - Two-year or custom period totals
 
+## Footer clearance (critical)
+
+Content MUST NOT touch or overlap the page footer. This is a common issue.
+
+- The `.page` element MUST use `display: grid; grid-template-rows: auto 1fr auto` so the footer takes its natural height and content fills the rest
+- The content area MUST have `overflow: hidden` to prevent text bleeding past its bounds
+- Never use `position: absolute` for footers — keep them in normal document flow as the third grid row
+- After generating, always take a screenshot and visually verify the bottom of each page
+- If content is too long, **reduce content** rather than shrinking the footer gap
+
 ## Output
 
 Save the HTML file in the current working directory with a descriptive filename like `proposal-[project-name].html`.

--- a/pdf-playground/commands/report.md
+++ b/pdf-playground/commands/report.md
@@ -58,10 +58,11 @@ If no report name provided, ask the user for:
 
 ## Footer clearance (critical)
 
-Content MUST NOT touch or overlap the page footer. This is a common issue.
+Content MUST NOT touch or overlap the page footer.
 
-- The `.page` element MUST use `display: grid; grid-template-rows: auto 1fr auto` so the footer takes its natural height and content fills the rest
-- The content area MUST have `overflow: hidden` to prevent text bleeding past its bounds
+- The `.page` element MUST use `display: grid; grid-template-rows: auto 1fr auto`
+- It MUST have exactly 3 direct children: `<header class="page-header">`, `<div class="page-body">`, `<footer class="page-footer">`
+- The content wrapper (`.page-body`) MUST have `overflow: hidden` to prevent text bleeding
 - Never use `position: absolute` for footers — keep them in normal document flow as the third grid row
 - After generating, always take a screenshot and visually verify the bottom of each page
 - If content is too long, **reduce content** rather than shrinking the footer gap

--- a/pdf-playground/commands/report.md
+++ b/pdf-playground/commands/report.md
@@ -56,6 +56,16 @@ If no report name provided, ask the user for:
 - Key sections to include
 - Any metrics or data to highlight
 
+## Footer clearance (critical)
+
+Content MUST NOT touch or overlap the page footer. This is a common issue.
+
+- The `.page` element MUST use `display: grid; grid-template-rows: auto 1fr auto` so the footer takes its natural height and content fills the rest
+- The content area MUST have `overflow: hidden` to prevent text bleeding past its bounds
+- Never use `position: absolute` for footers — keep them in normal document flow as the third grid row
+- After generating, always take a screenshot and visually verify the bottom of each page
+- If content is too long, **reduce content** rather than shrinking the footer gap
+
 ## Output
 
 Save the HTML file in the current working directory.

--- a/pdf-playground/commands/slides.md
+++ b/pdf-playground/commands/slides.md
@@ -74,11 +74,13 @@ If not provided, ask for:
 
 ## Footer clearance (critical)
 
-Content MUST NOT touch or overlap the slide footer. This is a common issue.
+Content MUST NOT touch or overlap the slide footer.
 
-- The `.slide` element MUST use `display: grid; grid-template-rows: auto 1fr auto` so the footer takes its natural height and content fills the rest
-- The content area MUST have `overflow: hidden` to prevent text bleeding past its bounds
+- The `.slide` element MUST use `display: grid; grid-template-rows: auto 1fr auto`
+- Content slides MUST have exactly 3 direct children: `<div class="slide-header">`, `<div class="slide-body">`, `<div class="slide-footer">`
+- The content wrapper (`.slide-body`) MUST have `overflow: hidden` to prevent text bleeding
 - Never use `position: absolute` for footers — keep them in normal document flow as the third grid row
+- Title and section slides that don't have footers can use flex layout instead
 - After generating, always take a screenshot and visually verify the bottom of each slide
 - If content is too long, **reduce content** rather than shrinking the footer gap
 

--- a/pdf-playground/commands/slides.md
+++ b/pdf-playground/commands/slides.md
@@ -72,6 +72,16 @@ If not provided, ask for:
 - Key topics
 - Aspect ratio preference
 
+## Footer clearance (critical)
+
+Content MUST NOT touch or overlap the slide footer. This is a common issue.
+
+- The `.slide` element MUST use `display: grid; grid-template-rows: auto 1fr auto` so the footer takes its natural height and content fills the rest
+- The content area MUST have `overflow: hidden` to prevent text bleeding past its bounds
+- Never use `position: absolute` for footers — keep them in normal document flow as the third grid row
+- After generating, always take a screenshot and visually verify the bottom of each slide
+- If content is too long, **reduce content** rather than shrinking the footer gap
+
 ## Output
 
 Save HTML file in current working directory.

--- a/pdf-playground/templates/event-template.html
+++ b/pdf-playground/templates/event-template.html
@@ -92,6 +92,7 @@
         }
 
         .flyer-content {
+            /* Grid body wrapper — fills the 1fr row between header and footer */
             padding: 0.75in;
             padding-top: 1in;
             padding-bottom: 0.3in;

--- a/pdf-playground/templates/event-template.html
+++ b/pdf-playground/templates/event-template.html
@@ -36,7 +36,8 @@
             height: 11in;
             background: var(--white);
             margin: 0 auto;
-            position: relative;
+            display: grid;
+            grid-template-rows: auto 1fr auto;
             overflow: hidden;
             box-shadow: 0 4px 24px rgba(0,0,0,0.12);
         }
@@ -93,6 +94,8 @@
         .flyer-content {
             padding: 0.75in;
             padding-top: 1in;
+            padding-bottom: 0.3in;
+            overflow: hidden;
         }
 
         .event-details {
@@ -199,10 +202,6 @@
         }
 
         .flyer-footer {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
             padding: 0.3in 0.75in;
             display: flex;
             justify-content: space-between;

--- a/pdf-playground/templates/proposal-template.html
+++ b/pdf-playground/templates/proposal-template.html
@@ -274,8 +274,11 @@
 
         /* ========== CONTENT PAGES ========== */
         .content-page {
-            padding: 0.5in 0.75in;
-            padding-bottom: 0.3in;
+            /* Grid child styles only — padding/overflow on .page-body */
+        }
+
+        .page-body {
+            padding: 0.3in 0.75in 0.3in;
             overflow: hidden;
         }
 
@@ -283,8 +286,7 @@
             display: flex;
             justify-content: space-between;
             align-items: flex-start;
-            margin-bottom: 0.3in;
-            padding-bottom: 0.12in;
+            padding: 0.5in 0.75in 0.12in;
             border-bottom: 1px solid var(--gray-200);
         }
 
@@ -603,7 +605,7 @@
 
         /* Footer */
         .page-footer {
-            margin: 0 0.75in;
+            padding: 0 0.75in 0.3in;
             display: flex;
             justify-content: space-between;
             align-items: center;
@@ -730,39 +732,41 @@
             <div class="page-header-right">Funding Proposal</div>
         </header>
 
-        <h2 class="section-title">Background</h2>
+        <div class="page-body">
+            <h2 class="section-title">Background</h2>
 
-        <p class="body-text">
-            [Opening paragraph describing the context and history of the project.]
-        </p>
-
-        <p class="body-text">
-            [Second paragraph with key findings or research that supports the need.]
-        </p>
-
-        <div class="highlight-box">
-            <p class="highlight-text">
-                [Key quote or statistic that emphasizes the importance of the work.]
+            <p class="body-text">
+                [Opening paragraph describing the context and history of the project.]
             </p>
-        </div>
 
-        <p class="body-text">
-            [Additional context or supporting information.]
-        </p>
+            <p class="body-text">
+                [Second paragraph with key findings or research that supports the need.]
+            </p>
 
-        <div class="two-column">
-            <div class="data-callout">
-                <div class="data-callout-label">[Data Label 1]</div>
-                <div class="data-callout-stat">[Key Stat]</div>
-                <div class="data-callout-desc">
-                    [Description and context for this statistic.]
-                </div>
+            <div class="highlight-box">
+                <p class="highlight-text">
+                    [Key quote or statistic that emphasizes the importance of the work.]
+                </p>
             </div>
-            <div class="data-callout">
-                <div class="data-callout-label">[Data Label 2]</div>
-                <div class="data-callout-stat">[Key Stat]</div>
-                <div class="data-callout-desc">
-                    [Description and context for this statistic.]
+
+            <p class="body-text">
+                [Additional context or supporting information.]
+            </p>
+
+            <div class="two-column">
+                <div class="data-callout">
+                    <div class="data-callout-label">[Data Label 1]</div>
+                    <div class="data-callout-stat">[Key Stat]</div>
+                    <div class="data-callout-desc">
+                        [Description and context for this statistic.]
+                    </div>
+                </div>
+                <div class="data-callout">
+                    <div class="data-callout-label">[Data Label 2]</div>
+                    <div class="data-callout-stat">[Key Stat]</div>
+                    <div class="data-callout-desc">
+                        [Description and context for this statistic.]
+                    </div>
                 </div>
             </div>
         </div>
@@ -780,38 +784,40 @@
             <div class="page-header-right">Funding Proposal</div>
         </header>
 
-        <h2 class="section-title">Proposed work</h2>
+        <div class="page-body">
+            <h2 class="section-title">Proposed work</h2>
 
-        <p class="body-text">
-            [Introduction to what the project will accomplish with funding.]
-        </p>
+            <p class="body-text">
+                [Introduction to what the project will accomplish with funding.]
+            </p>
 
-        <p class="body-text" style="font-weight: 600; color: var(--black); margin-top: 0.3in;">
-            [Project name] is seeking funding to:
-        </p>
+            <p class="body-text" style="font-weight: 600; color: var(--black); margin-top: 0.3in;">
+                [Project name] is seeking funding to:
+            </p>
 
-        <div class="priority-list">
-            <div class="priority-item">
-                <div class="priority-number">1</div>
-                <div class="priority-content">
-                    <h3>[Priority 1 title in sentence case]</h3>
-                    <p>[Description of what this priority involves and why it matters.]</p>
+            <div class="priority-list">
+                <div class="priority-item">
+                    <div class="priority-number">1</div>
+                    <div class="priority-content">
+                        <h3>[Priority 1 title in sentence case]</h3>
+                        <p>[Description of what this priority involves and why it matters.]</p>
+                    </div>
                 </div>
-            </div>
 
-            <div class="priority-item">
-                <div class="priority-number">2</div>
-                <div class="priority-content">
-                    <h3>[Priority 2 title in sentence case]</h3>
-                    <p>[Description of what this priority involves and why it matters.]</p>
+                <div class="priority-item">
+                    <div class="priority-number">2</div>
+                    <div class="priority-content">
+                        <h3>[Priority 2 title in sentence case]</h3>
+                        <p>[Description of what this priority involves and why it matters.]</p>
+                    </div>
                 </div>
-            </div>
 
-            <div class="priority-item">
-                <div class="priority-number">3</div>
-                <div class="priority-content">
-                    <h3>[Priority 3 title in sentence case]</h3>
-                    <p>[Description of what this priority involves and why it matters.]</p>
+                <div class="priority-item">
+                    <div class="priority-number">3</div>
+                    <div class="priority-content">
+                        <h3>[Priority 3 title in sentence case]</h3>
+                        <p>[Description of what this priority involves and why it matters.]</p>
+                    </div>
                 </div>
             </div>
         </div>
@@ -829,41 +835,43 @@
             <div class="page-header-right">Funding Proposal</div>
         </header>
 
-        <h2 class="section-title">Proven impact</h2>
+        <div class="page-body">
+            <h2 class="section-title">Proven impact</h2>
 
-        <p class="body-text">
-            [Introduction to evidence or case studies that demonstrate success.]
-        </p>
-
-        <div class="case-study">
-            <div class="case-study-header">
-                <div class="case-study-org">[Organization Name]</div>
-                <div class="case-study-location">[Location]</div>
-            </div>
-            <p class="case-study-text">
-                [Description of what this partner accomplished with support from the project.]
+            <p class="body-text">
+                [Introduction to evidence or case studies that demonstrate success.]
             </p>
-            <p class="case-study-highlight">
-                "[Key quote or outcome from this case study.]"
+
+            <div class="case-study">
+                <div class="case-study-header">
+                    <div class="case-study-org">[Organization Name]</div>
+                    <div class="case-study-location">[Location]</div>
+                </div>
+                <p class="case-study-text">
+                    [Description of what this partner accomplished with support from the project.]
+                </p>
+                <p class="case-study-highlight">
+                    "[Key quote or outcome from this case study.]"
+                </p>
+            </div>
+
+            <div class="case-study">
+                <div class="case-study-header">
+                    <div class="case-study-org">[Organization Name]</div>
+                    <div class="case-study-location">[Location]</div>
+                </div>
+                <p class="case-study-text">
+                    [Description of what this partner accomplished with support from the project.]
+                </p>
+                <p class="case-study-highlight">
+                    "[Key quote or outcome from this case study.]"
+                </p>
+            </div>
+
+            <p class="body-text" style="margin-top: 0.3in;">
+                [Closing statement about the need for continued or expanded funding.]
             </p>
         </div>
-
-        <div class="case-study">
-            <div class="case-study-header">
-                <div class="case-study-org">[Organization Name]</div>
-                <div class="case-study-location">[Location]</div>
-            </div>
-            <p class="case-study-text">
-                [Description of what this partner accomplished with support from the project.]
-            </p>
-            <p class="case-study-highlight">
-                "[Key quote or outcome from this case study.]"
-            </p>
-        </div>
-
-        <p class="body-text" style="margin-top: 0.3in;">
-            [Closing statement about the need for continued or expanded funding.]
-        </p>
 
         <footer class="page-footer">
             <div class="footer-left">Center for Cooperative Media • Montclair State University</div>
@@ -878,75 +886,77 @@
             <div class="page-header-right">Funding Proposal</div>
         </header>
 
-        <h2 class="section-title">The ask</h2>
+        <div class="page-body">
+            <h2 class="section-title">The ask</h2>
 
-        <p class="budget-intro">
-            [Brief explanation of the budget and what the funding will support.]
-        </p>
+            <p class="budget-intro">
+                [Brief explanation of the budget and what the funding will support.]
+            </p>
 
-        <table class="budget-table">
-            <thead>
-                <tr>
-                    <th>Expense item</th>
-                    <th>Amount per year</th>
-                    <th>Total for 2 years</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>
-                        [Expense item 1]
-                        <span class="expense-desc">[Details about this expense]</span>
-                    </td>
-                    <td>$XX,XXX</td>
-                    <td>$XX,XXX</td>
-                </tr>
-                <tr>
-                    <td>
-                        [Expense item 2]
-                        <span class="expense-desc">[Details about this expense]</span>
-                    </td>
-                    <td>$XX,XXX</td>
-                    <td>$XX,XXX</td>
-                </tr>
-                <tr>
-                    <td>
-                        [Expense item 3]
-                        <span class="expense-desc">[Details about this expense]</span>
-                    </td>
-                    <td>$XX,XXX</td>
-                    <td>$XX,XXX</td>
-                </tr>
-                <tr>
-                    <td>[Expense item 4]</td>
-                    <td>$XX,XXX</td>
-                    <td>$XX,XXX</td>
-                </tr>
-                <tr>
-                    <td><strong>Total</strong></td>
-                    <td><strong>$XXX,XXX</strong></td>
-                    <td><strong>$XXX,XXX</strong></td>
-                </tr>
-            </tbody>
-        </table>
+            <table class="budget-table">
+                <thead>
+                    <tr>
+                        <th>Expense item</th>
+                        <th>Amount per year</th>
+                        <th>Total for 2 years</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>
+                            [Expense item 1]
+                            <span class="expense-desc">[Details about this expense]</span>
+                        </td>
+                        <td>$XX,XXX</td>
+                        <td>$XX,XXX</td>
+                    </tr>
+                    <tr>
+                        <td>
+                            [Expense item 2]
+                            <span class="expense-desc">[Details about this expense]</span>
+                        </td>
+                        <td>$XX,XXX</td>
+                        <td>$XX,XXX</td>
+                    </tr>
+                    <tr>
+                        <td>
+                            [Expense item 3]
+                            <span class="expense-desc">[Details about this expense]</span>
+                        </td>
+                        <td>$XX,XXX</td>
+                        <td>$XX,XXX</td>
+                    </tr>
+                    <tr>
+                        <td>[Expense item 4]</td>
+                        <td>$XX,XXX</td>
+                        <td>$XX,XXX</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Total</strong></td>
+                        <td><strong>$XXX,XXX</strong></td>
+                        <td><strong>$XXX,XXX</strong></td>
+                    </tr>
+                </tbody>
+            </table>
 
-        <div class="total-callout">
-            <div class="total-label">
-                Two-year investment
-                <span>[Description of what this investment supports]</span>
+            <div class="total-callout">
+                <div class="total-label">
+                    Two-year investment
+                    <span>[Description of what this investment supports]</span>
+                </div>
+                <div class="total-amount">$XXX,XXX</div>
             </div>
-            <div class="total-amount">$XXX,XXX</div>
-        </div>
 
-        <div class="contact-block">
-            <div class="contact-info">
-                <h4>Center for Cooperative Media</h4>
-                <p>
-                    Montclair State University • College of Communication and Media<br>
-                    <a href="mailto:info@centerforcooperativemedia.org">info@centerforcooperativemedia.org</a> • <a href="https://centerforcooperativemedia.org">centerforcooperativemedia.org</a>
-                </p>
+            <div class="contact-block">
+                <div class="contact-info">
+                    <h4>Center for Cooperative Media</h4>
+                    <p>
+                        Montclair State University • College of Communication and Media<br>
+                        <a href="mailto:info@centerforcooperativemedia.org">info@centerforcooperativemedia.org</a> • <a href="https://centerforcooperativemedia.org">centerforcooperativemedia.org</a>
+                    </p>
+                </div>
+                <a href="[project-url]" class="cta-button">Learn More</a>
             </div>
-            <a href="[project-url]" class="cta-button">Learn More</a>
         </div>
 
         <footer class="page-footer">

--- a/pdf-playground/templates/proposal-template.html
+++ b/pdf-playground/templates/proposal-template.html
@@ -60,7 +60,8 @@
             min-height: 11in;
             background: var(--white);
             margin: 0 auto 20px;
-            position: relative;
+            display: grid;
+            grid-template-rows: auto 1fr auto;
             overflow: hidden;
             box-shadow: 0 4px 24px rgba(0,0,0,0.12);
         }
@@ -274,10 +275,8 @@
         /* ========== CONTENT PAGES ========== */
         .content-page {
             padding: 0.5in 0.75in;
-            padding-bottom: 1in;
-            min-height: 11in;
-            height: 11in;
-            position: relative;
+            padding-bottom: 0.3in;
+            overflow: hidden;
         }
 
         .page-header {
@@ -604,10 +603,7 @@
 
         /* Footer */
         .page-footer {
-            position: absolute;
-            bottom: 0.4in;
-            left: 0.75in;
-            right: 0.75in;
+            margin: 0 0.75in;
             display: flex;
             justify-content: space-between;
             align-items: center;

--- a/pdf-playground/templates/report-template.html
+++ b/pdf-playground/templates/report-template.html
@@ -126,16 +126,18 @@
 
         /* Content pages */
         .content-page {
-            padding: 0.5in 0.75in;
-            padding-bottom: 0.3in;
+            /* Grid child styles only — padding/overflow on .page-body */
+        }
+
+        .page-body {
+            padding: 0.3in 0.75in 0.3in;
             overflow: hidden;
         }
 
         .page-header {
             display: flex;
             justify-content: space-between;
-            margin-bottom: 0.3in;
-            padding-bottom: 0.1in;
+            padding: 0.5in 0.75in 0.1in;
             border-bottom: 1px solid var(--gray-200);
         }
 
@@ -235,7 +237,7 @@
 
         /* Footer */
         .page-footer {
-            margin: 0 0.75in;
+            padding: 0 0.75in 0.3in;
             display: flex;
             justify-content: space-between;
             padding-top: 0.1in;
@@ -276,39 +278,41 @@
             <div class="page-header-right">[Year]</div>
         </header>
 
-        <h2 class="section-title">Executive summary</h2>
+        <div class="page-body">
+            <h2 class="section-title">Executive summary</h2>
 
-        <p class="lead-text">
-            [Opening statement that captures the key message of the report in 2-3 sentences.]
-        </p>
+            <p class="lead-text">
+                [Opening statement that captures the key message of the report in 2-3 sentences.]
+            </p>
 
-        <p class="body-text">
-            [More detailed summary of findings, outcomes, or key takeaways.]
-        </p>
+            <p class="body-text">
+                [More detailed summary of findings, outcomes, or key takeaways.]
+            </p>
 
-        <div class="metrics-grid">
-            <div class="metric-card">
-                <div class="metric-number">[Number]</div>
-                <div class="metric-label">[Metric label]</div>
+            <div class="metrics-grid">
+                <div class="metric-card">
+                    <div class="metric-number">[Number]</div>
+                    <div class="metric-label">[Metric label]</div>
+                </div>
+                <div class="metric-card">
+                    <div class="metric-number">[Number]</div>
+                    <div class="metric-label">[Metric label]</div>
+                </div>
+                <div class="metric-card">
+                    <div class="metric-number">[Number]</div>
+                    <div class="metric-label">[Metric label]</div>
+                </div>
             </div>
-            <div class="metric-card">
-                <div class="metric-number">[Number]</div>
-                <div class="metric-label">[Metric label]</div>
+
+            <div class="pullquote">
+                <p class="pullquote-text">"[Key quote that captures the essence of the report's findings or mission.]"</p>
+                <p class="pullquote-cite">— [Name], [Title]</p>
             </div>
-            <div class="metric-card">
-                <div class="metric-number">[Number]</div>
-                <div class="metric-label">[Metric label]</div>
-            </div>
+
+            <p class="body-text">
+                [Additional context or forward-looking statement.]
+            </p>
         </div>
-
-        <div class="pullquote">
-            <p class="pullquote-text">"[Key quote that captures the essence of the report's findings or mission.]"</p>
-            <p class="pullquote-cite">— [Name], [Title]</p>
-        </div>
-
-        <p class="body-text">
-            [Additional context or forward-looking statement.]
-        </p>
 
         <footer class="page-footer">
             <div class="footer-left">Center for Cooperative Media • Montclair State University</div>
@@ -323,32 +327,34 @@
             <div class="page-header-right">[Year]</div>
         </header>
 
-        <h2 class="section-title">Key findings</h2>
+        <div class="page-body">
+            <h2 class="section-title">Key findings</h2>
 
-        <p class="body-text">
-            [Introduction to the findings section.]
-        </p>
+            <p class="body-text">
+                [Introduction to the findings section.]
+            </p>
 
-        <p class="body-text">
-            <strong>[Finding 1 title]:</strong> [Description of the first key finding with supporting data or context.]
-        </p>
+            <p class="body-text">
+                <strong>[Finding 1 title]:</strong> [Description of the first key finding with supporting data or context.]
+            </p>
 
-        <p class="body-text">
-            <strong>[Finding 2 title]:</strong> [Description of the second key finding with supporting data or context.]
-        </p>
+            <p class="body-text">
+                <strong>[Finding 2 title]:</strong> [Description of the second key finding with supporting data or context.]
+            </p>
 
-        <p class="body-text">
-            <strong>[Finding 3 title]:</strong> [Description of the third key finding with supporting data or context.]
-        </p>
+            <p class="body-text">
+                <strong>[Finding 3 title]:</strong> [Description of the third key finding with supporting data or context.]
+            </p>
 
-        <div class="pullquote">
-            <p class="pullquote-text">"[Quote from a partner, participant, or stakeholder that illustrates the impact.]"</p>
-            <p class="pullquote-cite">— [Name], [Organization]</p>
+            <div class="pullquote">
+                <p class="pullquote-text">"[Quote from a partner, participant, or stakeholder that illustrates the impact.]"</p>
+                <p class="pullquote-cite">— [Name], [Organization]</p>
+            </div>
+
+            <p class="body-text">
+                [Closing paragraph for this section.]
+            </p>
         </div>
-
-        <p class="body-text">
-            [Closing paragraph for this section.]
-        </p>
 
         <footer class="page-footer">
             <div class="footer-left">Center for Cooperative Media • Montclair State University</div>

--- a/pdf-playground/templates/report-template.html
+++ b/pdf-playground/templates/report-template.html
@@ -43,7 +43,8 @@
             min-height: 11in;
             background: var(--white);
             margin: 0 auto 20px;
-            position: relative;
+            display: grid;
+            grid-template-rows: auto 1fr auto;
             overflow: hidden;
             box-shadow: 0 4px 24px rgba(0,0,0,0.12);
         }
@@ -126,10 +127,8 @@
         /* Content pages */
         .content-page {
             padding: 0.5in 0.75in;
-            padding-bottom: 1in;
-            min-height: 11in;
-            height: 11in;
-            position: relative;
+            padding-bottom: 0.3in;
+            overflow: hidden;
         }
 
         .page-header {
@@ -236,10 +235,7 @@
 
         /* Footer */
         .page-footer {
-            position: absolute;
-            bottom: 0.4in;
-            left: 0.75in;
-            right: 0.75in;
+            margin: 0 0.75in;
             display: flex;
             justify-content: space-between;
             padding-top: 0.1in;

--- a/pdf-playground/templates/slides-template.html
+++ b/pdf-playground/templates/slides-template.html
@@ -43,7 +43,8 @@
             height: 7.5in;
             background: var(--white);
             margin: 20px auto;
-            position: relative;
+            display: grid;
+            grid-template-rows: auto 1fr auto;
             overflow: hidden;
             box-shadow: 0 4px 24px rgba(0,0,0,0.2);
         }
@@ -122,6 +123,8 @@
         /* ========== CONTENT SLIDE ========== */
         .slide-content {
             padding: 0.75in 1in;
+            overflow: hidden;
+            padding-bottom: 0.2in;
         }
 
         .slide-header {
@@ -165,10 +168,7 @@
         }
 
         .slide-footer {
-            position: absolute;
-            bottom: 0.3in;
-            left: 1in;
-            right: 1in;
+            padding: 0 1in 0.3in;
             display: flex;
             justify-content: space-between;
             font-size: 12pt;

--- a/pdf-playground/templates/slides-template.html
+++ b/pdf-playground/templates/slides-template.html
@@ -45,6 +45,7 @@
             margin: 20px auto;
             display: grid;
             grid-template-rows: auto 1fr auto;
+            position: relative; /* needed for absolutely-positioned children like .presenter */
             overflow: hidden;
             box-shadow: 0 4px 24px rgba(0,0,0,0.2);
         }
@@ -122,14 +123,17 @@
 
         /* ========== CONTENT SLIDE ========== */
         .slide-content {
-            padding: 0.75in 1in;
+            /* Grid child styles only — padding/overflow on .slide-body */
+        }
+
+        .slide-body {
+            padding: 0.3in 1in 0.2in;
             overflow: hidden;
-            padding-bottom: 0.2in;
+            font-size: 24pt;
         }
 
         .slide-header {
-            margin-bottom: 0.5in;
-            padding-bottom: 0.2in;
+            padding: 0.75in 1in 0.2in;
             border-bottom: 3px solid var(--red);
         }
 
@@ -138,10 +142,6 @@
             font-size: 36pt;
             font-weight: 700;
             color: var(--black);
-        }
-
-        .slide-body {
-            font-size: 24pt;
         }
 
         .slide-body ul {
@@ -168,7 +168,7 @@
         }
 
         .slide-footer {
-            padding: 0 1in 0.3in;
+            padding: 0 1in 0.4in;
             display: flex;
             justify-content: space-between;
             font-size: 12pt;


### PR DESCRIPTION
## Summary
- All document templates converted from absolute-positioned footers to CSS Grid `grid-template-rows: auto 1fr auto`
- Content areas now have `overflow: hidden` to prevent text bleeding into footers
- All 5 document commands updated with footer clearance verification rules
- Plugin version bumped to 1.2.0
- GitHub Pages docs updated with v1.2.0 changelog

## Templates updated
| Template | Changes |
|----------|---------|
| onepager | Already fixed in #16 |
| report | Removed `position: absolute` footer, `height: 11in` + `padding-bottom: 1in` pattern → grid rows |
| proposal | Same as report |
| event | Removed `position: absolute` footer → grid rows |
| slides | Removed `position: absolute` footer → grid rows |
| newsletter | No changes needed (email table layout) |

## Why grid rows instead of calc()
The old pattern used `height: calc(11in - Xin - Yin)` with hardcoded header/footer heights. These magic numbers drifted whenever padding or font sizes changed, causing content to overlap the footer. The grid approach makes header and footer take their natural height, with content filling the rest — no magic numbers needed.

## Test plan
- [ ] Generate a one-pager, report, proposal, slides, and event flyer
- [ ] Verify footer clearance on each
- [ ] Verify the GitHub Pages changelog section renders correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)