### PR TITLE
pdf-playground v1.3.0: slide template overhaul from real deck feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-04-14
+
+### Added
+- **pdf-playground v1.3.0**: Major slide template overhaul based on real presentation feedback from the Montclair State / NJPBA RFP walkthrough deck
+  - New `.slide-hero` layout: full-bleed photo background with right-aligned headline and red branded footer bar. Includes a `.slide-closing` variant with left-aligned headline and tightened subtitle for "Ready on [date]" close slides
+  - New `.slide-section.with-photo` layout: photo-background section divider with a red section chip ("Section 8.1") for decks that mirror numbered documents like RFP responses
+  - New `.three-col` layout: three text columns with dashed dividers for breaking a topic into parallel facets
+  - New `.four-col-tiles` layout: four numbered pillar cards with red top rule and short descriptions — for parallel capabilities or themes
+  - New `.stats-strip` layout: row of big numbers with small captions, each with a red left rule. Column count configurable via `--stat-cols` custom property
+  - New `.slide-table` layout: comparison/budget table with red header row, gray label column, grid rules
+  - New `.partner-grid` layout: 4-column grid of labeled tiles with red left accent bar for sponsor lists and letters of support
+  - New `.slide-footer-red` variant: filled red footer bar with wordmark image for branded decks (alternative to the muted text footer)
+  - Montserrat added to the font stack alongside Playfair Display + Source Sans 3. Switch via `--font-heading` and `--font-body` CSS variables
+- **pdf-design v1.1.0**: Reusable content blocks section added to SKILL.md
+  - Stats strip, three-column, four-tile pillars, and partner grid patterns documented as drop-in blocks for report and proposal pages
+  - Vertical rhythm guidelines added — tighter spacing is a feature, not a bug
+
+### Changed
+- **pdf-playground v1.3.0**: Tighter vertical rhythm throughout content slides
+  - Slide headline padding: 0.75in → 0.55in top
+  - Slide body padding: 0.3in → 0.22in top
+  - Red accent rule under headlines replaces full-width border-bottom for a cleaner visual relationship between title and body
+  - Default aspect ratio: 10×7.5 (4:3) → 13.333×7.5 (16:9). Flip via the `@page` rule if 4:3 is needed
+  - `commands/slides.md` rewritten with layout docs, design rules, content discipline guidance, and the multi-format delivery pattern (HTML → PDF → pptx → Google Slides)
+
 ## [1.5.1] - 2026-03-17
 
 ### Changed

--- a/docs/pdf-playground/index.html
+++ b/docs/pdf-playground/index.html
@@ -598,7 +598,36 @@ style:
 
                 <div class="feature-card p-8 rounded-xl mb-8">
                     <div class="flex items-center gap-3 mb-4">
-                        <span class="bg-accent text-white text-xs font-bold px-3 py-1 rounded-full">v1.2.0</span>
+                        <span class="bg-accent text-white text-xs font-bold px-3 py-1 rounded-full">v1.3.0</span>
+                        <span class="text-mist text-sm">April 2026</span>
+                    </div>
+                    <h3 class="font-display text-2xl font-bold mb-4">Slide template overhaul</h3>
+                    <p class="text-mist mb-6">
+                        Nine new slide layouts and tighter typography, pulled from real presentation feedback on the Montclair State walkthrough deck. Default aspect is now 16:9 and Montserrat joins the font stack for modern decks.
+                    </p>
+                    <div class="space-y-3">
+                        <div class="flex items-start gap-3">
+                            <i data-lucide="check-circle" class="w-5 h-5 text-accent mt-0.5 flex-shrink-0"></i>
+                            <p class="text-sm"><strong>Nine new layouts</strong> &mdash; Hero photo, closing hero, photo section divider, three-column, four-tile pillars, stats strip, budget/comparison table, partner grid, and a branded red footer bar variant.</p>
+                        </div>
+                        <div class="flex items-start gap-3">
+                            <i data-lucide="check-circle" class="w-5 h-5 text-accent mt-0.5 flex-shrink-0"></i>
+                            <p class="text-sm"><strong>Tighter vertical rhythm</strong> &mdash; Headline and body padding cut to sit closer together. A tight red accent rule replaces the full-width border for a cleaner relationship between title and content.</p>
+                        </div>
+                        <div class="flex items-start gap-3">
+                            <i data-lucide="check-circle" class="w-5 h-5 text-accent mt-0.5 flex-shrink-0"></i>
+                            <p class="text-sm"><strong>16:9 default + font switching</strong> &mdash; New decks render at 13.333&times;7.5 by default. Montserrat loads alongside Playfair Display and Source Sans 3 &mdash; switch pairs via <code>--font-heading</code> and <code>--font-body</code>.</p>
+                        </div>
+                        <div class="flex items-start gap-3">
+                            <i data-lucide="check-circle" class="w-5 h-5 text-accent mt-0.5 flex-shrink-0"></i>
+                            <p class="text-sm"><strong>Multi-format delivery pattern</strong> &mdash; The <code>/slides</code> command now documents the HTML &rarr; PDF &rarr; pptx &rarr; Google Slides pipeline so a single source renders pixel-perfect across all three formats.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="feature-card p-8 rounded-xl mb-8 opacity-80">
+                    <div class="flex items-center gap-3 mb-4">
+                        <span class="bg-ink/20 text-ink text-xs font-bold px-3 py-1 rounded-full">v1.2.0</span>
                         <span class="text-mist text-sm">March 2026</span>
                     </div>
                     <h3 class="font-display text-2xl font-bold mb-4">Footer clearance overhaul</h3>

