### PR TITLE
Add transcript scanner and activity-aware session-end hook

### DIFF
--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -97,6 +97,7 @@ Two config files live in `.autocontext/`:
 | `playbook_generation` | `auto` | Playbook regeneration: `auto`, `manual`, or `disabled` |
 | `multi_machine` | `{"enabled": false}` | Machine-scoped lessons with hostname list |
 | `builtin_rules` | all true | Toggle individual test quality rules |
+| `activity_signals` | (see below) | Override which tools/patterns count as meaningful activity (see Transcript scanner section) |
 
 **`config.local.json`** (gitignored, per-developer):
 
@@ -105,6 +106,50 @@ Two config files live in `.autocontext/`:
 | `identity` | Your name or username for lesson attribution |
 
 Machine-specific lessons can be tagged with `machine:<hostname>` to prevent them loading on other machines.
+
+## Transcript scanner
+
+The plugin includes a transcript scanner utility that detects meaningful activity in Claude Code session transcripts. It powers the activity gate in `session-end.sh` (skipping lesson validation when only research happened) and can be used by custom hooks.
+
+**Usage from a hook script:**
+
+```bash
+RESULT=$(python3 "$PLUGIN_ROOT/scripts/transcript-scanner.py" \
+    --transcript "$TRANSCRIPT_PATH" \
+    --since "$LAST_HANDOFF_MTIME" \
+    --config ".autocontext/config.json")
+
+# Returns JSON:
+# {"meaningful": true, "level": "high", "signals": [...], "tool_counts": {...}}
+```
+
+**Arguments:**
+- `--transcript` — path to the session JSONL file
+- `--since` — Unix timestamp (seconds). Only scan entries after this time. Default: scan all.
+- `--config` — path to config file. Reads `activity_signals` key if present.
+
+**Signal levels:**
+
+| Level | Triggers |
+|-------|----------|
+| High | Write, Edit, Bash with `git commit` / `gh pr create` / `firebase deploy` / `systemctl restart` |
+| Medium | Agent, Bash with `git push` / `npm run build` / `cargo build` |
+| Low | Read, Grep, Glob, unmatched Bash (does not trigger `meaningful: true`) |
+
+**Custom signal config** (optional key in `.autocontext/config.json`):
+
+```json
+{
+  "activity_signals": {
+    "high_tool_names": ["Write", "Edit"],
+    "medium_tool_names": ["Agent"],
+    "high_bash_patterns": ["git commit", "gh pr create", "deploy"],
+    "medium_bash_patterns": ["git push", "npm run build"]
+  }
+}
+```
+
+Each sub-key fully replaces that tier's defaults when present.
 
 ## Inspiration and attribution
 

--- a/autocontext/hooks/session-end.sh
+++ b/autocontext/hooks/session-end.sh
@@ -14,6 +14,36 @@ GENERATE_PLAYBOOK="$PLUGIN_ROOT/scripts/generate-playbook.py"
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('session_id',''))" 2>/dev/null || echo "")
 
+# ── Activity gate: skip validation if no meaningful work happened ──────────
+TRANSCRIPT_PATH=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('transcript_path',''))" 2>/dev/null || echo "")
+SCANNER_SCRIPT="$PLUGIN_ROOT/scripts/transcript-scanner.py"
+
+if [[ -n "$TRANSCRIPT_PATH" ]] && [[ -f "$SCANNER_SCRIPT" ]]; then
+    SINCE_TS=0
+    if [[ -f "$SESSION_LESSONS_FILE" ]]; then
+        SINCE_TS=$(stat -c %Y "$SESSION_LESSONS_FILE" 2>/dev/null || echo 0)
+    fi
+
+    SCAN_RESULT=$(python3 "$SCANNER_SCRIPT" \
+        --transcript "$TRANSCRIPT_PATH" \
+        --since "$SINCE_TS" \
+        --config "$AUTOCONTEXT_DIR/config.json" 2>/dev/null || echo '{"meaningful":true}')
+
+    IS_MEANINGFUL=$(echo "$SCAN_RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('meaningful',True))" 2>/dev/null || echo "True")
+
+    if [[ "$IS_MEANINGFUL" == "False" ]]; then
+        # Time fallback: validate anyway if session is 10+ minutes old
+        NOW=$(date +%s)
+        SESSION_START=$(stat -c %Y "$SESSION_LESSONS_FILE" 2>/dev/null || echo "$NOW")
+        SESSION_AGE=$((NOW - SESSION_START))
+        if [[ "$SESSION_AGE" -lt 600 ]]; then
+            echo '{}'
+            exit 0
+        fi
+    fi
+fi
+# ── End activity gate ──────────────────────────────────────────────────────
+
 if [[ ! -f "$SESSION_LESSONS_FILE" ]]; then
   echo '{}'
   exit 0

--- a/autocontext/scripts/transcript-scanner.py
+++ b/autocontext/scripts/transcript-scanner.py
@@ -15,7 +15,7 @@ import argparse
 import json
 import os
 import sys
-from datetime import datetime, timezone
+from datetime import datetime
 
 # ── Default signal classification ─────────────────────────────────────────────
 
@@ -65,6 +65,8 @@ def load_config(config_path):
 
 def build_classifiers(overrides):
     """Return (high_tools, medium_tools, high_bash, medium_bash) using overrides where present."""
+    if not isinstance(overrides, dict):
+        overrides = {}
     high_tools = set(overrides.get("high_tool_names", DEFAULT_HIGH_TOOL_NAMES))
     medium_tools = set(overrides.get("medium_tool_names", DEFAULT_MEDIUM_TOOL_NAMES))
     high_bash = overrides.get("high_bash_patterns", DEFAULT_HIGH_BASH_PATTERNS)
@@ -197,10 +199,10 @@ def scan(transcript_path, since_ts, overrides):
 
                 if tier == "high":
                     has_high = True
-                    signals.append({"type": name, "detail": detail, "ts": entry_ts})
+                    signals.append({"type": name, "detail": detail, "ts": entry_ts or 0})
                 elif tier == "medium":
                     has_medium = True
-                    signals.append({"type": name, "detail": detail, "ts": entry_ts})
+                    signals.append({"type": name, "detail": detail, "ts": entry_ts or 0})
 
     # Determine overall level
     if has_high:

