### PR TITLE
Rewrite ask-ai as nav text link with Gemini clipboard fix

### DIFF
--- a/docs/ask-ai.js
+++ b/docs/ask-ai.js
@@ -180,7 +180,7 @@
     // Trigger — styled as a nav text link with a small icon
     var trigger = document.createElement('button');
     trigger.setAttribute('aria-expanded', 'false');
-    trigger.setAttribute('aria-haspopup', 'dialog');
+    trigger.setAttribute('aria-haspopup', 'menu');
     trigger.setAttribute('type', 'button');
     trigger.title = 'Ask an AI about this page';
 
@@ -218,9 +218,12 @@
       { label: 'Ask Claude', iconFn: makeClaudeIcon, href: 'https://claude.ai/new?q=' + encoded },
       { label: 'Ask ChatGPT', iconFn: function () { return makeChatIcon(20, COLORS.iconColor); }, href: 'https://chatgpt.com/?q=' + encoded },
       { label: 'Ask Gemini (copies prompt)', iconFn: makeGeminiIcon, action: function () {
-        navigator.clipboard.writeText(prompt).then(function () {
-          window.open('https://gemini.google.com/app', '_blank', 'noopener,noreferrer');
-        });
+        var geminiUrl = 'https://gemini.google.com/app';
+        var w = window.open(geminiUrl, '_blank', 'noopener,noreferrer');
+        if (!w) window.location.href = geminiUrl;
+        if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+          navigator.clipboard.writeText(prompt).catch(function () {});
+        }
       }},
       { label: 'Download as markdown', iconFn: makeDownloadIcon, action: downloadMarkdown },
     ];
@@ -251,6 +254,8 @@
       el.appendChild(span);
       el.addEventListener('mouseenter', function () { el.style.background = COLORS.itemHover; });
       el.addEventListener('mouseleave', function () { el.style.background = 'transparent'; });
+      el.addEventListener('focus', function () { el.style.background = COLORS.itemHover; });
+      el.addEventListener('blur', function () { el.style.background = 'transparent'; });
       panel.appendChild(el);
     });
 