--- a/pdf-design/.claude-plugin/plugin.json
+++ b/pdf-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-design",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "PDF report and proposal design system with interactive editing",
   "author": {
     "name": "Joe Amditis",

--- a/pdf-design/SKILL.md
+++ b/pdf-design/SKILL.md
@@ -278,6 +278,189 @@ PYEOF
 
 ---
 
+## Reusable content blocks
+
+These patterns were proven out in the NJ Public TV walkthrough deck (pdf-playground 1.3.0) and work just as well inside report and proposal pages. Drop them into any `.page-body` or `.cover-footer`.
+
+### Headline with red accent rule
+
+A tight 0.95in × 0.08in red bar under the headline reads cleaner than a full-width border. Use for section headers inside content pages.
+
+```css
+.section-header h2 {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 22pt;
+    font-weight: 800;
+    color: var(--ccm-black);
+    line-height: 1.08;
+}
+
+.section-header h2::after {
+    content: '';
+    display: block;
+    width: 0.95in;
+    height: 0.08in;
+    background: var(--ccm-red);
+    margin-top: 0.14in;
+}
+```
+
+### Stats strip (big-number row)
+
+Row of 3–4 big numbers with a short caption and a red left rule. Great for executive-summary numbers on a cover or intro page.
+
+```html
+<div class="stats-strip">
+    <div class="stat"><div class="big">23,000+</div><div class="label">Students enrolled</div></div>
+    <div class="stat"><div class="big">$660M</div><div class="label">Annual operating budget</div></div>
+    <div class="stat"><div class="big">$2.3B</div><div class="label">Economic impact</div></div>
+    <div class="stat"><div class="big">252</div><div class="label">Acre main campus</div></div>
+</div>
+```
+
+```css
+.stats-strip {
+    display: grid;
+    grid-template-columns: repeat(var(--stat-cols, 4), 1fr);
+    gap: 0.3in;
+}
+.stats-strip .stat {
+    padding: 0.05in 0 0.1in 0.24in;
+    border-left: 4px solid var(--ccm-red);
+}
+.stats-strip .big {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 28pt;
+    font-weight: 800;
+    line-height: 1;
+    color: var(--ccm-black);
+    letter-spacing: -0.015em;
+}
+.stats-strip .label {
+    font-size: 9pt;
+    font-weight: 600;
+    margin-top: 0.1in;
+    color: var(--ccm-gray);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+```
+
+### Three-column content
+
+For breaking one topic into three parallel facets with a dashed divider between columns.
+
+```css
+.three-col {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 0.3in;
+}
+.three-col > div + div {
+    padding-left: 0.3in;
+    border-left: 2px dashed #d9d9d9;
+}
+.three-col h3 {
+    font-size: 10pt;
+    font-weight: 800;
+    color: var(--ccm-red);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 0.12in;
+}
+```
+
+### Four-tile pillars
+
+Numbered cards with a red top rule — for parallel capabilities, themes, or commitments. Common on proposal executive summary pages.
+
+```html
+<div class="four-col-tiles">
+    <div class="tile">
+        <div class="tile-num">Pillar 01</div>
+        <h3>Proven facilities and expertise</h3>
+        <p>Short 2–3 line description.</p>
+    </div>
+    <!-- 3 more tiles -->
+</div>
+```
+
+```css
+.four-col-tiles {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 0.15in;
+}
+.four-col-tiles .tile {
+    border-top: 4px solid var(--ccm-red);
+    padding: 0.18in 0.15in 0.15in;
+    background: #f7f6f5;
+}
+.four-col-tiles .tile-num {
+    font-size: 8pt;
+    font-weight: 800;
+    color: var(--ccm-red);
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    margin-bottom: 0.08in;
+}
+.four-col-tiles .tile h3 {
+    font-size: 12pt;
+    font-weight: 800;
+    color: var(--ccm-black);
+    margin-bottom: 0.08in;
+}
+.four-col-tiles .tile p {
+    font-size: 9pt;
+    line-height: 1.38;
+    color: var(--ccm-gray);
+    margin: 0;
+}
+```
+
+### Partner / label grid
+
+4-column grid of labeled tiles with a red left accent bar. Use for sponsor lists, letters of support, or advisory board rosters.
+
+```css
+.partner-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 0.12in 0.18in;
+}
+.partner-grid .partner {
+    position: relative;
+    padding: 0.14in 0.15in 0.14in 0.22in;
+    background: #f7f6f5;
+    font-size: 9pt;
+    font-weight: 600;
+    line-height: 1.25;
+    color: var(--ccm-black);
+}
+.partner-grid .partner::before {
+    content: '';
+    position: absolute;
+    left: 0; top: 0; bottom: 0;
+    width: 0.06in;
+    background: var(--ccm-red);
+}
+```
+
+### Vertical rhythm
+
+Every block above was tightened based on real presentation feedback. Key principles:
+
+- Accent rule sits ~0.14in below the headline, not further
+- Lede paragraph sits ~0.18in below the headline or rule
+- Body content sits ~0.22in below the lede
+- Between body sections, 0.25–0.3in gap is enough — don't add more
+- Between grid cards, use 0.15–0.2in gaps
+- The instinct to "add breathing room" almost always makes pages feel emptier rather than cleaner
+
+If a page feels too crowded, *reduce content*, don't expand spacing.
+
+---
+
 ## Known issues
 
 1. **Base64 images** — Don't read HTML with large base64 using Read tool (API error). Use sed/grep/Python.

--- a/pdf-playground/.claude-plugin/plugin.json
+++ b/pdf-playground/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-playground",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Interactive playground for creating and testing PDF reports and proposals",
   "author": {
     "name": "Joe Amditis",

--- a/pdf-playground/commands/slides.md
+++ b/pdf-playground/commands/slides.md
@@ -18,49 +18,66 @@ Read the plugin version from `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json` 
 
 ## Slide format
 
-Each slide: 10" × 7.5" (4:3) or 13.33" × 7.5" (16:9)
+Default: 16:9 widescreen (13.333" × 7.5"). Switch the `@page` rule to `10in 7.5in` for 4:3.
 
 ## Slide types
 
-**Title slide:**
-- Large centered title
-- Subtitle or presenter name
-- Date
-- Organization branding
+The template ships with layouts for most pitch- and walkthrough-style decks. Use the right one for each slide rather than forcing everything through a generic content layout.
 
-**Content slide:**
-- Slide title at top
-- Bullet points (max 5-6)
-- Slide number
+### Cover and hero
 
-**Section divider:**
-- Large section title
-- Primary color background
+**`.slide-title`** — Gradient title slide with centered headline, subtitle, presenter line. Use when no cover photo is available.
 
-**Two-column:**
-- Title at top
-- Left: text/bullets
-- Right: image or data area
+**`.slide-hero`** — Full-bleed photo background with right-aligned headline and subtitle, plus a red branded footer bar. Best for opening pitch decks. Set the background image on the `.hero-bg` child via inline style.
 
-**Quote slide:**
-- Large pull quote
-- Attribution
-- Accent styling
+**`.slide-hero.slide-closing`** — Same hero with left-aligned headline for closing "Ready on [date]" slides. The subtitle sits tight to the headline on purpose — the close reads as one unit, not two floating lines.
 
-**Stat slide:**
-- Large number
-- Description
+### Section dividers
 
-**End slide:**
-- Thank you
-- Contact info
+**`.slide-section`** — Solid red background with a large outlined section number and title. Use for clean typographic chapter breaks.
+
+**`.slide-section.with-photo`** — Photo background with a red section chip ("Section 8.1") and a large section title. Use when the deck mirrors a numbered document (RFP response, report) and reviewers need to cross-reference.
+
+### Content layouts
+
+**`.slide-content`** — Headline with red accent rule, optional `.lede` intro paragraph, and bullet list or prose. The workhorse layout. The accent rule is a tight 0.95in × 0.08in red bar under the headline, not a heavy border across the whole body.
+
+**`.slide-content.slide-two-col`** — Headline, optional lede, then two text columns with a dashed divider. Use for paired or compared topics.
+
+**`.three-col`** — Three text columns with dashed dividers. Use inside a `.slide-body` for breaking one topic into three facets (e.g., partners / programming / operations).
+
+**`.four-col-tiles`** — Four numbered tile cards with a red top rule, each containing a label ("Pillar 01"), short title, and 2–3 line description. Use for parallel capabilities or themes where each item deserves equal weight.
+
+**`.stats-strip`** — Row of big numbers with small captions, each with a red left rule. Default 4 columns — override with `style="--stat-cols: 3"` on the container. Use to summarize the top-line numbers from a longer section.
+
+**`.slide-table`** — Comparison or budget table with a red header row, gray-shaded label column, and grid rules. Use for scenario comparisons, budget tiers, or before/after data.
+
+**`.partner-grid`** — 4-column grid of label tiles with a red left accent bar. Use for letters of support, sponsor lists, or organizations.
+
+### Set pieces
+
+**`.slide-quote`** — Pull quote on a tinted background with a red left rule.
+
+**`.slide-stat`** — Single huge number centered on white. Use when one statistic carries the slide.
+
+**`.slide-end`** — Dark "thank you" closing slide with contact info.
 
 ## Design rules
 
-- Large fonts (title: 36-48pt, body: 24-28pt)
-- Minimal text (6×6 rule: max 6 bullets, 6 words each)
-- High contrast
-- Brand colors throughout
+- **Sentence case everywhere.** Never Title Case. Use `text-transform: uppercase` in CSS if you want visual caps on a section chip or hero title, but keep the source text in sentence case.
+- **Large fonts.** Title: 52–68pt. Headline: 32–36pt. Lede: 19pt bold. Body: 16pt. Footer: 10–11pt.
+- **Tight vertical rhythm.** Headline → accent rule → lede → body should feel connected, not spaced out. The template's default paddings are already tuned; don't add extra `margin-top` to children.
+- **Minimal text.** Max 5–6 bullets per slide, max 2 lines per bullet. If you need more, split the slide.
+- **Contrast.** Dark text on white, white text on red or dark photo overlays. No gray-on-gray.
+- **Brand colors.** Set `--red` on `:root` to your primary. Use `--font-heading` and `--font-body` to swap font pairs (Playfair/Source Sans for reports, Montserrat for modern decks).
+- **Photos earn their place.** Hero slides and section dividers with photos have more impact than gradient or solid-color versions. Use photos when you have good ones; fall back to gradients otherwise.
+- **Accent rule, not border-bottom.** The headline's red accent rule is tight to the title. Don't convert it to a full-width border unless you want a different visual system.
+
+## Content discipline
+
+- The lede should be one or two sentences max, sitting right below the headline.
+- Bold inline phrases in bullets anchor the most important words. Use sparingly — bolding everything bolds nothing.
+- Section chips should use the RFP/report section number ("Section 8.1") if the deck is a walkthrough, or a simple eyebrow label ("Chapter 2") otherwise.
 
 ## Presentation name
 
@@ -68,17 +85,19 @@ The name is: $ARGUMENTS
 
 If not provided, ask for:
 - Presentation title
+- Target audience (investors, selection committee, internal briefing, etc.)
 - Number of slides
-- Key topics
-- Aspect ratio preference
+- Key topics or RFP sections to walk through
+- Aspect ratio preference (default 16:9)
+- Whether photos are available for hero and divider slides
 
 ## Footer clearance (critical)
 
 Content MUST NOT touch or overlap the slide footer.
 
 - The `.slide` element MUST use `display: grid; grid-template-rows: auto 1fr auto`
-- Content slides MUST have exactly 3 direct children: `<div class="slide-header">`, `<div class="slide-body">`, `<div class="slide-footer">`
-- The content wrapper (`.slide-body`) MUST have `overflow: hidden` to prevent text bleeding
+- Content slides MUST have exactly 3 direct children: `<div class="slide-header">`, `<div class="slide-body">`, `<div class="slide-footer">` (or `.slide-footer-red` for the branded bar)
+- The `.slide-body` MUST have `overflow: hidden` to prevent text bleeding
 - Never use `position: absolute` for footers — keep them in normal document flow as the third grid row
 - Title and section slides that don't have footers can use flex layout instead
 - After generating, always take a screenshot and visually verify the bottom of each slide
@@ -86,5 +105,22 @@ Content MUST NOT touch or overlap the slide footer.
 
 ## Output
 
-Save HTML file in current working directory.
-To present: Open in browser, use print to PDF, or Decktape.
+Save HTML file in current working directory alongside a `photos/` folder for any hero/divider images.
+
+To export:
+- **PDF**: `chromium --headless=new --disable-gpu --no-sandbox --no-pdf-header-footer --print-to-pdf=out.pdf "file://$(pwd)/slides.html"`
+- **Google Slides / PowerPoint**: Screenshot each slide to PNG via `pdftoppm`, then assemble with python-pptx as full-bleed images. Upload the resulting `.pptx` to Google Drive with `mimeType: application/vnd.google-apps.presentation` to convert. This gives pixel-perfect fidelity across all three formats from a single HTML source.
+- **Text-editable PowerPoint**: Build a parallel python-pptx file with native text shapes. Use the same palette and structure but accept minor spacing differences — the trade-off is editability.
+
+## Multi-format delivery pattern
+
+When a deck needs to ship as PDF, PowerPoint, and Google Slides:
+
+1. Build the HTML deck (authoritative source)
+2. Render to PDF via Chromium headless
+3. Screenshot each slide to PNG via `pdftoppm -r 144 -png`
+4. Assemble PNGs into a `.pptx` with python-pptx (one full-bleed image per slide)
+5. Upload the `.pptx` to Google Drive with conversion to Google Slides
+6. Export the Google Slides as PDF for cross-verification
+
+All three formats share the same source pixels, so they're visually identical. Text isn't individually editable in the pptx/Slides — if editability is a requirement, build a parallel python-pptx version with native text shapes.

--- a/pdf-playground/commands/slides.md
+++ b/pdf-playground/commands/slides.md
@@ -18,7 +18,12 @@ Read the plugin version from `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json` 
 
 ## Slide format
 
-Default: 16:9 widescreen (13.333" × 7.5"). Switch the `@page` rule to `10in 7.5in` for 4:3.
+Default: 16:9 widescreen (13.333" × 7.5"). For 4:3, update both places in `templates/slides-template.html`:
+
+1. `--slide-width: 10in` on the `:root` block (drives the `.slide` width)
+2. `@page { size: 10in 7.5in; }` (drives the PDF page size — CSS variables aren't permitted inside `@page`, so it must be edited directly)
+
+If you only change one, the on-screen preview and the rendered PDF will disagree and content will clip.
 
 ## Slide types
 

--- a/pdf-playground/templates/slides-template.html
+++ b/pdf-playground/templates/slides-template.html
@@ -6,19 +6,34 @@
     <title>[Presentation Title]</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700;800&family=Source+Sans+3:wght@400;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700;800&family=Source+Sans+3:wght@400;600;700&family=Montserrat:wght@400;600;700;800&display=swap" rel="stylesheet">
     <style>
         :root {
             --red: #CA3553;
+            --red-dark: #8a2038;
+            --red-soft: #faf5f6;
             --black: #000000;
+            --ink: #141414;
+            --ink-soft: #3a3a3a;
+            --muted: #6a6a6a;
             --white: #ffffff;
-            --gray-100: #f5f4f2;
+            --gray-100: #f7f6f5;
+            --gray-200: #e7e5e2;
+            --gray-rule: #d9d9d9;
             --gray-600: #5c5754;
             --gray-800: #2d2a28;
+
+            /* Choose one font family pair by setting --font-heading / --font-body.
+               Defaults are Playfair Display + Source Sans 3 for reports.
+               For modern, sans-only decks (like the Montclair NJ Public TV walkthrough)
+               override both to 'Montserrat'. */
+            --font-heading: 'Playfair Display', Georgia, serif;
+            --font-body: 'Source Sans 3', Arial, sans-serif;
         }
 
+        /* Default 16:9 widescreen. Switch to `size: 10in 7.5in;` for 4:3. */
         @page {
-            size: 10in 7.5in; /* 4:3 aspect ratio */
+            size: 13.333in 7.5in;
             margin: 0;
         }
 
@@ -31,31 +46,33 @@
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
         body {
-            font-family: 'Source Sans 3', Arial, sans-serif;
-            font-size: 24pt;
+            font-family: var(--font-body);
+            font-size: 18pt;
             line-height: 1.4;
-            color: var(--gray-800);
+            color: var(--ink);
             background: var(--gray-600);
         }
 
         .slide {
-            width: 10in;
+            width: 13.333in;
             height: 7.5in;
             background: var(--white);
-            margin: 20px auto;
+            margin: 24px auto;
             display: grid;
             grid-template-rows: auto 1fr auto;
-            position: relative; /* needed for absolutely-positioned children like .presenter */
+            position: relative;
             overflow: hidden;
-            box-shadow: 0 4px 24px rgba(0,0,0,0.2);
+            box-shadow: 0 6px 28px rgba(0,0,0,0.35);
         }
 
         @media print {
             .slide { box-shadow: none; margin: 0; }
-            body { background: white; }
+            body { background: var(--white); }
         }
 
-        /* ========== TITLE SLIDE ========== */
+        /* ============================================================
+           TITLE SLIDE — gradient background (no photo needed)
+           ============================================================ */
         .slide-title {
             display: flex;
             flex-direction: column;
@@ -63,85 +80,258 @@
             align-items: center;
             text-align: center;
             padding: 1in;
-            background: linear-gradient(135deg, var(--red) 0%, #8a2038 100%);
+            background: linear-gradient(135deg, var(--red) 0%, var(--red-dark) 100%);
             color: var(--white);
         }
 
         .slide-title .logo {
-            font-family: 'Playfair Display', Georgia, serif;
+            font-family: var(--font-heading);
             font-size: 14pt;
             font-weight: 700;
             letter-spacing: 0.1em;
             text-transform: uppercase;
-            opacity: 0.8;
-            margin-bottom: 0.5in;
+            opacity: 0.85;
+            margin-bottom: 0.45in;
         }
 
         .slide-title h1 {
-            font-family: 'Playfair Display', Georgia, serif;
-            font-size: 48pt;
+            font-family: var(--font-heading);
+            font-size: 52pt;
             font-weight: 800;
-            line-height: 1.1;
-            margin-bottom: 0.3in;
+            line-height: 1.05;
+            margin-bottom: 0.2in;
+            max-width: 11in;
         }
 
         .slide-title .subtitle {
             font-size: 20pt;
-            opacity: 0.9;
+            font-weight: 600;
+            opacity: 0.95;
+            max-width: 10in;
         }
 
         .slide-title .presenter {
             position: absolute;
             bottom: 0.5in;
-            font-size: 14pt;
-            opacity: 0.7;
+            font-size: 13pt;
+            letter-spacing: 0.05em;
+            text-transform: uppercase;
+            opacity: 0.75;
         }
 
-        /* ========== SECTION DIVIDER ========== */
+        /* ============================================================
+           HERO PHOTO SLIDE — full-bleed background photo with overlay.
+           Set the photo via inline style on the child .hero-bg.
+           Headline is right-aligned by default to match the Montclair
+           template look.
+           ============================================================ */
+        .slide-hero {
+            grid-template-rows: 1fr auto;
+            color: var(--white);
+        }
+
+        .slide-hero .hero-bg {
+            position: absolute;
+            inset: 0;
+            background-size: cover;
+            background-position: center center;
+            z-index: 0;
+        }
+
+        .slide-hero .hero-bg::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(110deg, rgba(0,0,0,0.15) 0%, rgba(0,0,0,0.20) 45%, rgba(0,0,0,0.58) 100%);
+        }
+
+        .slide-hero .hero-content {
+            position: relative;
+            z-index: 2;
+            padding: 0.85in 0.85in 0.4in;
+            display: flex;
+            flex-direction: column;
+            justify-content: flex-start;
+            align-items: flex-end;
+            text-align: right;
+        }
+
+        .slide-hero h1 {
+            font-family: var(--font-heading);
+            font-size: 56pt;
+            font-weight: 800;
+            line-height: 1.02;
+            letter-spacing: -0.012em;
+            text-transform: uppercase;
+            max-width: 10.5in;
+            text-shadow: 0 2px 14px rgba(0,0,0,0.35);
+        }
+
+        .slide-hero .subtitle {
+            font-size: 17pt;
+            font-weight: 600;
+            margin-top: 0.35in;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            max-width: 10in;
+            opacity: 0.95;
+        }
+
+        /* Closing hero variant: headline left-aligned, subtitle tight to it.
+           Tightening the subtitle to the headline is a lesson from the
+           Montclair deck — floating it far below read as disconnected. */
+        .slide-hero.slide-closing .hero-content {
+            justify-content: center;
+            align-items: flex-start;
+            text-align: left;
+            padding: 1in 0.9in;
+        }
+
+        .slide-hero.slide-closing h1 {
+            font-size: 68pt;
+            max-width: 11in;
+        }
+
+        .slide-hero.slide-closing .subtitle {
+            margin-top: 0.22in;
+            font-size: 18pt;
+        }
+
+        /* ============================================================
+           SECTION DIVIDER — solid red (original; still works)
+           ============================================================ */
         .slide-section {
             display: flex;
             flex-direction: column;
             justify-content: center;
-            padding: 1in 1.5in;
+            padding: 0.9in 1.2in;
             background: var(--red);
             color: var(--white);
         }
 
         .slide-section .section-number {
-            font-family: 'Playfair Display', Georgia, serif;
-            font-size: 72pt;
+            font-family: var(--font-heading);
+            font-size: 64pt;
             font-weight: 800;
-            opacity: 0.3;
-            margin-bottom: 0.2in;
+            opacity: 0.28;
+            line-height: 1;
+            margin-bottom: 0.12in;
         }
 
         .slide-section h2 {
-            font-family: 'Playfair Display', Georgia, serif;
+            font-family: var(--font-heading);
             font-size: 42pt;
             font-weight: 700;
+            line-height: 1.05;
         }
 
-        /* ========== CONTENT SLIDE ========== */
-        .slide-content {
-            /* Grid child styles only — padding/overflow on .slide-body */
+        /* ============================================================
+           SECTION DIVIDER WITH PHOTO — background image + section chip.
+           Add .with-photo to .slide-section and set the photo inline.
+           ============================================================ */
+        .slide-section.with-photo {
+            padding: 0;
+            grid-template-rows: 1fr auto;
+            display: grid;
+            background: var(--ink);
         }
 
-        .slide-body {
-            padding: 0.3in 1in 0.2in;
-            overflow: hidden;
-            font-size: 24pt;
+        .slide-section.with-photo .photo-bg {
+            position: absolute;
+            inset: 0;
+            background-size: cover;
+            background-position: center;
+            z-index: 0;
         }
 
+        .slide-section.with-photo .photo-bg::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(90deg, rgba(0,0,0,0.70) 0%, rgba(0,0,0,0.45) 55%, rgba(0,0,0,0.25) 100%);
+        }
+
+        .slide-section.with-photo .section-content {
+            position: relative;
+            z-index: 2;
+            padding: 1.55in 0.85in;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: flex-start;
+        }
+
+        .slide-section.with-photo .section-chip {
+            display: inline-block;
+            font-family: var(--font-body);
+            font-size: 12pt;
+            font-weight: 700;
+            letter-spacing: 0.18em;
+            text-transform: uppercase;
+            padding: 0.1in 0.28in;
+            background: var(--red);
+            color: var(--white);
+            margin-bottom: 0.28in;
+        }
+
+        .slide-section.with-photo h2 {
+            font-size: 50pt;
+            font-weight: 800;
+            line-height: 1.02;
+            letter-spacing: -0.01em;
+            max-width: 11in;
+            text-shadow: 0 2px 14px rgba(0,0,0,0.35);
+        }
+
+        /* ============================================================
+           CONTENT SLIDE — white background, headline + red accent rule.
+           Spacing tightened based on real presentation feedback.
+           ============================================================ */
         .slide-header {
-            padding: 0.75in 1in 0.2in;
-            border-bottom: 3px solid var(--red);
+            padding: 0.55in 0.85in 0.12in;
         }
 
         .slide-header h2 {
-            font-family: 'Playfair Display', Georgia, serif;
-            font-size: 36pt;
-            font-weight: 700;
-            color: var(--black);
+            font-family: var(--font-heading);
+            font-size: 34pt;
+            font-weight: 800;
+            color: var(--ink);
+            line-height: 1.08;
+            letter-spacing: -0.005em;
+        }
+
+        /* Red accent rule under the headline. Sits tight to the title,
+           not across the full body — cleaner than a border-bottom. */
+        .slide-header h2::after {
+            content: '';
+            display: block;
+            width: 0.95in;
+            height: 0.08in;
+            background: var(--red);
+            margin-top: 0.18in;
+        }
+
+        .slide-body {
+            padding: 0.22in 0.85in 0.28in;
+            overflow: hidden;
+            font-size: 18pt;
+        }
+
+        /* Intro paragraph — sits directly under the headline, slightly heavier. */
+        .slide-body .lede {
+            font-size: 19pt;
+            font-weight: 600;
+            line-height: 1.32;
+            color: var(--ink);
+            margin-bottom: 0.28in;
+            max-width: 11.5in;
+        }
+
+        .slide-body p {
+            font-size: 16pt;
+            line-height: 1.45;
+            margin-bottom: 0.18in;
+            color: var(--ink-soft);
         }
 
         .slide-body ul {
@@ -151,57 +341,281 @@
         }
 
         .slide-body li {
-            padding: 0.15in 0;
-            padding-left: 0.4in;
             position: relative;
+            padding-left: 0.42in;
+            margin-bottom: 0.16in;
+            font-size: 16pt;
+            line-height: 1.42;
+            color: var(--ink-soft);
         }
 
         .slide-body li::before {
             content: '';
             position: absolute;
-            left: 0;
-            top: 0.35in;
-            width: 0.15in;
-            height: 0.15in;
+            left: 0.12in;
+            top: 0.16in;
+            width: 0.2in;
+            height: 0.06in;
             background: var(--red);
-            border-radius: 50%;
         }
 
+        .slide-body li strong { color: var(--ink); font-weight: 700; }
+
+        /* ============================================================
+           FOOTER — two variants. Use .slide-footer for a muted text
+           footer, or .slide-footer-red for a filled red bar (branded
+           decks with wordmarks).
+           ============================================================ */
         .slide-footer {
-            padding: 0 1in 0.4in;
+            padding: 0 0.85in 0.35in;
             display: flex;
             justify-content: space-between;
-            font-size: 12pt;
+            align-items: flex-end;
+            font-size: 11pt;
             color: var(--gray-600);
         }
 
-        .slide-number {
-            font-family: 'Playfair Display', Georgia, serif;
+        .slide-footer .slide-number {
+            font-family: var(--font-heading);
             font-weight: 700;
             color: var(--red);
         }
 
-        /* ========== TWO-COLUMN SLIDE ========== */
+        .slide-footer-red {
+            background: var(--red);
+            color: var(--white);
+            height: 0.55in;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 0 0.55in;
+            font-size: 10pt;
+            font-weight: 700;
+            letter-spacing: 0.07em;
+            text-transform: uppercase;
+        }
+
+        .slide-footer-red .wordmark {
+            height: 0.32in;
+            width: auto;
+            object-fit: contain;
+        }
+
+        /* ============================================================
+           TWO-COLUMN CONTENT
+           ============================================================ */
         .slide-two-col .slide-body {
+            display: block;
+        }
+
+        .two-col {
             display: grid;
             grid-template-columns: 1fr 1fr;
             gap: 0.5in;
         }
 
-        .column h3 {
-            font-family: 'Playfair Display', Georgia, serif;
-            font-size: 24pt;
-            font-weight: 700;
+        .two-col > div + div {
+            padding-left: 0.5in;
+            border-left: 2px dashed var(--gray-rule);
+        }
+
+        .two-col h3,
+        .three-col h3 {
+            font-family: var(--font-body);
+            font-size: 13pt;
+            font-weight: 800;
             color: var(--red);
-            margin-bottom: 0.2in;
+            margin-bottom: 0.18in;
+            line-height: 1.15;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
         }
 
-        .column p {
-            font-size: 20pt;
-            color: var(--gray-600);
+        /* ============================================================
+           THREE-COLUMN CONTENT — for breaking a topic into three
+           related facets with dashed dividers between columns.
+           ============================================================ */
+        .three-col {
+            display: grid;
+            grid-template-columns: 1fr 1fr 1fr;
+            gap: 0.4in;
         }
 
-        /* ========== QUOTE SLIDE ========== */
+        .three-col > div + div {
+            padding-left: 0.4in;
+            border-left: 2px dashed var(--gray-rule);
+        }
+
+        .three-col p,
+        .three-col li {
+            font-size: 13pt;
+            line-height: 1.4;
+            margin-bottom: 0.1in;
+            color: var(--ink-soft);
+        }
+
+        .three-col li {
+            padding-left: 0.3in;
+        }
+
+        .three-col li::before {
+            top: 0.12in;
+            left: 0.08in;
+            width: 0.16in;
+            height: 0.05in;
+        }
+
+        /* ============================================================
+           FOUR-COLUMN TILES ("pillars") — numbered cards with a
+           short description. Great for pitch-deck capabilities.
+           ============================================================ */
+        .four-col-tiles {
+            display: grid;
+            grid-template-columns: repeat(4, 1fr);
+            gap: 0.22in;
+            margin-top: 0.05in;
+        }
+
+        .four-col-tiles .tile {
+            border-top: 5px solid var(--red);
+            padding: 0.22in 0.2in 0.2in;
+            background: var(--gray-100);
+        }
+
+        .four-col-tiles .tile-num {
+            font-size: 10pt;
+            font-weight: 800;
+            color: var(--red);
+            letter-spacing: 0.15em;
+            text-transform: uppercase;
+            margin-bottom: 0.1in;
+        }
+
+        .four-col-tiles .tile h3 {
+            font-family: var(--font-heading);
+            font-size: 17pt;
+            font-weight: 800;
+            color: var(--ink);
+            line-height: 1.15;
+            margin-bottom: 0.12in;
+            text-transform: none;
+            letter-spacing: 0;
+        }
+
+        .four-col-tiles .tile p {
+            font-size: 12pt;
+            line-height: 1.38;
+            color: var(--ink-soft);
+            margin: 0;
+        }
+
+        /* ============================================================
+           STATS STRIP — row of big numbers with small labels, each
+           with a red left rule. Best with 3–4 stats.
+           Set --stat-cols on .stats-strip to change column count.
+           ============================================================ */
+        .stats-strip {
+            display: grid;
+            grid-template-columns: repeat(var(--stat-cols, 4), 1fr);
+            gap: 0.35in;
+            margin-top: 0.1in;
+        }
+
+        .stats-strip .stat {
+            padding: 0.04in 0 0.08in 0.26in;
+            border-left: 5px solid var(--red);
+        }
+
+        .stats-strip .big {
+            font-family: var(--font-heading);
+            font-size: 34pt;
+            font-weight: 800;
+            line-height: 1;
+            color: var(--ink);
+            letter-spacing: -0.015em;
+        }
+
+        .stats-strip .label {
+            font-family: var(--font-body);
+            font-size: 11pt;
+            font-weight: 600;
+            margin-top: 0.12in;
+            color: var(--muted);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            line-height: 1.25;
+        }
+
+        /* ============================================================
+           COMPARISON / BUDGET TABLE — red header row, grid rules.
+           ============================================================ */
+        .slide-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 0.15in;
+            font-size: 14pt;
+        }
+
+        .slide-table th,
+        .slide-table td {
+            padding: 0.16in 0.22in;
+            border: 1px solid var(--gray-rule);
+            text-align: left;
+            line-height: 1.25;
+            vertical-align: middle;
+        }
+
+        .slide-table thead th {
+            background: var(--red);
+            color: var(--white);
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            font-size: 11pt;
+            padding: 0.13in 0.22in;
+        }
+
+        .slide-table tbody th {
+            background: var(--gray-100);
+            color: var(--ink);
+            font-weight: 700;
+            width: 32%;
+        }
+
+        /* ============================================================
+           PARTNER / LABEL GRID — tiles for lists of sponsors,
+           organizations, or letters of support.
+           ============================================================ */
+        .partner-grid {
+            display: grid;
+            grid-template-columns: repeat(4, 1fr);
+            gap: 0.16in 0.22in;
+            margin-top: 0.18in;
+        }
+
+        .partner-grid .partner {
+            position: relative;
+            padding: 0.18in 0.2in 0.18in 0.28in;
+            background: var(--gray-100);
+            font-size: 13pt;
+            font-weight: 600;
+            line-height: 1.25;
+            color: var(--ink);
+        }
+
+        .partner-grid .partner::before {
+            content: '';
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            width: 0.08in;
+            background: var(--red);
+        }
+
+        /* ============================================================
+           QUOTE SLIDE
+           ============================================================ */
         .slide-quote {
             display: flex;
             flex-direction: column;
@@ -211,27 +625,28 @@
         }
 
         .slide-quote blockquote {
-            font-family: 'Playfair Display', Georgia, serif;
-            font-size: 32pt;
+            font-family: var(--font-heading);
+            font-size: 30pt;
             font-style: italic;
             color: var(--gray-800);
-            line-height: 1.4;
-            position: relative;
+            line-height: 1.35;
             padding-left: 0.5in;
             border-left: 4px solid var(--red);
         }
 
         .slide-quote cite {
             display: block;
-            font-family: 'Source Sans 3', Arial, sans-serif;
-            font-size: 18pt;
+            font-family: var(--font-body);
+            font-size: 16pt;
             font-style: normal;
             color: var(--gray-600);
             margin-top: 0.3in;
             padding-left: 0.5in;
         }
 
-        /* ========== STAT SLIDE ========== */
+        /* ============================================================
+           BIG STAT SLIDE — single huge number centered
+           ============================================================ */
         .slide-stat {
             display: flex;
             flex-direction: column;
@@ -242,20 +657,23 @@
         }
 
         .big-number {
-            font-family: 'Playfair Display', Georgia, serif;
-            font-size: 144pt;
+            font-family: var(--font-heading);
+            font-size: 136pt;
             font-weight: 800;
             color: var(--red);
             line-height: 1;
         }
 
         .stat-label {
-            font-size: 28pt;
+            font-size: 26pt;
             color: var(--gray-600);
             margin-top: 0.3in;
+            max-width: 9in;
         }
 
-        /* ========== END SLIDE ========== */
+        /* ============================================================
+           END SLIDE — dark background "thank you"
+           ============================================================ */
         .slide-end {
             display: flex;
             flex-direction: column;
@@ -268,79 +686,301 @@
         }
 
         .slide-end h2 {
-            font-family: 'Playfair Display', Georgia, serif;
+            font-family: var(--font-heading);
             font-size: 42pt;
             font-weight: 700;
-            margin-bottom: 0.5in;
+            margin-bottom: 0.4in;
         }
 
         .slide-end .contact {
-            font-size: 18pt;
-            opacity: 0.8;
+            font-size: 16pt;
+            opacity: 0.85;
         }
 
         .slide-end .contact a {
             color: var(--red);
+            text-decoration: none;
         }
     </style>
 </head>
 <body>
 
-    <!-- SLIDE 1: Title -->
+    <!-- ==========================================================
+         SLIDE 1 — TITLE (gradient, no photo required)
+         For a photo-backed title slide, use .slide-hero instead.
+         ========================================================== -->
     <div class="slide slide-title">
-        <div class="logo">Center for Cooperative Media</div>
+        <div class="logo">[Organization name]</div>
         <h1>[Presentation title in sentence case]</h1>
         <p class="subtitle">[Subtitle or event name]</p>
-        <p class="presenter">[Presenter Name] • [Date]</p>
+        <p class="presenter">[Presenter name] • [Date]</p>
     </div>
 
-    <!-- SLIDE 2: Section Divider -->
+    <!-- ==========================================================
+         SLIDE 2 — HERO PHOTO (branded pitch-deck style)
+         ========================================================== -->
+    <div class="slide slide-hero">
+        <div class="hero-bg" style="background-image: url('photos/campus-aerial.jpg');"></div>
+        <div class="hero-content">
+            <h1>[Deck title in sentence case]</h1>
+            <div class="subtitle">[Organization] · [Subtitle] · [Date]</div>
+        </div>
+        <div class="slide-footer-red">
+            <span>[Context line]</span>
+            <img class="wordmark" src="photos/wordmark-white.png" alt="[Organization wordmark]">
+        </div>
+    </div>
+
+    <!-- ==========================================================
+         SLIDE 3 — SECTION DIVIDER (solid red)
+         ========================================================== -->
     <div class="slide slide-section">
         <div class="section-number">01</div>
         <h2>[Section title]</h2>
     </div>
 
-    <!-- SLIDE 3: Content with bullets -->
+    <!-- ==========================================================
+         SLIDE 4 — SECTION DIVIDER WITH PHOTO
+         ========================================================== -->
+    <div class="slide slide-section with-photo">
+        <div class="photo-bg" style="background-image: url('photos/campus-detail.jpg');"></div>
+        <div class="section-content">
+            <div class="section-chip">Section 8.X</div>
+            <h2>[Section title]</h2>
+        </div>
+        <div class="slide-footer-red">
+            <span>[Context line]</span>
+            <img class="wordmark" src="photos/wordmark-white.png" alt="[Organization wordmark]">
+        </div>
+    </div>
+
+    <!-- ==========================================================
+         SLIDE 5 — CONTENT WITH BULLETS
+         The headline gets a red accent rule automatically.
+         ========================================================== -->
     <div class="slide slide-content">
         <div class="slide-header">
             <h2>[Slide title in sentence case]</h2>
         </div>
         <div class="slide-body">
+            <p class="lede">[Optional intro paragraph sitting under the headline — keep to two lines.]</p>
             <ul>
-                <li>[Key point 1 - keep it brief]</li>
-                <li>[Key point 2 - one line is ideal]</li>
-                <li>[Key point 3 - avoid paragraphs]</li>
-                <li>[Key point 4 - max 5-6 bullets]</li>
+                <li>[Key point 1 — keep it brief]</li>
+                <li>[Key point 2 — one line is ideal]</li>
+                <li><strong>[Bolded phrase]</strong> [can anchor important points]</li>
+                <li>[Key point 4 — max 5-6 bullets per slide]</li>
             </ul>
         </div>
         <div class="slide-footer">
-            <span>[Presentation Title]</span>
-            <span class="slide-number">3</span>
+            <span>[Presentation title]</span>
+            <span class="slide-number">5</span>
         </div>
     </div>
 
-    <!-- SLIDE 4: Two-column -->
+    <!-- ==========================================================
+         SLIDE 6 — TWO-COLUMN
+         ========================================================== -->
     <div class="slide slide-content slide-two-col">
         <div class="slide-header">
             <h2>[Comparison or dual topic]</h2>
         </div>
         <div class="slide-body">
-            <div class="column">
-                <h3>[Column 1 title]</h3>
-                <p>[Brief content for column 1]</p>
-            </div>
-            <div class="column">
-                <h3>[Column 2 title]</h3>
-                <p>[Brief content for column 2]</p>
+            <p class="lede">[Optional intro paragraph above the two columns.]</p>
+            <div class="two-col">
+                <div>
+                    <h3>[Column 1 heading]</h3>
+                    <ul>
+                        <li>[Point]</li>
+                        <li>[Point]</li>
+                        <li>[Point]</li>
+                    </ul>
+                </div>
+                <div>
+                    <h3>[Column 2 heading]</h3>
+                    <ul>
+                        <li>[Point]</li>
+                        <li>[Point]</li>
+                        <li>[Point]</li>
+                    </ul>
+                </div>
             </div>
         </div>
         <div class="slide-footer">
-            <span>[Presentation Title]</span>
-            <span class="slide-number">4</span>
+            <span>[Presentation title]</span>
+            <span class="slide-number">6</span>
         </div>
     </div>
 
-    <!-- SLIDE 5: Quote -->
+    <!-- ==========================================================
+         SLIDE 7 — THREE-COLUMN CONTENT
+         ========================================================== -->
+    <div class="slide slide-content">
+        <div class="slide-header">
+            <h2>[Three-facet topic]</h2>
+        </div>
+        <div class="slide-body">
+            <p class="lede">[Optional intro paragraph.]</p>
+            <div class="three-col">
+                <div>
+                    <h3>[Column 1]</h3>
+                    <p>[Short paragraph describing this facet.]</p>
+                </div>
+                <div>
+                    <h3>[Column 2]</h3>
+                    <p>[Short paragraph describing this facet.]</p>
+                </div>
+                <div>
+                    <h3>[Column 3]</h3>
+                    <p>[Short paragraph describing this facet.]</p>
+                </div>
+            </div>
+        </div>
+        <div class="slide-footer">
+            <span>[Presentation title]</span>
+            <span class="slide-number">7</span>
+        </div>
+    </div>
+
+    <!-- ==========================================================
+         SLIDE 8 — FOUR-TILE PILLARS
+         Use for four parallel capabilities, themes, or promises.
+         ========================================================== -->
+    <div class="slide slide-content">
+        <div class="slide-header">
+            <h2>[Pillars or parallel capabilities]</h2>
+        </div>
+        <div class="slide-body">
+            <p class="lede">[Optional intro paragraph.]</p>
+            <div class="four-col-tiles">
+                <div class="tile">
+                    <div class="tile-num">Pillar 01</div>
+                    <h3>[Pillar 1 name]</h3>
+                    <p>[Short description — two or three lines.]</p>
+                </div>
+                <div class="tile">
+                    <div class="tile-num">Pillar 02</div>
+                    <h3>[Pillar 2 name]</h3>
+                    <p>[Short description.]</p>
+                </div>
+                <div class="tile">
+                    <div class="tile-num">Pillar 03</div>
+                    <h3>[Pillar 3 name]</h3>
+                    <p>[Short description.]</p>
+                </div>
+                <div class="tile">
+                    <div class="tile-num">Pillar 04</div>
+                    <h3>[Pillar 4 name]</h3>
+                    <p>[Short description.]</p>
+                </div>
+            </div>
+        </div>
+        <div class="slide-footer">
+            <span>[Presentation title]</span>
+            <span class="slide-number">8</span>
+        </div>
+    </div>
+
+    <!-- ==========================================================
+         SLIDE 9 — STATS STRIP
+         ========================================================== -->
+    <div class="slide slide-content">
+        <div class="slide-header">
+            <h2>[Stats headline]</h2>
+        </div>
+        <div class="slide-body">
+            <p class="lede">[Optional intro paragraph framing the numbers.]</p>
+            <div class="stats-strip" style="--stat-cols: 4;">
+                <div class="stat"><div class="big">[Number]</div><div class="label">[Caption]</div></div>
+                <div class="stat"><div class="big">[Number]</div><div class="label">[Caption]</div></div>
+                <div class="stat"><div class="big">[Number]</div><div class="label">[Caption]</div></div>
+                <div class="stat"><div class="big">[Number]</div><div class="label">[Caption]</div></div>
+            </div>
+            <ul style="margin-top: 0.3in;">
+                <li>[Supporting bullet below the numbers]</li>
+                <li>[Another supporting bullet]</li>
+            </ul>
+        </div>
+        <div class="slide-footer">
+            <span>[Presentation title]</span>
+            <span class="slide-number">9</span>
+        </div>
+    </div>
+
+    <!-- ==========================================================
+         SLIDE 10 — COMPARISON TABLE (e.g. budget scenarios)
+         ========================================================== -->
+    <div class="slide slide-content">
+        <div class="slide-header">
+            <h2>[Comparison / budget headline]</h2>
+        </div>
+        <div class="slide-body">
+            <p class="lede">[Intro paragraph explaining the comparison.]</p>
+            <table class="slide-table">
+                <thead>
+                    <tr>
+                        <th>[Row label header]</th>
+                        <th>[Scenario A]</th>
+                        <th>[Scenario B]</th>
+                        <th>[Scenario C]</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <th>[Row 1 label]</th>
+                        <td>[Value]</td>
+                        <td>[Value]</td>
+                        <td>[Value]</td>
+                    </tr>
+                    <tr>
+                        <th>[Row 2 label]</th>
+                        <td>[Value]</td>
+                        <td>[Value]</td>
+                        <td>[Value]</td>
+                    </tr>
+                    <tr>
+                        <th>[Row 3 label]</th>
+                        <td>[Value]</td>
+                        <td>[Value]</td>
+                        <td>[Value]</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <div class="slide-footer">
+            <span>[Presentation title]</span>
+            <span class="slide-number">10</span>
+        </div>
+    </div>
+
+    <!-- ==========================================================
+         SLIDE 11 — PARTNER / LABEL GRID
+         ========================================================== -->
+    <div class="slide slide-content">
+        <div class="slide-header">
+            <h2>[Partners or letters of support]</h2>
+        </div>
+        <div class="slide-body">
+            <p class="lede">[Optional intro paragraph.]</p>
+            <div class="partner-grid">
+                <div class="partner">[Partner name]</div>
+                <div class="partner">[Partner name]</div>
+                <div class="partner">[Partner name]</div>
+                <div class="partner">[Partner name]</div>
+                <div class="partner">[Partner name]</div>
+                <div class="partner">[Partner name]</div>
+                <div class="partner">[Partner name]</div>
+                <div class="partner">[Partner name]</div>
+            </div>
+        </div>
+        <div class="slide-footer">
+            <span>[Presentation title]</span>
+            <span class="slide-number">11</span>
+        </div>
+    </div>
+
+    <!-- ==========================================================
+         SLIDE 12 — QUOTE
+         ========================================================== -->
     <div class="slide slide-quote">
         <blockquote>
             "[Impactful quote that supports your message.]"
@@ -348,18 +988,37 @@
         <cite>— [Name], [Title/Organization]</cite>
     </div>
 
-    <!-- SLIDE 6: Big stat -->
+    <!-- ==========================================================
+         SLIDE 13 — BIG STAT
+         ========================================================== -->
     <div class="slide slide-stat">
         <div class="big-number">[Number]</div>
         <div class="stat-label">[What this number represents]</div>
     </div>
 
-    <!-- SLIDE 7: End slide -->
+    <!-- ==========================================================
+         SLIDE 14 — CLOSING HERO ("Ready on [date]")
+         ========================================================== -->
+    <div class="slide slide-hero slide-closing">
+        <div class="hero-bg" style="background-image: url('photos/closing-photo.jpg');"></div>
+        <div class="hero-content">
+            <h1>[Closing headline]</h1>
+            <div class="subtitle">[One-sentence close or call to action.]</div>
+        </div>
+        <div class="slide-footer-red">
+            <span>[Context line]</span>
+            <img class="wordmark" src="photos/wordmark-white.png" alt="[Organization wordmark]">
+        </div>
+    </div>
+
+    <!-- ==========================================================
+         SLIDE 15 — END / THANK YOU
+         ========================================================== -->
     <div class="slide slide-end">
         <h2>Thank you</h2>
         <div class="contact">
             [Name] • <a href="mailto:[email]">[email]</a><br>
-            <a href="https://centerforcooperativemedia.org">centerforcooperativemedia.org</a>
+            <a href="https://example.org">example.org</a>
         </div>
     </div>
 

--- a/pdf-playground/templates/slides-template.html
+++ b/pdf-playground/templates/slides-template.html
@@ -29,11 +29,17 @@
                override both to 'Montserrat'. */
             --font-heading: 'Playfair Display', Georgia, serif;
             --font-body: 'Source Sans 3', Arial, sans-serif;
+
+            /* Slide dimensions — default 16:9 widescreen.
+               For 4:3, set --slide-width: 10in AND update the @page rule below to
+               `size: 10in 7.5in`. CSS custom properties are not permitted inside
+               @page, so the two values must be kept in sync manually. */
+            --slide-width: 13.333in;
+            --slide-height: 7.5in;
         }
 
-        /* Default 16:9 widescreen. Switch to `size: 10in 7.5in;` for 4:3. */
         @page {
-            size: 13.333in 7.5in;
+            size: 13.333in 7.5in; /* keep in sync with --slide-width / --slide-height */
             margin: 0;
         }
 
@@ -54,8 +60,8 @@
         }
 
         .slide {
-            width: 13.333in;
-            height: 7.5in;
+            width: var(--slide-width);
+            height: var(--slide-height);
             background: var(--white);
             margin: 24px auto;
             display: grid;


### PR DESCRIPTION
## Summary

Major slide template overhaul for **pdf-playground v1.3.0** based on real presentation feedback from the Montclair State / NJPBA RFP walkthrough deck that went to the state. Plus a companion update to **pdf-design v1.1.0** with reusable content blocks that work inside reports and proposals.

## What's new in pdf-playground

### New slide layouts in `templates/slides-template.html`
- **`.slide-hero`** — full-bleed photo background with right-aligned headline and red branded footer bar. Includes a `.slide-closing` variant for "Ready on [date]" closers where the subtitle sits tight to the headline.
- **`.slide-section.with-photo`** — photo-background section divider with a red section chip ("Section 8.1"). Use when the deck mirrors a numbered document.
- **`.three-col`** — three text columns with dashed dividers, for breaking a topic into parallel facets.
- **`.four-col-tiles`** — four numbered pillar cards with red top rule and short descriptions. The "four pillars" pitch-deck standard.
- **`.stats-strip`** — row of big numbers with small captions, each with a red left rule. Column count configurable via `--stat-cols`.
- **`.slide-table`** — comparison/budget table with red header row, gray label column, grid rules.
- **`.partner-grid`** — 4-column grid of labeled tiles with red left accent bar for sponsor lists and letters of support.
- **`.slide-footer-red`** — filled red footer bar with wordmark image for branded decks (alternative to muted text footer).

### Tightened existing layouts
- Slide header top padding `0.75in` → `0.55in`
- Slide body top padding `0.3in` → `0.22in`
- Red accent rule under headlines replaces full-width border-bottom — cleaner visual relationship between title and body
- Default aspect ratio `10in × 7.5in` (4:3) → `13.333in × 7.5in` (16:9)
- Montserrat added alongside Playfair Display + Source Sans 3. Switch via `--font-heading` and `--font-body` CSS variables

### `commands/slides.md` rewritten
- New layouts documented with usage guidance
- Design rules expanded: sentence case, tight vertical rhythm, content discipline
- Multi-format delivery pattern documented (HTML → PDF → pptx → Google Slides)

## What's new in pdf-design

### `SKILL.md` gets a Reusable content blocks section
Stats strip, three-column, four-tile pillars, partner grid, and headline-with-accent-rule patterns documented as drop-in blocks for report and proposal pages. Each pattern has its own HTML snippet and CSS.

### Vertical rhythm guidelines
Tighter spacing is a feature, not a bug. If a page feels crowded, reduce content — don't expand spacing.

## Test plan

- [ ] Render `slides-template.html` headlessly and verify all 15 slides come out at correct 16:9 dimensions with no footer overlap
- [ ] Visually check each new layout (hero, section-with-photo, three-col, four-col-tiles, stats-strip, slide-table, partner-grid) against the Montclair reference deck
- [ ] Run `/slides` in a fresh Claude Code session to confirm the command reads the updated template correctly
- [ ] Verify `pdf-playground/.claude-plugin/plugin.json` reports v1.3.0
- [ ] Verify `pdf-design/.claude-plugin/plugin.json` reports v1.1.0
- [ ] Spot-check that the existing 7 layouts from v1.2.0 still render identically (backward compatibility)