--- a/autocontext/scripts/transcript-scanner.py
+++ b/autocontext/scripts/transcript-scanner.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""
+transcript-scanner.py — scan a Claude Code session transcript for meaningful activity.
+
+Usage:
+    python3 transcript-scanner.py --transcript /path/to/session.jsonl [--since UNIX_TS] [--config path/to/config.json]
+
+Output (JSON to stdout):
+    {"meaningful": true/false, "level": "high"/"medium"/"none",
+     "signals": [{"type": "...", "detail": "...", "ts": ...}, ...],
+     "tool_counts": {"Write": 1, "Read": 5, ...}}
+"""
+
+import argparse
+import json
+import os
+import sys
+
+# ── Default signal classification ─────────────────────────────────────────────
+
+DEFAULT_HIGH_TOOL_NAMES = ["Write", "Edit"]
+DEFAULT_MEDIUM_TOOL_NAMES = ["Agent"]
+
+DEFAULT_HIGH_BASH_PATTERNS = [
+    "git commit",
+    "gh pr create",
+    "gh pr merge",
+    "firebase deploy",
+    "systemctl restart",
+    "systemctl stop",
+    "systemctl start",
+]
+
+DEFAULT_MEDIUM_BASH_PATTERNS = [
+    "git push",
+    "npm run build",
+    "cargo build",
+    "pip install",
+    "npm install",
+]
+
+# Tools whose names contain these strings are high-signal (email tools)
+HIGH_TOOL_NAME_SUBSTRINGS = ["email", "compose"]
+
+NOT_MEANINGFUL_TOOLS = {"Read", "Grep", "Glob"}
+
+
+def not_meaningful_result():
+    return {"meaningful": False, "level": "none", "signals": [], "tool_counts": {}}
+
+
+def load_config(config_path):
+    """Load optional config file and return activity_signals overrides (or empty dict)."""
+    if not config_path:
+        return {}
+    try:
+        with open(config_path) as f:
+            cfg = json.load(f)
+        return cfg.get("activity_signals", {})
+    except Exception as e:
+        sys.stderr.write(f"[transcript-scanner] warning: could not read config: {e}\n")
+        return {}
+
+
+def build_classifiers(overrides):
+    """Return (high_tools, medium_tools, high_bash, medium_bash) using overrides where present."""
+    high_tools = set(overrides.get("high_tool_names", DEFAULT_HIGH_TOOL_NAMES))
+    medium_tools = set(overrides.get("medium_tool_names", DEFAULT_MEDIUM_TOOL_NAMES))
+    high_bash = overrides.get("high_bash_patterns", DEFAULT_HIGH_BASH_PATTERNS)
+    medium_bash = overrides.get("medium_bash_patterns", DEFAULT_MEDIUM_BASH_PATTERNS)
+    return high_tools, medium_tools, high_bash, medium_bash
+
+
+def classify_tool_use(name, inp, high_tools, medium_tools, high_bash, medium_bash):
+    """
+    Returns (tier, detail) where tier is "high", "medium", or None.
+    inp is the tool_use input dict.
+    """
+    # Explicit high tool names
+    if name in high_tools:
+        detail = inp.get("file_path", "")
+        return "high", detail
+
+    # Explicit medium tool names
+    if name in medium_tools:
+        raw = inp.get("description") or inp.get("prompt") or ""
+        detail = raw[:120]
+        return "medium", detail
+
+    # Email/compose tools (substring match on name) — high
+    name_lower = name.lower()
+    if any(sub in name_lower for sub in HIGH_TOOL_NAME_SUBSTRINGS):
+        return "high", name
+
+    # Bash — check patterns
+    if name == "Bash":
+        command = inp.get("command", "")
+        detail = command[:120]
+        for pattern in high_bash:
+            if pattern in command:
+                return "high", detail
+        for pattern in medium_bash:
+            if pattern in command:
+                return "medium", detail
+        # Unmatched Bash — no signal
+        return None, detail
+
+    # Low-signal tools (no trigger)
+    return None, ""
+
+
+def scan(transcript_path, since_ts, overrides):
+    """
+    Parse the JSONL transcript and return the result dict.
+    since_ts: float seconds (epoch). Entries with ts_ms/1000 < since_ts are skipped.
+              Entries with no ts field are always included (fail-open).
+    """
+    high_tools, medium_tools, high_bash, medium_bash = build_classifiers(overrides)
+
+    signals = []
+    tool_counts = {}
+    has_high = False
+    has_medium = False
+
+    try:
+        with open(transcript_path) as f:
+            lines = f.readlines()
+    except Exception as e:
+        sys.stderr.write(f"[transcript-scanner] could not read transcript: {e}\n")
+        return not_meaningful_result()
+
+    for raw_line in lines:
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+
+        try:
+            entry = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+
+        # Only process assistant entries
+        if entry.get("type") != "assistant":
+            continue
+
+        # Timestamp filtering (fail-open: no ts = always include)
+        ts_ms = entry.get("ts")
+        if since_ts is not None and ts_ms is not None:
+            if ts_ms / 1000 < since_ts:
+                continue
+        # ts_ms is the entry-level ts we store in signals
+        entry_ts = ts_ms
+
+        # Walk content array for tool_use blocks
+        content = entry.get("message", {}).get("content", [])
+        if not isinstance(content, list):
+            continue
+
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") != "tool_use":
+                continue
+
+            name = block.get("name", "")
+            inp = block.get("input", {})
+            if not isinstance(inp, dict):
+                inp = {}
+
+            # Count all tool uses
+            tool_counts[name] = tool_counts.get(name, 0) + 1
+
+            tier, detail = classify_tool_use(
+                name, inp, high_tools, medium_tools, high_bash, medium_bash
+            )
+
+            if tier == "high":
+                has_high = True
+                signals.append({"type": name, "detail": detail, "ts": entry_ts})
+            elif tier == "medium":
+                has_medium = True
+                signals.append({"type": name, "detail": detail, "ts": entry_ts})
+
+    # Determine overall level
+    if has_high:
+        level = "high"
+    elif has_medium:
+        level = "medium"
+    else:
+        level = "none"
+
+    meaningful = has_high or has_medium
+
+    return {
+        "meaningful": meaningful,
+        "level": level,
+        "signals": signals,
+        "tool_counts": tool_counts,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Scan a Claude Code transcript for meaningful activity."
+    )
+    parser.add_argument("--transcript", help="Path to session JSONL transcript")
+    parser.add_argument(
+        "--since",
+        type=float,
+        default=None,
+        help="Only consider entries after this Unix timestamp (seconds)",
+    )
+    parser.add_argument("--config", help="Path to config JSON with activity_signals overrides")
+
+    args = parser.parse_args()
+
+    # No transcript path → not meaningful
+    if not args.transcript:
+        print(json.dumps(not_meaningful_result()))
+        return
+
+    # Missing file → not meaningful
+    if not os.path.exists(args.transcript):
+        print(json.dumps(not_meaningful_result()))
+        return
+
+    overrides = load_config(args.config)
+    result = scan(args.transcript, args.since, overrides)
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/autocontext/scripts/transcript-scanner.py
+++ b/autocontext/scripts/transcript-scanner.py
@@ -15,6 +15,7 @@ import argparse
 import json
 import os
 import sys
+from datetime import datetime, timezone
 
 # ── Default signal classification ─────────────────────────────────────────────
 
@@ -42,8 +43,6 @@ DEFAULT_MEDIUM_BASH_PATTERNS = [
 # Tools whose names contain these strings are high-signal (email tools)
 HIGH_TOOL_NAME_SUBSTRINGS = ["email", "compose"]
 
-NOT_MEANINGFUL_TOOLS = {"Read", "Grep", "Glob"}
-
 
 def not_meaningful_result():
     return {"meaningful": False, "level": "none", "signals": [], "tool_counts": {}}
@@ -52,6 +51,8 @@ def not_meaningful_result():
 def load_config(config_path):
     """Load optional config file and return activity_signals overrides (or empty dict)."""
     if not config_path:
+        return {}
+    if not os.path.isfile(config_path):
         return {}
     try:
         with open(config_path) as f:
@@ -109,11 +110,32 @@ def classify_tool_use(name, inp, high_tools, medium_tools, high_bash, medium_bas
     return None, ""
 
 
+def resolve_timestamp(raw_ts):
+    """
+    Resolve a raw timestamp value to Unix seconds (float), or None if unparseable.
+    Handles:
+      - int/float: treated as milliseconds, divided by 1000
+      - str: parsed as ISO 8601 (e.g. "2026-04-03T16:17:28.078Z")
+    """
+    if raw_ts is None:
+        return None
+    if isinstance(raw_ts, (int, float)):
+        return raw_ts / 1000
+    if isinstance(raw_ts, str):
+        try:
+            ts_str = raw_ts.replace("Z", "+00:00")
+            dt = datetime.fromisoformat(ts_str)
+            return dt.timestamp()
+        except ValueError:
+            return None
+    return None
+
+
 def scan(transcript_path, since_ts, overrides):
     """
     Parse the JSONL transcript and return the result dict.