@@ -292,29 +297,49 @@
   function inject() {
     var component = createComponent();
 
-    // Strategy: find the right-side nav links container and append there.
-    // Skills index: <nav> with direct-child flex divs — use the last (right side).
-    // Skills subpages: <nav> with inner flex div — append there.
+    // Inject into the right side of the nav.
+    // On subpages with a GitHub link in a justify-between container, group
+    // the widget with the GitHub link so it stays on the right.
+    // On index pages, append to the last flex child (right-side links).
     var nav = document.querySelector('nav[role="navigation"], nav#main-nav, header nav, nav');
     if (!nav) return;
 
-    var flexChildren = nav.querySelectorAll(':scope > [class*="flex"]');
-    if (flexChildren.length > 1) {
-      flexChildren[flexChildren.length - 1].appendChild(component);
-    } else if (flexChildren.length === 1) {
-      flexChildren[0].appendChild(component);
+    var githubLink = nav.querySelector('a[href*="github.com"]');
+    if (githubLink && githubLink.parentElement) {
+      var parent = githubLink.parentElement;
+      var cls = typeof parent.className === 'string' ? parent.className : '';
+      if (cls.indexOf('flex') !== -1 && cls.indexOf('justify-between') !== -1) {
+        // Subpage: wrap GitHub link + Ask AI together on the right
+        var group = document.createElement('span');
+        group.style.cssText = 'display:inline-flex;align-items:center;gap:0.75rem;';
+        parent.replaceChild(group, githubLink);
+        group.appendChild(githubLink);
+        group.appendChild(component);
+      } else {
+        parent.insertBefore(component, githubLink.nextSibling);
+      }
     } else {
-      nav.appendChild(component);
+      var flexChildren = nav.querySelectorAll(':scope > [class*="flex"]');
+      if (flexChildren.length > 1) {
+        flexChildren[flexChildren.length - 1].appendChild(component);
+      } else if (flexChildren.length === 1) {
+        flexChildren[0].appendChild(component);
+      } else {
+        nav.appendChild(component);
+      }
     }
 
-    // Derive trigger color from a sibling link
-    var siblingLink = nav.querySelector('a');
-    if (siblingLink) {
-      var computed = window.getComputedStyle(siblingLink);
-      var btn = component.querySelector('button');
-      if (btn) {
-        btn.style.color = computed.color;
-        COLORS.triggerColor = computed.color;
+    // Derive trigger color from a sibling link in the same container
+    var container = component.parentElement;
+    if (container) {
+      var links = container.querySelectorAll('a');
+      for (var j = 0; j < links.length; j++) {
+        if (!links[j].closest('[data-ask-ai]')) {
+          var computed = window.getComputedStyle(links[j]);
+          var btn = component.querySelector('button');
+          if (btn) { btn.style.color = computed.color; COLORS.triggerColor = computed.color; }
+          break;
+        }
       }
     }
   }

--- a/docs/ask-ai.js
+++ b/docs/ask-ai.js
@@ -1,15 +1,14 @@
 // ask-ai.js — "Ask an AI about this" dropdown for skills.amditis.tech
 // Self-contained vanilla JS. No external CSS dependencies.
-// Injected as the first child of <main> on each page.
+// Injected as a text-style nav link in the header/nav bar.
 
 (function () {
   'use strict';
 
-  // -- Theme constants (cream) --
+  // -- Theme constants --
   var COLORS = {
-    buttonBg: '#3d4b40',
-    buttonText: '#ffffff',
-    buttonBorder: '#3d4b40',
+    triggerColor: '#6b6b6b',
+    triggerHoverColor: '#121212',
     panelBg: '#ffffff',
     panelText: '#121212',
     panelBorder: '#d6cdb7',
@@ -20,70 +19,40 @@
 
   var FONT = "'Plus Jakarta Sans', sans-serif";
 
-  // -- SVG icons (inline, 20x20) --
+  // -- SVG icon factories --
   // All icon markup is static/hardcoded. No user input is interpolated.
 
-  function makeChevronIcon() {
+  function makeSvg(w, h, color) {
     var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-    svg.setAttribute('width', '16');
-    svg.setAttribute('height', '16');
+    svg.setAttribute('width', String(w));
+    svg.setAttribute('height', String(h));
     svg.setAttribute('viewBox', '0 0 24 24');
     svg.setAttribute('fill', 'none');
-    svg.setAttribute('stroke', 'currentColor');
+    svg.setAttribute('stroke', color || 'currentColor');
     svg.setAttribute('stroke-width', '2');
     svg.setAttribute('stroke-linecap', 'round');
     svg.setAttribute('stroke-linejoin', 'round');
-    var polyline = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
-    polyline.setAttribute('points', '6 9 12 15 18 9');
-    svg.appendChild(polyline);
     return svg;
   }
 
-  function makeClaudeIcon() {
-    // Sparkle/star shape
-    var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-    svg.setAttribute('width', '20');
-    svg.setAttribute('height', '20');
-    svg.setAttribute('viewBox', '0 0 24 24');
-    svg.setAttribute('fill', 'none');
-    svg.setAttribute('stroke', COLORS.iconColor);
-    svg.setAttribute('stroke-width', '2');
-    svg.setAttribute('stroke-linecap', 'round');
-    svg.setAttribute('stroke-linejoin', 'round');
-    var polygon = document.createElementNS('http://www.w3.org/2000/svg', 'polygon');
-    polygon.setAttribute('points', '12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2');
-    svg.appendChild(polygon);
-    return svg;
-  }
-
-  function makeChatIcon() {
-    // Chat bubble
-    var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-    svg.setAttribute('width', '20');
-    svg.setAttribute('height', '20');
-    svg.setAttribute('viewBox', '0 0 24 24');
-    svg.setAttribute('fill', 'none');
-    svg.setAttribute('stroke', COLORS.iconColor);
-    svg.setAttribute('stroke-width', '2');
-    svg.setAttribute('stroke-linecap', 'round');
-    svg.setAttribute('stroke-linejoin', 'round');
+  function makeChatIcon(size, color) {
+    var svg = makeSvg(size || 20, size || 20, color || COLORS.iconColor);
     var path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
     path.setAttribute('d', 'M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z');
     svg.appendChild(path);
     return svg;
   }
 
+  function makeClaudeIcon() {
+    var svg = makeSvg(20, 20, COLORS.iconColor);
+    var polygon = document.createElementNS('http://www.w3.org/2000/svg', 'polygon');
+    polygon.setAttribute('points', '12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2');
+    svg.appendChild(polygon);
+    return svg;
+  }
+
   function makeGeminiIcon() {
-    // Diamond shape
-    var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-    svg.setAttribute('width', '20');
-    svg.setAttribute('height', '20');
-    svg.setAttribute('viewBox', '0 0 24 24');
-    svg.setAttribute('fill', 'none');
-    svg.setAttribute('stroke', COLORS.iconColor);
-    svg.setAttribute('stroke-width', '2');
-    svg.setAttribute('stroke-linecap', 'round');
-    svg.setAttribute('stroke-linejoin', 'round');
+    var svg = makeSvg(20, 20, COLORS.iconColor);
     var rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
     rect.setAttribute('x', '12');
     rect.setAttribute('y', '1');
@@ -96,24 +65,14 @@
   }
 
   function makeDownloadIcon() {
-    var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-    svg.setAttribute('width', '20');
-    svg.setAttribute('height', '20');
-    svg.setAttribute('viewBox', '0 0 24 24');
-    svg.setAttribute('fill', 'none');
-    svg.setAttribute('stroke', COLORS.iconColor);
-    svg.setAttribute('stroke-width', '2');
-    svg.setAttribute('stroke-linecap', 'round');
-    svg.setAttribute('stroke-linejoin', 'round');
+    var svg = makeSvg(20, 20, COLORS.iconColor);
     var path1 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
     path1.setAttribute('d', 'M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4');
     var polyline = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
     polyline.setAttribute('points', '7 10 12 15 17 10');
     var line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
-    line.setAttribute('x1', '12');
-    line.setAttribute('y1', '15');
-    line.setAttribute('x2', '12');
-    line.setAttribute('y2', '3');
+    line.setAttribute('x1', '12'); line.setAttribute('y1', '15');
+    line.setAttribute('x2', '12'); line.setAttribute('y2', '3');
     svg.appendChild(path1);
     svg.appendChild(polyline);
     svg.appendChild(line);
@@ -133,16 +92,12 @@
   }
 
   function getPageContext() {
+    var root = document.querySelector('main') || document.body;
     var parts = [];
 
-    // Meta description
     var meta = document.querySelector('meta[name="description"]');
-    if (meta && meta.content) {
-      parts.push(meta.content.trim());
-    }
+    if (meta && meta.content) parts.push(meta.content.trim());
 
-    // Section headings (h2s/h3s) as outline
-    var root = document.querySelector('main') || document.body;
     var headings = root.querySelectorAll('h2, h3');
     if (headings.length) {
       var outline = [];
@@ -150,12 +105,9 @@
         var text = headings[i].textContent.trim();
         if (text) outline.push('- ' + text);
       }
-      if (outline.length) {
-        parts.push('Sections covered:\n' + outline.join('\n'));
-      }
+      if (outline.length) parts.push('Sections covered:\n' + outline.join('\n'));
     }
 
-    // First paragraph of main content
     var firstP = root.querySelector('p');
     if (firstP && firstP.textContent.trim()) {
       var pText = firstP.textContent.trim();
@@ -170,9 +122,7 @@
     var title = getTitle();
     var context = getPageContext();
     var prompt = 'I\'m learning about "' + title + '".';
-    if (context) {
-      prompt += '\n\nHere\'s what the page covers:\n\n' + context;
-    }
+    if (context) prompt += '\n\nHere\'s what the page covers:\n\n' + context;
     prompt += '\n\nCan you explain the key concepts and help me understand how to apply them?';
     return prompt;
   }
@@ -184,19 +134,11 @@
   function loadTurndown() {
     if (turndownPromise) return turndownPromise;
     turndownPromise = new Promise(function (resolve, reject) {
-      if (window.TurndownService) {
-        resolve(window.TurndownService);
-        return;
-      }
+      if (window.TurndownService) { resolve(window.TurndownService); return; }
       var script = document.createElement('script');
       script.src = 'https://unpkg.com/turndown@7.2.0/dist/turndown.js';
-      script.onload = function () {
-        resolve(window.TurndownService);
-      };
-      script.onerror = function () {
-        turndownPromise = null;
-        reject(new Error('Failed to load Turndown.js'));
-      };
+      script.onload = function () { resolve(window.TurndownService); };
+      script.onerror = function () { turndownPromise = null; reject(new Error('Failed to load Turndown.js')); };
       document.head.appendChild(script);
     });
     return turndownPromise;
@@ -210,12 +152,10 @@
         var clone = source.cloneNode(true);
         var widget = clone.querySelector('[data-ask-ai]');
         if (widget) widget.remove();
-        var html = clone.innerHTML;
-        var md = td.turndown(html);
+        var md = td.turndown(clone.innerHTML);
         var title = getTitle();
         var url = window.location.href;
-        var full = '# ' + title + '\n\nSource: ' + url + '\n\n' + md;
-        var blob = new Blob([full], { type: 'text/markdown;charset=utf-8' });
+        var blob = new Blob(['# ' + title + '\n\nSource: ' + url + '\n\n' + md], { type: 'text/markdown;charset=utf-8' });
         var a = document.createElement('a');
         a.href = URL.createObjectURL(blob);
         a.download = getSlug() + '.md';
@@ -229,115 +169,67 @@
       });
   }
 
-  // -- Style helpers --
-
-  function applyStyles(el, styles) {
-    var css = '';
-    for (var key in styles) {
-      if (styles.hasOwnProperty(key)) {
-        css += key + ':' + styles[key] + ';';
-      }
-    }
-    el.style.cssText = css;
-  }
-
   // -- Build the component --
 
   function createComponent() {
-    var prompt = buildPrompt();
-    var encoded = encodeURIComponent(prompt);
-
-    // Container for the button + dropdown (no wrapper — injected directly into a layout row)
+    // Container positions the dropdown relative to the trigger
     var container = document.createElement('div');
     container.setAttribute('data-ask-ai', 'true');
-    applyStyles(container, {
-      'position': 'relative',
-      'display': 'inline-block',
-    });
+    container.style.position = 'relative';
 
-    // Trigger button
+    // Trigger — styled as a nav text link with a small icon
     var trigger = document.createElement('button');
     trigger.setAttribute('aria-expanded', 'false');
     trigger.setAttribute('aria-haspopup', 'dialog');
     trigger.setAttribute('type', 'button');
     trigger.title = 'Ask an AI about this page';
-    applyStyles(trigger, {
-      'background': COLORS.buttonBg,
-      'color': COLORS.buttonText,
-      'border': 'none',
-      'border-radius': '50%',
-      'width': '2rem',
-      'height': '2rem',
-      'padding': '0',
-      'cursor': 'pointer',
-      'display': 'inline-flex',
-      'align-items': 'center',
-      'justify-content': 'center',
-      'transition': 'opacity 0.15s ease, transform 0.15s ease',
-      'flex-shrink': '0',
-      'align-self': 'center',
-    });
 
-    var chatIcon = makeChatIcon();
-    chatIcon.setAttribute('stroke', '#ffffff');
-    chatIcon.setAttribute('width', '16');
-    chatIcon.setAttribute('height', '16');
-    trigger.appendChild(chatIcon);
+    // Chat bubble icon (12px, decorative)
+    var icon = makeChatIcon(12, 'currentColor');
+    icon.setAttribute('aria-hidden', 'true');
+    icon.setAttribute('focusable', 'false');
+    trigger.appendChild(icon);
 
-    trigger.addEventListener('mouseenter', function () {
-      trigger.style.opacity = '0.85';
-      trigger.style.transform = 'scale(1.1)';
-    });
-    trigger.addEventListener('mouseleave', function () {
-      trigger.style.opacity = '1';
-      trigger.style.transform = 'scale(1)';
-    });
+    var label = document.createElement('span');
+    label.textContent = 'Ask AI';
+    trigger.appendChild(label);
+
+    trigger.style.cssText = 'display:inline-flex;align-items:center;gap:0.25rem;' +
+      'background:none;border:none;padding:0;cursor:pointer;' +
+      'font:inherit;letter-spacing:inherit;text-transform:inherit;' +
+      'color:' + COLORS.triggerColor + ';transition:color 0.15s;white-space:nowrap;';
+
+    trigger.addEventListener('mouseenter', function () { trigger.style.color = COLORS.triggerHoverColor; });
+    trigger.addEventListener('mouseleave', function () { trigger.style.color = COLORS.triggerColor; });
+    trigger.addEventListener('focus', function () { trigger.style.color = COLORS.triggerHoverColor; });
+    trigger.addEventListener('blur', function () { trigger.style.color = COLORS.triggerColor; });
 
     // Dropdown panel
     var panel = document.createElement('div');
-    applyStyles(panel, {
-      'display': 'none',
-      'position': 'absolute',
-      'top': 'calc(100% + 0.5rem)',
-      'right': '0',
-      'min-width': '15rem',
-      'background': COLORS.panelBg,
-      'color': COLORS.panelText,
-      'border': '1px solid ' + COLORS.panelBorder,
-      'border-radius': '0.75rem',
-      'box-shadow': COLORS.panelShadow,
-      'padding': '0.375rem',
-      'z-index': '50',
-      'font-family': FONT,
-    });
+    panel.style.cssText = 'display:none;position:absolute;top:calc(100% + 0.5rem);right:0;' +
+      'min-width:15rem;background:' + COLORS.panelBg + ';color:' + COLORS.panelText + ';' +
+      'border:1px solid ' + COLORS.panelBorder + ';border-radius:0.75rem;' +
+      'box-shadow:' + COLORS.panelShadow + ';padding:0.375rem;z-index:50;font-family:' + FONT + ';';
 
-    // Menu items config
+    // Menu items
+    var prompt = buildPrompt();
+    var encoded = encodeURIComponent(prompt);
     var menuItems = [
       { label: 'Ask Claude', iconFn: makeClaudeIcon, href: 'https://claude.ai/new?q=' + encoded },
-      { label: 'Ask ChatGPT', iconFn: makeChatIcon, href: 'https://chatgpt.com/?q=' + encoded },
-      { label: 'Ask Gemini', iconFn: makeGeminiIcon, href: 'https://gemini.google.com/app?q=' + encoded },
+      { label: 'Ask ChatGPT', iconFn: function () { return makeChatIcon(20, COLORS.iconColor); }, href: 'https://chatgpt.com/?q=' + encoded },
+      { label: 'Ask Gemini (copies prompt)', iconFn: makeGeminiIcon, action: function () {
+        navigator.clipboard.writeText(prompt).then(function () {
+          window.open('https://gemini.google.com/app', '_blank', 'noopener,noreferrer');
+        });
+      }},
       { label: 'Download as markdown', iconFn: makeDownloadIcon, action: downloadMarkdown },
     ];
 
-    var ITEM_STYLES = {
-      'display': 'flex',
-      'align-items': 'center',
-      'gap': '0.625rem',
-      'width': '100%',
-      'padding': '0.5rem 0.75rem',
-      'border': 'none',
-      'background': 'transparent',
-      'color': COLORS.panelText,
-      'font-family': FONT,
-      'font-size': '0.875rem',
-      'font-weight': '500',
-      'text-decoration': 'none',
-      'cursor': 'pointer',
-      'border-radius': '0.5rem',
-      'transition': 'background 0.12s ease',
-      'text-align': 'left',
-      'box-sizing': 'border-box',
-    };
+    var itemCss = 'display:flex;align-items:center;gap:0.625rem;width:100%;' +
+      'padding:0.5rem 0.75rem;border:none;background:transparent;' +
+      'color:' + COLORS.panelText + ';font-family:' + FONT + ';font-size:0.875rem;' +
+      'font-weight:500;text-decoration:none;cursor:pointer;border-radius:0.5rem;' +
+      'transition:background 0.12s;text-align:left;box-sizing:border-box;';
 
     menuItems.forEach(function (item) {
       var el;
@@ -346,112 +238,83 @@
         el.href = item.href;
         el.target = '_blank';
         el.rel = 'noopener noreferrer';
-        el.addEventListener('click', function () {
-          closeDropdown();
-        });
+        el.addEventListener('click', function () { closeDropdown(); });
       } else {
         el = document.createElement('button');
         el.setAttribute('type', 'button');
-        el.addEventListener('click', function () {
-          closeDropdown();
-          item.action();
-        });
+        el.addEventListener('click', function () { closeDropdown(); item.action(); });
       }
-      applyStyles(el, ITEM_STYLES);
-
+      el.style.cssText = itemCss;
       el.appendChild(item.iconFn());
       var span = document.createElement('span');
       span.textContent = item.label;
       el.appendChild(span);
-
-      el.addEventListener('mouseenter', function () {
-        el.style.background = COLORS.itemHover;
-      });
-      el.addEventListener('mouseleave', function () {
-        el.style.background = 'transparent';
-      });
-
+      el.addEventListener('mouseenter', function () { el.style.background = COLORS.itemHover; });
+      el.addEventListener('mouseleave', function () { el.style.background = 'transparent'; });
       panel.appendChild(el);
     });
 
     // -- Toggle logic --
-
     var isOpen = false;
 
     function openDropdown() {
       isOpen = true;
       panel.style.display = 'block';
       trigger.setAttribute('aria-expanded', 'true');
-      // Reposition if overflowing right edge
-      requestAnimationFrame(function () {
-        var rect = panel.getBoundingClientRect();
-        if (rect.right > window.innerWidth - 8) {
-          panel.style.left = 'auto';
-          panel.style.right = '0';
-        }
-      });
     }
 
     function closeDropdown() {
       isOpen = false;
       panel.style.display = 'none';
       trigger.setAttribute('aria-expanded', 'false');
-      // Reset positioning
-      panel.style.left = '0';
-      panel.style.right = 'auto';
     }
 
     trigger.addEventListener('click', function (e) {
       e.stopPropagation();
-      if (isOpen) {
-        closeDropdown();
-      } else {
-        openDropdown();
-      }
+      if (isOpen) { closeDropdown(); } else { openDropdown(); }
     });
 
-    // Close on outside click
     document.addEventListener('click', function (e) {
-      if (isOpen && !container.contains(e.target)) {
-        closeDropdown();
-      }
+      if (isOpen && !container.contains(e.target)) closeDropdown();
     });
 
-    // Close on Escape
     document.addEventListener('keydown', function (e) {
-      if (e.key === 'Escape' && isOpen) {
-        closeDropdown();
-        trigger.focus();
-      }
+      if (e.key === 'Escape' && isOpen) { closeDropdown(); trigger.focus(); }
     });
 
-    // Assemble
     container.appendChild(trigger);
     container.appendChild(panel);
-
     return container;
   }
 
   // -- Inject into page --
 
   function inject() {
-    var mainEl = document.querySelector('main');
-    if (!mainEl) return;
     var component = createComponent();
 
-    // Inject into the right side of the nav (alongside nav links, not the logo).
-    // Strategy: find all direct-child flex containers in the nav/header,
-    // and append to the LAST one (right side in justify-between layouts).
-    var nav = document.querySelector('header nav, nav[role="navigation"], nav');
-    if (nav) {
-      var flexChildren = nav.querySelectorAll(':scope > [class*="flex"]');
-      if (flexChildren.length > 1) {
-        // Multiple flex children = justify-between layout; use the last (right side)
-        flexChildren[flexChildren.length - 1].appendChild(component);
-      } else if (flexChildren.length === 1) {
-        flexChildren[0].appendChild(component);
-      } else {
-        nav.appendChild(component);
+    // Strategy: find the right-side nav links container and append there.
+    // Skills index: <nav> with direct-child flex divs — use the last (right side).
+    // Skills subpages: <nav> with inner flex div — append there.
+    var nav = document.querySelector('nav[role="navigation"], nav#main-nav, header nav, nav');
+    if (!nav) return;
+
+    var flexChildren = nav.querySelectorAll(':scope > [class*="flex"]');
+    if (flexChildren.length > 1) {
+      flexChildren[flexChildren.length - 1].appendChild(component);
+    } else if (flexChildren.length === 1) {
+      flexChildren[0].appendChild(component);
+    } else {
+      nav.appendChild(component);
+    }
+
+    // Derive trigger color from a sibling link
+    var siblingLink = nav.querySelector('a');
+    if (siblingLink) {
+      var computed = window.getComputedStyle(siblingLink);
+      var btn = component.querySelector('button');
+      if (btn) {
+        btn.style.color = computed.color;
+        COLORS.triggerColor = computed.color;
       }
     }
   }


### PR DESCRIPTION
## Summary
- Replaces circular icon button with text-style nav link matching existing nav items
- "Ask AI" label with 12px chat bubble icon, inherits all typography from parent nav
- Gemini copies prompt to clipboard then opens (doesn't support URL prefill)
- Accessible: aria-hidden on decorative icon, focus/blur states for keyboard users
- Derives trigger color from sibling link at runtime for cross-page consistency
- Right-side placement via last flex child detection

## Test plan
- [ ] Index page: "Ask AI" appears in right-side nav next to Skills/Hooks/Install/About/GitHub
- [ ] Subpages (source-verification, etc.): appears next to "View on GitHub" link
- [ ] Hover/focus turns text darker
- [ ] Dropdown opens right-aligned, all 4 items work
- [ ] Gemini copies prompt and opens new tab
- [ ] Markdown download excludes the widget