### PR TITLE
fix: update pdf-design skill and template to CSS Grid footer layout

### DIFF
--- a/pdf-design/SKILL.md
+++ b/pdf-design/SKILL.md
@@ -119,8 +119,9 @@ h1, h2, h3 {
 .page {
     width: 8.5in;
     height: 11in;
-    padding: 0.5in 0.65in;
-    position: relative;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    overflow: hidden;
     page-break-after: always;
 }
 ```
@@ -147,10 +148,15 @@ h1, h2, h3 {
 ```html
 <div class="page content-page">
     <div class="page-header">
-        <div class="page-header-title">Document Title</div>
+        <div class="page-header-title">Document title</div>
         <div class="page-number">2</div>
     </div>
-    <!-- Content -->
+    <div class="page-body">
+        <!-- Content goes here -->
+    </div>
+    <footer class="page-footer">
+        <!-- Footer -->
+    </footer>
 </div>
 ```
 
@@ -173,17 +179,31 @@ h1, h2, h3 {
 </table>
 ```
 
-### Page footer (institution note)
+### Page footer
 ```css
-.institution-note {
-    position: absolute;
-    bottom: 0.5in;
-    left: 0.65in;
-    right: 0.65in;
+.page-body {
+    padding: 0 0.65in 0.3in;
+    overflow: hidden;
+}
+
+.page-footer {
+    padding: 0 0.65in 0.5in;
     border-top: 1px solid #e2e8f0;
     font-size: 0.8rem;
 }
 ```
+
+---
+
+## Footer clearance
+
+Content must not touch or overlap the page footer.
+
+- The `.page` element must use `display: grid; grid-template-rows: auto 1fr auto`
+- It must have exactly 3 direct children: header, content wrapper (`.page-body`), footer
+- The content wrapper must have `overflow: hidden` to prevent text bleeding
+- Never use `position: absolute` for footers — keep them in normal document flow as the third grid row
+- If content is too long, reduce content rather than shrinking the footer gap
 
 ---
 

--- a/pdf-design/SKILL.md
+++ b/pdf-design/SKILL.md
@@ -182,7 +182,7 @@ h1, h2, h3 {
 ### Page footer
 ```css
 .page-body {
-    padding: 0 0.65in 0.3in;
+    padding: 0.2in 0.65in 0.3in;
     overflow: hidden;
 }
 
@@ -197,12 +197,13 @@ h1, h2, h3 {
 
 ## Footer clearance
 
-Content must not touch or overlap the page footer.
+Content must not touch or overlap the page footer. These rules apply to **content pages** — cover pages and special layouts may use different structures.
 
-- The `.page` element must use `display: grid; grid-template-rows: auto 1fr auto`
-- It must have exactly 3 direct children: header, content wrapper (`.page-body`), footer
+- Content pages must use `display: grid; grid-template-rows: auto 1fr auto` on `.page`
+- Content pages must have exactly 3 direct children: header, content wrapper (`.page-body`), footer
 - The content wrapper must have `overflow: hidden` to prevent text bleeding
 - Never use `position: absolute` for footers — keep them in normal document flow as the third grid row
+- Use `.page-footer:empty { display: none; }` so pages without footer content don't render a blank border
 - If content is too long, reduce content rather than shrinking the footer gap
 
 ---

--- a/pdf-design/templates/democracy-day-proposal.html
+++ b/pdf-design/templates/democracy-day-proposal.html
@@ -44,11 +44,12 @@
         .page {
             width: 8.5in;
             height: 11in;
-            padding: 0.5in 0.65in;
             background: white;
             position: relative;
-            page-break-after: always;
+            display: grid;
+            grid-template-rows: auto 1fr auto;
             overflow: hidden;
+            page-break-after: always;
         }
 
         .page:last-child {
@@ -60,6 +61,7 @@
             display: flex;
             flex-direction: column;
             justify-content: space-between;
+            padding: 0.5in 0.65in;
             background: linear-gradient(165deg, var(--civic-navy) 0%, #243b5c 50%, var(--civic-navy) 100%);
             color: white;
             position: relative;
@@ -190,13 +192,24 @@
             background: white;
         }
 
+        .page-body {
+            padding: 0 0.65in 0.3in;
+            overflow: hidden;
+        }
+
+        .page-footer {
+            padding: 0 0.65in 0.5in;
+            border-top: 1px solid var(--civic-light);
+            font-size: 0.8rem;
+            color: var(--civic-slate);
+        }
+
         .page-header {
             display: flex;
             justify-content: space-between;
             align-items: baseline;
             border-bottom: 2px solid var(--civic-navy);
-            padding-bottom: 0.1in;
-            margin-bottom: 0.3in;
+            padding: 0.5in 0.65in 0.1in;
         }
 
         .page-header-title {
@@ -534,16 +547,9 @@
             opacity: 0.7;
         }
 
-        /* FOOTER NOTE */
+        /* FOOTER NOTE (legacy class, use .page-footer instead) */
         .institution-note {
-            position: absolute;
-            bottom: 0.5in;
-            left: 0.65in;
-            right: 0.65in;
             padding-top: 0.15in;
-            border-top: 1px solid var(--civic-light);
-            font-size: 0.8rem;
-            color: var(--civic-slate);
         }
 
         @media print {
@@ -602,6 +608,7 @@
         <div class="page-header-title">U.S. Democracy Day · Funding Proposal</div>
         <div class="page-number">2</div>
     </div>
+    <div class="page-body">
 
     <h2>What is U.S. Democracy Day?</h2>
 
@@ -652,6 +659,9 @@
     <p class="source-note">
         Source: Pew Research Center. While voter turnout has been growing in recent general and midterm elections, it still often lags behind in local and municipal races.
     </p>
+
+    </div>
+    <footer class="page-footer"></footer>
 </div>
 
 <!-- PAGE 3: WHAT'S NEXT -->
@@ -660,6 +670,7 @@
         <div class="page-header-title">U.S. Democracy Day · Funding Proposal</div>
         <div class="page-number">3</div>
     </div>
+    <div class="page-body">
 
     <h2>What's next</h2>
 
@@ -704,6 +715,9 @@
             </div>
         </div>
     </div>
+
+    </div>
+    <footer class="page-footer"></footer>
 </div>
 
 <!-- PAGE 4: PROVEN STRATEGIES + BUDGET -->
@@ -712,6 +726,7 @@
         <div class="page-header-title">U.S. Democracy Day · Funding Proposal</div>
         <div class="page-number">4</div>
     </div>
+    <div class="page-body">
 
     <h2>Proven strategies</h2>
 
@@ -751,6 +766,9 @@
             It's these strategies to reach underserved communities that require additional funding, support, and coaching. For more information about Democracy Day, read our 2025 report with partner examples, survey information, and key takeaways.
         </p>
     </div>
+
+    </div>
+    <footer class="page-footer"></footer>
 </div>
 
 <!-- PAGE 5: THE ASK -->
@@ -759,6 +777,7 @@
         <div class="page-header-title">U.S. Democracy Day · Funding Proposal</div>
         <div class="page-number">5</div>
     </div>
+    <div class="page-body">
 
     <h2>The ask</h2>
 
@@ -835,12 +854,14 @@
             </div>
         </div>
 
-        <div class="institution-note">
-            <p>
-                <strong>Democracy Day</strong> is a project based at the Center for Cooperative Media at Montclair State University. The Center applies for grants through the Montclair State University Foundation.
-            </p>
-        </div>
     </div>
+
+    </div>
+    <footer class="page-footer">
+        <p>
+            <strong>Democracy Day</strong> is a project based at the Center for Cooperative Media at Montclair State University. The Center applies for grants through the Montclair State University Foundation.
+        </p>
+    </footer>
 </div>
 
 
@@ -850,6 +871,7 @@
         <div class="page-header-title">U.S. Democracy Day · Funding Proposal</div>
         <div class="page-number">Appendix</div>
     </div>
+    <div class="page-body">
 
     <h2 style="color: var(--civic-navy); margin-bottom: 0.3in;">Budget options</h2>
     
@@ -901,6 +923,8 @@
         </tfoot>
     </table>
 
+    </div>
+    <footer class="page-footer"></footer>
 </div>
 
 <!-- APPENDIX PAGE 2: STATEWIDE OPTION -->
@@ -909,6 +933,7 @@
         <div class="page-header-title">U.S. Democracy Day · Funding Proposal</div>
         <div class="page-number">Appendix</div>
     </div>
+    <div class="page-body">
 
     <!-- OPTION 2: STATEWIDE -->
     <h3 style="color: var(--civic-navy); font-size: 1.1rem; margin-top: 0.1in; margin-bottom: 0.1in;">Option B: Statewide (10 newsrooms)</h3>
@@ -956,6 +981,8 @@
         </tfoot>
     </table>
 
+    </div>
+    <footer class="page-footer"></footer>
 </div>
 
 <!-- APPENDIX PAGE 2: LOCAL OPTION -->
@@ -964,6 +991,7 @@
         <div class="page-header-title">U.S. Democracy Day · Funding Proposal</div>
         <div class="page-number">Appendix</div>
     </div>
+    <div class="page-body">
 
     <!-- OPTION 3: LOCAL -->
     <h3 style="color: var(--civic-navy); font-size: 1.1rem; margin-top: 0.1in; margin-bottom: 0.1in;">Option C: Local (6 newsrooms)</h3>
@@ -1011,6 +1039,8 @@
         </tfoot>
     </table>
 
+    </div>
+    <footer class="page-footer"></footer>
 </div>
 
 </body>

--- a/pdf-design/templates/democracy-day-proposal.html
+++ b/pdf-design/templates/democracy-day-proposal.html
@@ -45,7 +45,6 @@
             width: 8.5in;
             height: 11in;
             background: white;
-            position: relative;
             display: grid;
             grid-template-rows: auto 1fr auto;
             overflow: hidden;
@@ -193,7 +192,7 @@
         }
 
         .page-body {
-            padding: 0 0.65in 0.3in;
+            padding: 0.2in 0.65in 0.3in;
             overflow: hidden;
         }
 
@@ -202,6 +201,10 @@
             border-top: 1px solid var(--civic-light);
             font-size: 0.8rem;
             color: var(--civic-slate);
+        }
+
+        .page-footer:empty {
+            display: none;
         }
 
         .page-header {


### PR DESCRIPTION
## Summary

Applies the same CSS Grid footer pattern from pdf-playground v1.2.0 to the older `pdf-design` skill:

- `.page` uses `display: grid; grid-template-rows: auto 1fr auto` instead of `position: relative`
- All 7 content pages in the democracy-day template now have 3-child structure (header, `.page-body`, footer)
- `.page-body` wrapper has `overflow: hidden` to prevent content bleeding into footers
- Footers are in normal document flow, not absolute-positioned
- SKILL.md updated with grid layout guidance and footer clearance rules
- `.institution-note` absolute positioning replaced with `.page-footer` in flow

## Test plan
- [ ] Democracy Day proposal template renders correctly with grid layout
- [ ] Footers pin to bottom of each page
- [ ] Content doesn't bleed past footer boundary
- [ ] Cover page (flex layout) unaffected