-    since_ts: float seconds (epoch). Entries with ts_ms/1000 < since_ts are skipped.
-              Entries with no ts field are always included (fail-open).
+    since_ts: float seconds (epoch). Entries with timestamp < since_ts are skipped.
+              Entries with no timestamp field are always included (fail-open).
     """
     high_tools, medium_tools, high_bash, medium_bash = build_classifiers(overrides)
 
@@ -123,63 +145,62 @@ def scan(transcript_path, since_ts, overrides):
     has_medium = False
 
     try:
-        with open(transcript_path) as f:
-            lines = f.readlines()
+        transcript_file = open(transcript_path)
     except Exception as e:
         sys.stderr.write(f"[transcript-scanner] could not read transcript: {e}\n")
         return not_meaningful_result()
 
-    for raw_line in lines:
-        raw_line = raw_line.strip()
-        if not raw_line:
-            continue
-
-        try:
-            entry = json.loads(raw_line)
-        except json.JSONDecodeError:
-            continue
-
-        # Only process assistant entries
-        if entry.get("type") != "assistant":
-            continue
-
-        # Timestamp filtering (fail-open: no ts = always include)
-        ts_ms = entry.get("ts")
-        if since_ts is not None and ts_ms is not None:
-            if ts_ms / 1000 < since_ts:
-                continue
-        # ts_ms is the entry-level ts we store in signals
-        entry_ts = ts_ms
-
-        # Walk content array for tool_use blocks
-        content = entry.get("message", {}).get("content", [])
-        if not isinstance(content, list):
-            continue
-
-        for block in content:
-            if not isinstance(block, dict):
-                continue
-            if block.get("type") != "tool_use":
+    with transcript_file:
+        for raw_line in transcript_file:
+            raw_line = raw_line.strip()
+            if not raw_line:
                 continue
 
-            name = block.get("name", "")
-            inp = block.get("input", {})
-            if not isinstance(inp, dict):
-                inp = {}
+            try:
+                entry = json.loads(raw_line)
+            except json.JSONDecodeError:
+                continue
 
-            # Count all tool uses
-            tool_counts[name] = tool_counts.get(name, 0) + 1
+            # Only process assistant entries
+            if entry.get("type") != "assistant":
+                continue
 
-            tier, detail = classify_tool_use(
-                name, inp, high_tools, medium_tools, high_bash, medium_bash
-            )
+            # Timestamp filtering (fail-open: no timestamp = always include)
+            raw_ts = entry.get("timestamp")
+            entry_ts = resolve_timestamp(raw_ts)
+            if since_ts is not None and entry_ts is not None:
+                if entry_ts < since_ts:
+                    continue
 
-            if tier == "high":
-                has_high = True
-                signals.append({"type": name, "detail": detail, "ts": entry_ts})
-            elif tier == "medium":
-                has_medium = True
-                signals.append({"type": name, "detail": detail, "ts": entry_ts})
+            # Walk content array for tool_use blocks
+            content = entry.get("message", {}).get("content", [])
+            if not isinstance(content, list):
+                continue
+
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                if block.get("type") != "tool_use":
+                    continue
+
+                name = block.get("name", "")
+                inp = block.get("input", {})
+                if not isinstance(inp, dict):
+                    inp = {}
+
+                # Count all tool uses
+                tool_counts[name] = tool_counts.get(name, 0) + 1
+
+                tier, detail = classify_tool_use(
+                    name, inp, high_tools, medium_tools, high_bash, medium_bash
+                )
+
+                if tier == "high":
+                    has_high = True
+                    signals.append({"type": name, "detail": detail, "ts": entry_ts})
+                elif tier == "medium":
+                    has_medium = True
+                    signals.append({"type": name, "detail": detail, "ts": entry_ts})
 
     # Determine overall level
     if has_high:

--- a/autocontext/tests/test-session-end-gate.sh
+++ b/autocontext/tests/test-session-end-gate.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AUTOCONTEXT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SESSION_END="$AUTOCONTEXT_DIR/hooks/session-end.sh"
+TEST_DIR="/tmp/test-session-end-gate-$$"
+
+PASS=0
+FAIL=0
+
+trap "rm -rf '$TEST_DIR'" EXIT
+
+assert_eq() {
+    local label="$1"
+    local expected="$2"
+    local actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label (expected '$expected', got '$actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Set up minimal autocontext project structure
+mkdir -p "$TEST_DIR/.autocontext/cache"
+
+# Minimal lessons.json with one lesson at confidence 0.5
+cat > "$TEST_DIR/.autocontext/lessons.json" <<'JSON'
+[{"id":"test-lesson-1","text":"Always write tests first.","tags":["testing"],"confidence":0.5,"validated_count":0}]
+JSON
+
+# session-lessons.json with the same lesson (so session-end has something to validate)
+cat > "$TEST_DIR/.autocontext/cache/session-lessons.json" <<'JSON'
+[{"id":"test-lesson-1","text":"Always write tests first.","tags":["testing"],"confidence":0.5,"validated_count":0}]
+JSON
+
+# Create a research-only transcript (only Read/Grep/Glob — not meaningful)
+TRANSCRIPT="$TEST_DIR/research-only.jsonl"
+cat > "$TRANSCRIPT" <<'JSONL'
+{"type":"assistant","timestamp":"2026-04-03T10:00:00.000Z","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"/tmp/foo.py"}}]}}
+{"type":"assistant","timestamp":"2026-04-03T10:01:00.000Z","message":{"content":[{"type":"tool_use","name":"Grep","input":{"pattern":"foo"}}]}}
+{"type":"assistant","timestamp":"2026-04-03T10:02:00.000Z","message":{"content":[{"type":"tool_use","name":"Glob","input":{"pattern":"*.py"}}]}}
+JSONL
+
+# Touch session-lessons.json to be recent (< 10 min old) so time fallback doesn't fire
+touch "$TEST_DIR/.autocontext/cache/session-lessons.json"
+
+# Run session-end.sh from the test project dir
+OUTPUT=$(
+    cd "$TEST_DIR"
+    printf '{"session_id":"gate-test-session","transcript_path":"%s"}\n' "$TRANSCRIPT" \
+        | CLAUDE_PLUGIN_ROOT="$AUTOCONTEXT_DIR" bash "$SESSION_END" 2>/dev/null
+)
+
+assert_eq "session-end outputs {} for research-only + fresh session" "{}" "$OUTPUT"
+
+# Confidence should be unchanged (session was skipped, no validation bump)
+CONF_AFTER=$(python3 -c "
+import json
+with open('$TEST_DIR/.autocontext/lessons.json') as f:
+    lessons = json.load(f)
+print(lessons[0]['confidence'])
+")
+assert_eq "Confidence unchanged after skip" "0.5" "$CONF_AFTER"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [[ "$FAIL" -gt 0 ]]; then
+    exit 1
+fi

--- a/autocontext/tests/test-transcript-scanner.sh
+++ b/autocontext/tests/test-transcript-scanner.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCANNER="$(cd "$(dirname "$0")/.." && pwd)/scripts/transcript-scanner.py"
+TMPDIR_BASE="/tmp/test-transcript-scanner-$$"
+mkdir -p "$TMPDIR_BASE"
+trap "rm -rf '$TMPDIR_BASE'" EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local label="$1"
+    local expected="$2"
+    local actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label (expected '$expected', got '$actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Helper: build a minimal JSONL entry
+make_entry() {
+    local tool_name="$1"
+    local input_json="$2"
+    local ts="${3:-}"
+    if [[ -n "$ts" ]]; then
+        printf '{"type":"assistant","timestamp":"%s","message":{"content":[{"type":"tool_use","name":"%s","input":%s}]}}\n' \
+            "$ts" "$tool_name" "$input_json"
+    else
+        printf '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"%s","input":%s}]}}\n' \
+            "$tool_name" "$input_json"
+    fi
+}
+
+# ── Test 1: Write/Edit = high ─────────────────────────────────────────────────
+T="$TMPDIR_BASE/t1.jsonl"
+make_entry "Write" '{"file_path":"/tmp/foo.py"}' > "$T"
+result=$(python3 "$SCANNER" --transcript "$T")
+meaningful=$(echo "$result" | python3 -c "import json,sys; print(json.load(sys.stdin)['meaningful'])")
+level=$(echo "$result" | python3 -c "import json,sys; print(json.load(sys.stdin)['level'])")
+assert_eq "Write is meaningful" "True" "$meaningful"
+assert_eq "Write level is high" "high" "$level"
+
+# ── Test 2: Read/Grep/Glob only = not meaningful ──────────────────────────────
+T="$TMPDIR_BASE/t2.jsonl"
+make_entry "Read" '{"file_path":"/tmp/foo.py"}' > "$T"
+make_entry "Grep" '{"pattern":"foo"}' >> "$T"
+make_entry "Glob" '{"pattern":"*.py"}' >> "$T"
+result=$(python3 "$SCANNER" --transcript "$T")
+meaningful=$(echo "$result" | python3 -c "import json,sys; print(json.load(sys.stdin)['meaningful'])")
+assert_eq "Read/Grep/Glob only = not meaningful" "False" "$meaningful"
+
+# ── Test 3: git commit Bash = high ────────────────────────────────────────────
+T="$TMPDIR_BASE/t3.jsonl"
+make_entry "Bash" '{"command":"git commit -m \"fix thing\""}' > "$T"
+result=$(python3 "$SCANNER" --transcript "$T")
+level=$(echo "$result" | python3 -c "import json,sys; print(json.load(sys.stdin)['level'])")
+assert_eq "git commit Bash = high" "high" "$level"
+
+# ── Test 4: Agent = medium ────────────────────────────────────────────────────
+T="$TMPDIR_BASE/t4.jsonl"
+make_entry "Agent" '{"description":"do some research"}' > "$T"
+result=$(python3 "$SCANNER" --transcript "$T")
+level=$(echo "$result" | python3 -c "import json,sys; print(json.load(sys.stdin)['level'])")
+assert_eq "Agent = medium" "medium" "$level"
+
+# ── Test 5: --since filters old entries ──────────────────────────────────────
+T="$TMPDIR_BASE/t5.jsonl"
+# Timestamp in milliseconds (old: 2020-01-01)
+make_entry "Write" '{"file_path":"/tmp/old.py"}' "2020-01-01T00:00:00.000Z" > "$T"
+result=$(python3 "$SCANNER" --transcript "$T" --since 9999999999)
+meaningful=$(echo "$result" | python3 -c "import json,sys; print(json.load(sys.stdin)['meaningful'])")
+assert_eq "--since filters old entries" "False" "$meaningful"
+
+# ── Test 6: Missing file = not meaningful ────────────────────────────────────
+result=$(python3 "$SCANNER" --transcript "/tmp/this-file-does-not-exist-$$")
+meaningful=$(echo "$result" | python3 -c "import json,sys; print(json.load(sys.stdin)['meaningful'])")
+assert_eq "Missing file = not meaningful" "False" "$meaningful"
+
+# ── Test 7: No args = not meaningful ─────────────────────────────────────────
+result=$(python3 "$SCANNER")
+meaningful=$(echo "$result" | python3 -c "import json,sys; print(json.load(sys.stdin)['meaningful'])")
+assert_eq "No args = not meaningful" "False" "$meaningful"
+
+# ── Test 8: Custom config overrides ──────────────────────────────────────────
+T="$TMPDIR_BASE/t8.jsonl"
+CFG="$TMPDIR_BASE/config8.json"
+# Mark "Read" as a high tool via config
+printf '{"activity_signals":{"high_tool_names":["Read"]}}\n' > "$CFG"
+make_entry "Read" '{"file_path":"/tmp/foo.py"}' > "$T"
+result=$(python3 "$SCANNER" --transcript "$T" --config "$CFG")
+level=$(echo "$result" | python3 -c "import json,sys; print(json.load(sys.stdin)['level'])")
+assert_eq "Custom config overrides high_tool_names" "high" "$level"
+
+# ── Test 9: Non-dict activity_signals in config is handled safely ─────────────
+T="$TMPDIR_BASE/t9.jsonl"
+CFG="$TMPDIR_BASE/config9.json"
+printf '{"activity_signals":null}\n' > "$CFG"
+make_entry "Write" '{"file_path":"/tmp/foo.py"}' > "$T"
+result=$(python3 "$SCANNER" --transcript "$T" --config "$CFG" 2>&1)
+meaningful=$(echo "$result" | python3 -c "import json,sys; print(json.load(sys.stdin)['meaningful'])")
+assert_eq "null activity_signals handled safely" "True" "$meaningful"
+
+# ── Test 10: ISO 8601 timestamps ─────────────────────────────────────────────
+T="$TMPDIR_BASE/t10.jsonl"
+# Recent ISO 8601 timestamp
+make_entry "Write" '{"file_path":"/tmp/iso.py"}' "2026-04-03T16:17:28.078Z" > "$T"
+result=$(python3 "$SCANNER" --transcript "$T" --since 1000000000)
+meaningful=$(echo "$result" | python3 -c "import json,sys; print(json.load(sys.stdin)['meaningful'])")
+ts=$(echo "$result" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['signals'][0]['ts'] if d['signals'] else 0)")
+assert_eq "ISO 8601 entry is meaningful" "True" "$meaningful"
+# ts should be a positive float, not null/0
+if python3 -c "import sys; sys.exit(0 if float('$ts') > 0 else 1)"; then
+    echo "PASS: ISO 8601 ts resolved to positive float ($ts)"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: ISO 8601 ts not resolved ($ts)"
+    FAIL=$((FAIL + 1))
+fi
+
+# ── Test 11: Entries without timestamp included when --since set ──────────────
+T="$TMPDIR_BASE/t11.jsonl"
+# Entry with no timestamp field at all
+printf '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Write","input":{"file_path":"/tmp/notimestamp.py"}}]}}\n' > "$T"
+result=$(python3 "$SCANNER" --transcript "$T" --since 9999999999)
+meaningful=$(echo "$result" | python3 -c "import json,sys; print(json.load(sys.stdin)['meaningful'])")
+assert_eq "No-timestamp entry included even with --since" "True" "$meaningful"
+
+# ── ts fallback = 0 when timestamp missing ────────────────────────────────────
+ts=$(echo "$result" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['signals'][0]['ts'] if d['signals'] else 'missing')")
+assert_eq "Missing timestamp signal ts = 0" "0" "$ts"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [[ "$FAIL" -gt 0 ]]; then
+    exit 1
+fi

--- a/docs/superpowers/plans/2026-04-03-transcript-scanner.md
+++ b/docs/superpowers/plans/2026-04-03-transcript-scanner.md
@@ -1,0 +1,596 @@
+# Transcript scanner implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a shared transcript scanner utility to the autocontext plugin and wire it into session-end.sh so lesson validation only runs when meaningful work happened.
+
+**Architecture:** Standalone Python script (`transcript-scanner.py`) reads Claude Code session JSONL transcripts and returns structured activity signals as JSON. The existing `session-end.sh` Stop hook calls this script before doing any lesson validation work and exits early if no meaningful activity is detected (with a 10-minute time fallback).
+
+**Tech Stack:** Python 3 (stdlib only — json, argparse, os, sys, time), bash
+
+---
+
+### Task 1: Create transcript scanner script
+
+**Files:**
+- Create: `autocontext/scripts/transcript-scanner.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create a test script that exercises the scanner against synthetic JSONL input:
+
+```bash
+cat > /tmp/test-transcript-scanner.sh << 'TESTEOF'
+#!/bin/bash
+set -euo pipefail
+
+SCANNER="$(pwd)/autocontext/scripts/transcript-scanner.py"
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo "PASS: $label"
+        ((PASS++))
+    else
+        echo "FAIL: $label"
+        echo "  expected: $expected"
+        echo "  actual:   $actual"
+        ((FAIL++))
+    fi
+}
+
+# --- Test 1: Write/Edit signals detected ---
+TMPFILE=$(mktemp /tmp/transcript-XXXX.jsonl)
+cat > "$TMPFILE" << 'JSONL'
+{"type":"assistant","timestamp":1000000,"message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"src/app.py"}}]}}
+{"type":"assistant","timestamp":2000000,"message":{"content":[{"type":"tool_use","name":"Write","input":{"file_path":"src/new-file.py"}}]}}
+{"type":"assistant","timestamp":3000000,"message":{"content":[{"type":"tool_use","name":"Edit","input":{"file_path":"src/app.py","old_string":"x","new_string":"y"}}]}}
+JSONL
+RESULT=$(python3 "$SCANNER" --transcript "$TMPFILE")
+MEANINGFUL=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin)['meaningful'])")
+LEVEL=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin)['level'])")
+SIGNAL_COUNT=$(echo "$RESULT" | python3 -c "import json,sys; print(len(json.load(sys.stdin)['signals']))")
+assert_eq "write/edit detected as meaningful" "True" "$MEANINGFUL"
+assert_eq "write/edit level is high" "high" "$LEVEL"
+assert_eq "write/edit signal count" "2" "$SIGNAL_COUNT"
+rm -f "$TMPFILE"
+
+# --- Test 2: Read/Grep only = not meaningful ---
+TMPFILE=$(mktemp /tmp/transcript-XXXX.jsonl)
+cat > "$TMPFILE" << 'JSONL'
+{"type":"assistant","timestamp":1000000,"message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"src/app.py"}}]}}
+{"type":"assistant","timestamp":2000000,"message":{"content":[{"type":"tool_use","name":"Grep","input":{"pattern":"foo"}}]}}
+{"type":"assistant","timestamp":3000000,"message":{"content":[{"type":"tool_use","name":"Glob","input":{"pattern":"**/*.py"}}]}}
+JSONL
+RESULT=$(python3 "$SCANNER" --transcript "$TMPFILE")
+MEANINGFUL=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin)['meaningful'])")
+assert_eq "read-only not meaningful" "False" "$MEANINGFUL"
+rm -f "$TMPFILE"
+
+# --- Test 3: git commit in Bash = high signal ---
+TMPFILE=$(mktemp /tmp/transcript-XXXX.jsonl)
+cat > "$TMPFILE" << 'JSONL'
+{"type":"assistant","timestamp":1000000,"message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"git commit -m 'fix bug'"}}]}}
+JSONL
+RESULT=$(python3 "$SCANNER" --transcript "$TMPFILE")
+MEANINGFUL=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin)['meaningful'])")
+LEVEL=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin)['level'])")
+assert_eq "git commit is meaningful" "True" "$MEANINGFUL"
+assert_eq "git commit level is high" "high" "$LEVEL"
+rm -f "$TMPFILE"
+
+# --- Test 4: Agent tool = medium signal ---
+TMPFILE=$(mktemp /tmp/transcript-XXXX.jsonl)
+cat > "$TMPFILE" << 'JSONL'
+{"type":"assistant","timestamp":1000000,"message":{"content":[{"type":"tool_use","name":"Agent","input":{"description":"research","prompt":"find files"}}]}}
+JSONL
+RESULT=$(python3 "$SCANNER" --transcript "$TMPFILE")
+MEANINGFUL=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin)['meaningful'])")
+LEVEL=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin)['level'])")
+assert_eq "agent is meaningful" "True" "$MEANINGFUL"
+assert_eq "agent level is medium" "medium" "$LEVEL"
+rm -f "$TMPFILE"
+
+# --- Test 5: --since filters old entries ---
+TMPFILE=$(mktemp /tmp/transcript-XXXX.jsonl)
+cat > "$TMPFILE" << 'JSONL'
+{"type":"assistant","timestamp":1000000,"message":{"content":[{"type":"tool_use","name":"Write","input":{"file_path":"old.py"}}]}}
+{"type":"assistant","timestamp":5000000,"message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"new.py"}}]}}
+JSONL
+RESULT=$(python3 "$SCANNER" --transcript "$TMPFILE" --since 2000)
+MEANINGFUL=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin)['meaningful'])")
+assert_eq "since filters old Write" "False" "$MEANINGFUL"
+rm -f "$TMPFILE"
+
+# --- Test 6: Missing transcript file = not meaningful ---
+RESULT=$(python3 "$SCANNER" --transcript "/tmp/nonexistent-transcript.jsonl")
+MEANINGFUL=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin)['meaningful'])")
+assert_eq "missing file not meaningful" "False" "$MEANINGFUL"
+
+# --- Test 7: No --transcript arg = not meaningful ---
+RESULT=$(python3 "$SCANNER")
+MEANINGFUL=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin)['meaningful'])")
+assert_eq "no args not meaningful" "False" "$MEANINGFUL"
+
+# --- Test 8: tool_counts populated ---
+TMPFILE=$(mktemp /tmp/transcript-XXXX.jsonl)
+cat > "$TMPFILE" << 'JSONL'
+{"type":"assistant","timestamp":1000000,"message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"a.py"}}]}}
+{"type":"assistant","timestamp":2000000,"message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"b.py"}}]}}
+{"type":"assistant","timestamp":3000000,"message":{"content":[{"type":"tool_use","name":"Write","input":{"file_path":"c.py"}}]}}
+JSONL
+RESULT=$(python3 "$SCANNER" --transcript "$TMPFILE")
+READ_COUNT=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin)['tool_counts'].get('Read',0))")
+WRITE_COUNT=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin)['tool_counts'].get('Write',0))")
+assert_eq "tool_counts Read=2" "2" "$READ_COUNT"
+assert_eq "tool_counts Write=1" "1" "$WRITE_COUNT"
+rm -f "$TMPFILE"
+
+# --- Test 9: Custom config overrides defaults ---
+TMPFILE=$(mktemp /tmp/transcript-XXXX.jsonl)
+CFGFILE=$(mktemp /tmp/config-XXXX.json)
+cat > "$TMPFILE" << 'JSONL'
+{"type":"assistant","timestamp":1000000,"message":{"content":[{"type":"tool_use","name":"Write","input":{"file_path":"a.py"}}]}}
+JSONL
+cat > "$CFGFILE" << 'JSON'
+{"activity_signals":{"high_tool_names":["Bash"],"medium_tool_names":[],"high_bash_patterns":[],"medium_bash_patterns":[]}}
+JSON
+RESULT=$(python3 "$SCANNER" --transcript "$TMPFILE" --config "$CFGFILE")
+MEANINGFUL=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin)['meaningful'])")
+assert_eq "config override: Write not high when overridden" "False" "$MEANINGFUL"
+rm -f "$TMPFILE" "$CFGFILE"
+
+# --- Test 10: Entries without timestamp included when --since set ---
+TMPFILE=$(mktemp /tmp/transcript-XXXX.jsonl)
+cat > "$TMPFILE" << 'JSONL'
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Write","input":{"file_path":"no-ts.py"}}]}}
+JSONL
+RESULT=$(python3 "$SCANNER" --transcript "$TMPFILE" --since 9999999)
+MEANINGFUL=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin)['meaningful'])")
+assert_eq "no-timestamp entry included" "True" "$MEANINGFUL"
+rm -f "$TMPFILE"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]
+TESTEOF
+chmod +x /tmp/test-transcript-scanner.sh
+```
+
+Note: the test script does not `exit 1` on failure here — it uses the exit code from `[[ "$FAIL" -eq 0 ]]` so the script can be appended to in Task 2.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/jamditis/projects/claude-skills-journalism && bash /tmp/test-transcript-scanner.sh`
+Expected: FAIL — `transcript-scanner.py` doesn't exist yet.
+
+- [ ] **Step 3: Write the scanner implementation**
+
+Create `autocontext/scripts/transcript-scanner.py`:
+
+```python
+#!/usr/bin/env python3
+"""Scan a Claude Code session transcript for meaningful activity signals.
+
+Reads a JSONL transcript file and classifies tool usage into high/medium/low
+signal levels. Returns structured JSON to stdout.
+
+Usage:
+    python3 transcript-scanner.py --transcript /path/to/session.jsonl [--since UNIX_TS] [--config path/to/config.json]
+"""
+
+import argparse
+import json
+import os
+import sys
+
+DEFAULT_HIGH_TOOL_NAMES = ["Write", "Edit"]
+DEFAULT_MEDIUM_TOOL_NAMES = ["Agent"]
+DEFAULT_HIGH_BASH_PATTERNS = [
+    "git commit",
+    "gh pr create",
+    "gh pr merge",
+    "firebase deploy",
+    "systemctl restart",
+    "systemctl stop",
+    "systemctl start",
+]
+DEFAULT_MEDIUM_BASH_PATTERNS = [
+    "git push",
+    "npm run build",
+    "cargo build",
+    "pip install",
+    "npm install",
+]
+
+
+def load_config(config_path):
+    """Load signal config from file, returning None if unavailable."""
+    if not config_path or not os.path.isfile(config_path):
+        return None
+    try:
+        with open(config_path) as f:
+            cfg = json.load(f)
+        return cfg.get("activity_signals")
+    except Exception:
+        return None
+
+
+def get_signals_config(config_path):
+    """Return signal classification config, using defaults where needed."""
+    overrides = load_config(config_path)
+    if overrides and isinstance(overrides, dict):
+        return {
+            "high_tool_names": overrides.get("high_tool_names", DEFAULT_HIGH_TOOL_NAMES),
+            "medium_tool_names": overrides.get("medium_tool_names", DEFAULT_MEDIUM_TOOL_NAMES),
+            "high_bash_patterns": overrides.get("high_bash_patterns", DEFAULT_HIGH_BASH_PATTERNS),
+            "medium_bash_patterns": overrides.get("medium_bash_patterns", DEFAULT_MEDIUM_BASH_PATTERNS),
+        }
+    return {
+        "high_tool_names": DEFAULT_HIGH_TOOL_NAMES,
+        "medium_tool_names": DEFAULT_MEDIUM_TOOL_NAMES,
+        "high_bash_patterns": DEFAULT_HIGH_BASH_PATTERNS,
+        "medium_bash_patterns": DEFAULT_MEDIUM_BASH_PATTERNS,
+    }
+
+
+def classify_tool_use(name, inp, cfg):
+    """Classify a tool use block. Returns ('high'|'medium'|None, detail_string)."""
+    # High-signal tool names
+    if name in cfg["high_tool_names"]:
+        detail = inp.get("file_path", name)
+        return "high", detail
+
+    # Medium-signal tool names
+    if name in cfg["medium_tool_names"]:
+        detail = inp.get("description", inp.get("prompt", name))
+        if isinstance(detail, str):
+            detail = detail[:120]
+        return "medium", detail
+
+    # Bash command pattern matching
+    if name == "Bash":
+        cmd = inp.get("command", "")
+        for pattern in cfg["high_bash_patterns"]:
+            if pattern in cmd:
+                return "high", cmd[:120]
+        for pattern in cfg["medium_bash_patterns"]:
+            if pattern in cmd:
+                return "medium", cmd[:120]
+
+    # MCP tools with email/compose in name
+    if "email" in name.lower() or "compose" in name.lower():
+        return "high", name
+
+    return None, None
+
+
+def scan_transcript(transcript_path, since_ts, cfg):
+    """Scan the transcript JSONL and return activity results."""
+    signals = []
+    tool_counts = {}
+    max_level = "none"
+
+    if not transcript_path or not os.path.isfile(transcript_path):
+        return {
+            "meaningful": False,
+            "level": "none",
+            "signals": [],
+            "tool_counts": {},
+        }
+
+    try:
+        with open(transcript_path) as f:
+            for line in f:
+                try:
+                    entry = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+
+                if entry.get("type") != "assistant":
+                    continue
+
+                # Timestamp filtering (milliseconds in JSONL)
+                ts = entry.get("timestamp")
+                if since_ts > 0 and ts is not None:
+                    if isinstance(ts, (int, float)) and ts / 1000 < since_ts:
+                        continue
+
+                msg = entry.get("message", {})
+                content = msg.get("content", [])
+                if not isinstance(content, list):
+                    continue
+
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    if block.get("type") != "tool_use":
+                        continue
+
+                    name = block.get("name", "")
+                    inp = block.get("input", {})
+
+                    # Count all tool uses
+                    tool_counts[name] = tool_counts.get(name, 0) + 1
+
+                    # Classify
+                    level, detail = classify_tool_use(name, inp, cfg)
+                    if level:
+                        entry_ts = entry.get("timestamp")
+                        if isinstance(entry_ts, (int, float)):
+                            entry_ts = int(entry_ts / 1000)
+                        else:
+                            entry_ts = 0
+                        signals.append({
+                            "type": name,
+                            "detail": detail or name,
+                            "ts": entry_ts,
+                        })
+                        if level == "high":
+                            max_level = "high"
+                        elif level == "medium" and max_level != "high":
+                            max_level = "medium"
+
+    except (IOError, OSError) as e:
+        print(f"[transcript-scanner] warning: {e}", file=sys.stderr)
+
+    return {
+        "meaningful": max_level in ("high", "medium"),
+        "level": max_level,
+        "signals": signals,
+        "tool_counts": tool_counts,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Scan session transcript for activity signals")
+    parser.add_argument("--transcript", default="", help="Path to session JSONL file")
+    parser.add_argument("--since", type=float, default=0, help="Unix timestamp — ignore entries before this")
+    parser.add_argument("--config", default="", help="Path to config JSON with activity_signals key")
+    args = parser.parse_args()
+
+    cfg = get_signals_config(args.config)
+    result = scan_transcript(args.transcript, args.since, cfg)
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/jamditis/projects/claude-skills-journalism && bash /tmp/test-transcript-scanner.sh`
+Expected: All 10 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add autocontext/scripts/transcript-scanner.py
+git commit -m "Add transcript scanner utility for activity-based hook gating"
+```
+
+---
+
+### Task 2: Add activity gate to session-end.sh
+
+**Files:**
+- Modify: `autocontext/hooks/session-end.sh:13-15` (after stdin read, before lesson file checks)
+
+- [ ] **Step 1: Write the failing test**
+
+Append integration tests to the existing test script. The append replaces the final summary block with additional tests and a new summary:
+
+```bash
+# Remove the old summary lines (last 4 lines) and append new tests
+head -n -4 /tmp/test-transcript-scanner.sh > /tmp/test-transcript-scanner.tmp
+mv /tmp/test-transcript-scanner.tmp /tmp/test-transcript-scanner.sh
+chmod +x /tmp/test-transcript-scanner.sh
+
+cat >> /tmp/test-transcript-scanner.sh << 'TESTEOF'
+
+# --- session-end.sh integration tests ---
+
+# Test 11: session-end exits early for non-meaningful session under 10 min
+# We test this by checking that session-end.sh outputs '{}' when the
+# transcript has no meaningful activity and session-lessons.json is fresh.
+
+TMPDIR=$(mktemp -d /tmp/session-end-test-XXXX)
+cd "$TMPDIR"
+mkdir -p .autocontext/cache
+
+# Create a minimal lessons.json and session-lessons.json
+echo '[{"id":"test1","text":"test lesson","confidence":0.7,"validated_count":0,"last_validated":"2026-04-03T00:00:00+00:00","deleted":false,"tags":[],"category":"test"}]' > .autocontext/lessons.json
+echo '[{"id":"test1","text":"test lesson","confidence":0.7,"validated_count":0,"last_validated":"2026-04-03T00:00:00+00:00","deleted":false,"tags":[],"category":"test"}]' > .autocontext/cache/session-lessons.json
+
+# Touch session-lessons.json to NOW (session just started)
+touch .autocontext/cache/session-lessons.json
+
+# Create a research-only transcript
+TRANSCRIPT=$(mktemp /tmp/transcript-XXXX.jsonl)
+cat > "$TRANSCRIPT" << 'JSONL'
+{"type":"assistant","timestamp":1000000,"message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"a.py"}}]}}
+JSONL
+
+# Feed session-end.sh with the transcript path
+PLUGIN_ROOT="$(cd /home/jamditis/projects/claude-skills-journalism/autocontext && pwd)"
+RESULT=$(echo "{\"session_id\":\"test\",\"transcript_path\":\"$TRANSCRIPT\"}" | \
+    CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" bash "$PLUGIN_ROOT/hooks/session-end.sh" 2>/dev/null)
+
+assert_eq "session-end skips for non-meaningful + fresh session" "{}" "$RESULT"
+
+# Verify lessons.json was NOT modified (confidence should be unchanged)
+CONFIDENCE=$(python3 -c "import json; print(json.load(open('.autocontext/lessons.json'))[0]['confidence'])")
+assert_eq "confidence unchanged after skip" "0.7" "$CONFIDENCE"
+
+rm -rf "$TMPDIR" "$TRANSCRIPT"
+cd /home/jamditis/projects/claude-skills-journalism
+
+echo ""
+echo "Final results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1
+TESTEOF
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/jamditis/projects/claude-skills-journalism && bash /tmp/test-transcript-scanner.sh`
+Expected: Tests 1-10 pass, test 11 FAILS — session-end.sh doesn't have the gate yet.
+
+- [ ] **Step 3: Add the activity gate to session-end.sh**
+
+Insert the gate after line 15 (after `INPUT=$(cat)` and `SESSION_ID=...`), before line 17 (`if [[ ! -f "$SESSION_LESSONS_FILE" ]]`).
+
+The new block to insert between the `SESSION_ID` line and the `SESSION_LESSONS_FILE` check:
+
+```bash
+# ── Activity gate: skip validation if no meaningful work happened ──────────
+TRANSCRIPT_PATH=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('transcript_path',''))" 2>/dev/null || echo "")
+SCANNER_SCRIPT="$PLUGIN_ROOT/scripts/transcript-scanner.py"
+
+if [[ -n "$TRANSCRIPT_PATH" ]] && [[ -f "$SCANNER_SCRIPT" ]]; then
+    SINCE_TS=0
+    if [[ -f "$SESSION_LESSONS_FILE" ]]; then
+        SINCE_TS=$(stat -c %Y "$SESSION_LESSONS_FILE" 2>/dev/null || echo 0)
+    fi
+
+    SCAN_RESULT=$(python3 "$SCANNER_SCRIPT" \
+        --transcript "$TRANSCRIPT_PATH" \
+        --since "$SINCE_TS" \
+        --config "$AUTOCONTEXT_DIR/config.json" 2>/dev/null || echo '{"meaningful":true}')
+
+    IS_MEANINGFUL=$(echo "$SCAN_RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('meaningful',True))" 2>/dev/null || echo "True")
+
+    if [[ "$IS_MEANINGFUL" == "False" ]]; then
+        # Time fallback: validate anyway if session is 10+ minutes old
+        NOW=$(date +%s)
+        SESSION_START=$(stat -c %Y "$SESSION_LESSONS_FILE" 2>/dev/null || echo "$NOW")
+        SESSION_AGE=$((NOW - SESSION_START))
+        if [[ "$SESSION_AGE" -lt 600 ]]; then
+            echo '{}'
+            exit 0
+        fi
+    fi
+fi
+# ── End activity gate ──────────────────────────────────────────────────────
+```
+
+The rest of session-end.sh remains unchanged.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/jamditis/projects/claude-skills-journalism && bash /tmp/test-transcript-scanner.sh`
+Expected: All 11 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add autocontext/hooks/session-end.sh
+git commit -m "Add activity gate to session-end.sh to skip validation for research-only sessions"
+```
+
+---
+
+### Task 3: Update README with scanner docs and activity_signals config
+
+**Files:**
+- Modify: `autocontext/README.md`
+
+- [ ] **Step 1: Add transcript scanner section to README**
+
+Add after the "Configuration" section (after line 107), before "Inspiration and attribution":
+
+```markdown
+## Transcript scanner
+
+The plugin includes a shared transcript scanner utility that detects meaningful activity in Claude Code session transcripts. It powers the activity gate in `session-end.sh` and can be used by custom hooks.
+
+**Usage from a hook script:**
+
+```bash
+RESULT=$(python3 "$PLUGIN_ROOT/scripts/transcript-scanner.py" \
+    --transcript "$TRANSCRIPT_PATH" \
+    --since "$LAST_HANDOFF_MTIME" \
+    --config ".autocontext/config.json")
+
+# Returns JSON:
+# {"meaningful": true, "level": "high", "signals": [...], "tool_counts": {...}}
+```
+
+**Arguments:**
+- `--transcript` — path to the session JSONL file
+- `--since` — Unix timestamp (seconds). Only scan entries after this time. Default: 0 (scan all).
+- `--config` — path to config file. Reads `activity_signals` key if present.
+
+**Signal levels:**
+
+| Level | Triggers |
+|-------|----------|
+| High | Write, Edit, Bash with `git commit` / `gh pr create` / `firebase deploy` / `systemctl restart` |
+| Medium | Agent, Bash with `git push` / `npm run build` / `cargo build` |
+| Low | Read, Grep, Glob, unmatched Bash (does not trigger `meaningful: true`) |
+```
+
+- [ ] **Step 2: Add activity_signals to the config table**
+
+Add a new row to the `config.json` table in the Configuration section (after the `builtin_rules` row):
+
+```markdown
+| `activity_signals` | (see below) | Override which tools/patterns count as meaningful activity (see Transcript scanner section) |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add autocontext/README.md
+git commit -m "Document transcript scanner utility and activity_signals config"
+```
+
+---
+
+### Task 4: Clean up test file and verify full integration
+
+**Files:**
+- No files created or modified. Verification only.
+
+- [ ] **Step 1: Run the full test suite one final time**
+
+Run: `cd /home/jamditis/projects/claude-skills-journalism && bash /tmp/test-transcript-scanner.sh`
+Expected: All 11 tests PASS.
+
+- [ ] **Step 2: Test scanner against the real current session transcript**
+
+Run:
+```bash
+python3 autocontext/scripts/transcript-scanner.py \
+    --transcript "$(ls -t ~/.claude/projects/-home-jamditis/*.jsonl | head -1)"
+```
+
+Expected: `meaningful: true` with Write/Edit signals from this session's work.
+
+- [ ] **Step 3: Test scanner with --since filtering against real transcript**
+
+Run:
+```bash
+python3 autocontext/scripts/transcript-scanner.py \
+    --transcript "$(ls -t ~/.claude/projects/-home-jamditis/*.jsonl | head -1)" \
+    --since 9999999999
+```
+
+Expected: `meaningful: false` — all entries are before that far-future timestamp.
+
+- [ ] **Step 4: Clean up test script**
+
+```bash
+rm -f /tmp/test-transcript-scanner.sh
+```
+
+- [ ] **Step 5: Create branch and push for PR**
+
+```bash
+cd /home/jamditis/projects/claude-skills-journalism
+git checkout -b feat/transcript-scanner
+git push -u origin feat/transcript-scanner
+```

--- a/docs/superpowers/specs/2026-04-03-transcript-scanner-design.md
+++ b/docs/superpowers/specs/2026-04-03-transcript-scanner-design.md
@@ -1,0 +1,150 @@
+# Transcript scanner and activity-aware session-end hook
+
+**Date:** 2026-04-03
+**Status:** Approved
+**Scope:** autocontext plugin (`claude-skills-journalism`)
+
+## Problem
+
+The autocontext `session-end.sh` Stop hook runs after every Claude response. It validates lessons (bumping confidence, checking for contradictions) and regenerates the playbook each time. While it's a lightweight command hook (not an agent spawn), it does unnecessary disk I/O on sessions where nothing meaningful happened — pure Q&A, research, or reading.
+
+Separately, users who build custom Stop hooks (like session handoff writers) lack a reusable way to detect whether a session produced meaningful work. Each hook ends up reimplementing transcript parsing logic independently.
+
+## Solution
+
+Two changes:
+
+1. **Shared transcript scanner** (`scripts/transcript-scanner.py`) — a standalone utility that reads a Claude Code session transcript (JSONL) and returns structured activity signals.
+2. **Activity gate in `session-end.sh`** — calls the scanner before doing lesson validation. Skips work when no meaningful activity happened, with a 10-minute time fallback.
+
+## Design
+
+### Transcript scanner
+
+**Location:** `autocontext/scripts/transcript-scanner.py`
+
+**Interface:**
+```bash
+python3 "$PLUGIN_ROOT/scripts/transcript-scanner.py" \
+    --transcript "/path/to/session.jsonl" \
+    --since 1743700000 \
+    --config ".autocontext/config.json"
+```
+
+All arguments are optional:
+- `--transcript` — path to the session JSONL file. If missing, empty, or file doesn't exist, returns `{"meaningful": false}` (no data to scan, so no signals found). Callers that want fail-open behavior should handle this themselves.
+- `--since` — Unix timestamp (seconds). Only consider tool calls after this time. Entries without a timestamp field are included regardless. Default: 0 (scan all).
+- `--config` — path to config file for custom signal definitions. Falls back to hardcoded defaults if missing or unreadable.
+
+**Output (JSON to stdout):**
+```json
+{
+  "meaningful": true,
+  "level": "high",
+  "signals": [
+    {"type": "Write", "detail": "src/hooks/session-end.sh", "ts": 1743700500},
+    {"type": "Bash", "detail": "git commit -m 'Fix hook'", "ts": 1743700600}
+  ],
+  "tool_counts": {"Write": 1, "Edit": 3, "Read": 12, "Bash": 7, "Grep": 4}
+}
+```
+
+When no meaningful activity:
+```json
+{
+  "meaningful": false,
+  "level": "none",
+  "signals": [],
+  "tool_counts": {"Read": 5, "Grep": 2}
+}
+```
+
+**Signal classification (defaults):**
+
+| Level | Trigger |
+|-------|---------|
+| High | Write tool, Edit tool, Bash containing: `git commit`, `gh pr create`, `gh pr merge`, `firebase deploy`, `systemctl restart`, `systemctl stop`, `systemctl start`. Any MCP tool with "email" or "compose" in the name. |
+| Medium | Agent tool, Bash containing: `git push`, `npm run build`, `cargo build`, `pip install`, `npm install`. |
+| Low (no trigger) | Read, Grep, Glob, Bash not matching any pattern above. |
+
+Result is `meaningful: true` when any high or medium signal is found.
+
+**Config override** (optional key in `.autocontext/config.json`):
+```json
+{
+  "activity_signals": {
+    "high_bash_patterns": ["git commit", "gh pr create", "deploy"],
+    "medium_bash_patterns": ["git push", "npm run build"],
+    "high_tool_names": ["Write", "Edit"],
+    "medium_tool_names": ["Agent"]
+  }
+}
+```
+
+If the `activity_signals` key is absent, defaults apply. If present, each sub-key fully replaces that signal tier (not merged with defaults). This lets projects narrow or widen what counts as meaningful.
+
+**Transcript JSONL parsing:**
+
+The scanner reads lines from the JSONL file. For each line:
+1. Parse as JSON. Skip invalid lines.
+2. Skip entries where `type` is not `"assistant"`.
+3. If `--since` is set and the entry has a `timestamp` field (milliseconds), skip entries before that time. Entries without a timestamp field are always included (fail-open at entry level).
+4. Walk `message.content` array looking for blocks where `type == "tool_use"`.
+5. For each tool use, check `name` and `input` against the signal classification.
+6. Collect matching signals and aggregate tool counts.
+
+**Error handling:** The scanner itself returns `{"meaningful": false}` when there's no data to scan (missing file, empty path). Unexpected errors (malformed JSON mid-file, permission issues) are logged to stderr and the scanner continues scanning remaining lines. The fail-open behavior lives in `session-end.sh`, which defaults to `{"meaningful": true}` if the scanner subprocess fails entirely — so validation proceeds as before.
+
+### Changes to session-end.sh
+
+Add an activity gate at the top of the script, after reading stdin and before the lesson validation logic.
+
+**Gate logic:**
+1. Extract `transcript_path` from stdin JSON (already available in Stop hook input).
+2. Call `transcript-scanner.py` with `--transcript` and `--since` (mtime of `session-lessons.json`, which marks session start).
+3. If scanner returns `meaningful: false`:
+   - Check session age (now - mtime of session-lessons.json).
+   - If under 10 minutes (600 seconds), return `{}` and exit — skip validation.
+   - If 10+ minutes, fall through to normal validation (time fallback).
+4. If scanner returns `meaningful: true` or errors, proceed with existing validation.
+
+**Fail-open guarantees:**
+- If `transcript-scanner.py` doesn't exist → fall through to existing behavior.
+- If Python call errors → default to `{"meaningful": true}` → fall through.
+- If stdin doesn't contain `transcript_path` → fall through.
+
+The existing lesson validation, playbook regeneration, and skill tracking cleanup code is unchanged.
+
+### What this does NOT change
+
+- `session-start.sh` — runs once per session, already efficient.
+- `post-tool-use.sh` — already scoped to specific tool types.
+- `user-prompt-submit.sh` — fires on user messages, correct trigger for correction detection.
+- `generate-playbook.py` — called by session-end.sh only when validation runs.
+- Plugin config schema — `activity_signals` is optional, all existing configs work unchanged.
+
+## Backward compatibility
+
+- No new required config keys.
+- No changes to lesson.json schema.
+- If the scanner script is missing (e.g., older plugin version), session-end.sh falls through to current behavior.
+- The scanner reads the transcript JSONL format that Claude Code produces. No version-specific coupling — it only looks for `type: "assistant"` entries with `content` arrays containing `tool_use` blocks.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `autocontext/scripts/transcript-scanner.py` | New file |
+| `autocontext/hooks/session-end.sh` | Add activity gate before lesson validation |
+| `autocontext/README.md` | Document scanner utility and `activity_signals` config |
+
+## Testing
+
+- **Scanner with active session transcript:** Feed a real JSONL with Write/Edit calls, verify `meaningful: true` and correct signals list.
+- **Scanner with research-only transcript:** Feed JSONL with only Read/Grep/Glob, verify `meaningful: false`.
+- **Scanner with empty/missing transcript:** Verify fail-open (`meaningful: true`).
+- **Scanner with `--since` filtering:** Verify only tool calls after the timestamp are considered.
+- **Scanner with custom config:** Verify config overrides replace defaults.
+- **session-end.sh gate:** Verify lesson validation is skipped for non-meaningful sessions under 10 min.
+- **session-end.sh time fallback:** Verify validation runs for non-meaningful sessions over 10 min.
+- **session-end.sh without scanner:** Remove scanner script, verify existing behavior unchanged.


### PR DESCRIPTION
## Summary

- Adds `autocontext/scripts/transcript-scanner.py` — a shared utility that scans Claude Code session transcripts (JSONL) for meaningful activity signals (Write, Edit, git commit, PR creation, deploys, etc.)
- Adds an activity gate to `autocontext/hooks/session-end.sh` that skips lesson validation when only research tools (Read, Grep, Glob) were used, with a 10-minute time fallback
- Documents the scanner utility and new `activity_signals` config key in the README

## Why

The `session-end.sh` Stop hook runs after every Claude response. While it's a lightweight command hook (not an agent spawn), it does unnecessary disk I/O — reading/writing `lessons.json` and regenerating the playbook — on sessions where nothing meaningful happened. The scanner provides a reusable way to detect meaningful activity, and the gate uses it to skip validation for research-only responses.

## Test plan

- [ ] 19 assertions across 12 tests covering: signal classification (Write/Edit/Bash/Agent), --since filtering (integer ms + ISO 8601 strings), missing/empty transcripts, config overrides, fail-open behavior, and session-end.sh integration
- [ ] Verified scanner against real session transcript (35 signals detected correctly)
- [ ] Verified --since filtering against real transcript (far-future timestamp returns no signals)
- [ ] Backward compatible: no required config changes, fail-open when scanner is missing