### PR TITLE
pdf-playground v1.3.1: SessionStart version-check hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **pdf-playground v1.3.1**: `session-start.sh` hook that checks GitHub for a newer plugin version and prints a one-line warning if the installed copy is behind
   - Fetches `.claude-plugin/plugin.json` from the repo's `master` branch (raw.githubusercontent.com) and compares with `sort -V` for correct semver ordering
-  - Rate-limited to once per 24 hours via `~/.cache/pdf-playground/last-version-check` so sessions never hit GitHub more than daily
+  - Rate-limited to once per 24 hours via `$XDG_CACHE_HOME/pdf-playground/last-version-check` when set, or `~/.cache/pdf-playground/last-version-check` otherwise. Applies to failed checks too — an offline host gets rate-limited the same way a successful one does
   - 3-second network timeout and silent failure on any error — a missing curl/jq, offline host, or GitHub outage never delays or pollutes session start
   - Points users at `/pdf-playground:update` to pull the new version
   - First proactive update nudge for the plugin — previously users had to remember to run the update command themselves

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2026-04-14
+
+### Added
+- **pdf-playground v1.3.1**: `session-start.sh` hook that checks GitHub for a newer plugin version and prints a one-line warning if the installed copy is behind
+  - Fetches `.claude-plugin/plugin.json` from the repo's `master` branch (raw.githubusercontent.com) and compares with `sort -V` for correct semver ordering
+  - Rate-limited to once per 24 hours via `~/.cache/pdf-playground/last-version-check` so sessions never hit GitHub more than daily
+  - 3-second network timeout and silent failure on any error — a missing curl/jq, offline host, or GitHub outage never delays or pollutes session start
+  - Points users at `/pdf-playground:update` to pull the new version
+  - First proactive update nudge for the plugin — previously users had to remember to run the update command themselves
+
 ## [1.6.0] - 2026-04-14
 
 ### Added

--- a/pdf-playground/.claude-plugin/plugin.json
+++ b/pdf-playground/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-playground",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Interactive playground for creating and testing PDF reports and proposals",
   "author": {
     "name": "Joe Amditis",

--- a/pdf-playground/hooks/session-start.sh
+++ b/pdf-playground/hooks/session-start.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# pdf-playground SessionStart hook — checks GitHub for a newer plugin version
+# once every 24 hours and prints a one-line warning if the installed copy is
+# out of date. Silent on network failure so the user's session never gets
+# delayed or polluted by this check.
+
+set -eu
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(dirname "$(dirname "$0")")}"
+PLUGIN_JSON="$PLUGIN_ROOT/.claude-plugin/plugin.json"
+
+# Marketplace raw URL — points at master so it always reflects the latest
+# published version of pdf-playground regardless of tag cadence.
+REMOTE_URL="https://raw.githubusercontent.com/jamditis/claude-skills-journalism/master/pdf-playground/.claude-plugin/plugin.json"
+
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/pdf-playground"
+CACHE_FILE="$CACHE_DIR/last-version-check"
+CACHE_TTL_SECONDS=86400  # 24 hours
+
+# Drain stdin — Claude Code pipes session context here and we want to
+# acknowledge it without blocking the caller. The contents are unused.
+cat > /dev/null || true
+
+# Bail silently if the local plugin.json is missing or unreadable. A broken
+# install should not make session start louder.
+[ -r "$PLUGIN_JSON" ] || exit 0
+
+# Need jq + curl for this to work at all. If either is missing, skip silently
+# — we don't want an optional update check to become a hard dependency.
+command -v jq   >/dev/null 2>&1 || exit 0
+command -v curl >/dev/null 2>&1 || exit 0
+
+LOCAL_VERSION=$(jq -r '.version // empty' "$PLUGIN_JSON" 2>/dev/null || true)
+[ -n "$LOCAL_VERSION" ] || exit 0
+
+# Rate-limit: skip the network call if the cache file was touched within the
+# last CACHE_TTL_SECONDS. This keeps us well under any sensible GitHub rate
+# limit even for users who open dozens of sessions a day.
+mkdir -p "$CACHE_DIR" 2>/dev/null || exit 0
+if [ -f "$CACHE_FILE" ]; then
+  NOW=$(date +%s)
+  LAST=$(stat -c %Y "$CACHE_FILE" 2>/dev/null || stat -f %m "$CACHE_FILE" 2>/dev/null || echo 0)
+  AGE=$(( NOW - LAST ))
+  if [ "$AGE" -lt "$CACHE_TTL_SECONDS" ]; then
+    exit 0
+  fi
+fi
+
+# Fetch with a short timeout; bail silently on any network trouble.
+REMOTE_JSON=$(curl -fsSL --max-time 3 "$REMOTE_URL" 2>/dev/null || true)
+[ -n "$REMOTE_JSON" ] || exit 0
+
+REMOTE_VERSION=$(printf '%s' "$REMOTE_JSON" | jq -r '.version // empty' 2>/dev/null || true)
+[ -n "$REMOTE_VERSION" ] || exit 0
+
+# Touch the cache file regardless of whether we print a warning — the point
+# is to rate-limit the *check*, not the warning itself.
+: > "$CACHE_FILE"
+
+# Compare with `sort -V` so 1.10.0 sorts after 1.9.0 the way a human expects.
+# If LOCAL is already >= REMOTE, nothing to say.
+LATEST=$(printf '%s\n%s\n' "$LOCAL_VERSION" "$REMOTE_VERSION" | sort -V | tail -n1)
+if [ "$LATEST" = "$LOCAL_VERSION" ]; then
+  exit 0
+fi
+
+cat <<MSG
+pdf-playground v$REMOTE_VERSION is available (installed: v$LOCAL_VERSION). Run /pdf-playground:update to upgrade, or skip with \`rm $CACHE_FILE\` to recheck later.
+MSG

--- a/pdf-playground/hooks/session-start.sh
+++ b/pdf-playground/hooks/session-start.sh
@@ -46,16 +46,21 @@ if [ -f "$CACHE_FILE" ]; then
   fi
 fi
 
+# Touch the cache file BEFORE we hit the network so a failing check is also
+# rate-limited. Without this, an offline user or a captive portal would add
+# up to --max-time seconds to every single session start until connectivity
+# returned. If we can't even create the cache file (read-only home, full
+# disk), bail silently — never propagate the error.
+if ! { : > "$CACHE_FILE"; } 2>/dev/null; then
+  exit 0
+fi
+
 # Fetch with a short timeout; bail silently on any network trouble.
 REMOTE_JSON=$(curl -fsSL --max-time 3 "$REMOTE_URL" 2>/dev/null || true)
 [ -n "$REMOTE_JSON" ] || exit 0
 
 REMOTE_VERSION=$(printf '%s' "$REMOTE_JSON" | jq -r '.version // empty' 2>/dev/null || true)
 [ -n "$REMOTE_VERSION" ] || exit 0
-
-# Touch the cache file regardless of whether we print a warning — the point
-# is to rate-limit the *check*, not the warning itself.
-: > "$CACHE_FILE"
 
 # Compare with `sort -V` so 1.10.0 sorts after 1.9.0 the way a human expects.
 # If LOCAL is already >= REMOTE, nothing to say.
@@ -65,5 +70,5 @@ if [ "$LATEST" = "$LOCAL_VERSION" ]; then
 fi
 
 cat <<MSG
-pdf-playground v$REMOTE_VERSION is available (installed: v$LOCAL_VERSION). Run /pdf-playground:update to upgrade, or skip with \`rm $CACHE_FILE\` to recheck later.
+pdf-playground v$REMOTE_VERSION is available (installed: v$LOCAL_VERSION). Run /pdf-playground:update to upgrade, or remove $CACHE_FILE to force a recheck on the next session.
 MSG


### PR DESCRIPTION
## Summary
- Adds `pdf-playground/hooks/session-start.sh` — a SessionStart hook that checks GitHub once per day for a newer plugin version and prints a one-line warning if the installed copy is behind.
- Bumps pdf-playground to v1.3.1.
- First proactive update nudge for the plugin. Before this, users had to remember to run `/pdf-playground:update` on their own cadence.

## Why
The Claude Code plugin system caches plugins by version and never broadcasts new releases. We found out the hard way that v1.3.0 would sit in user caches untouched until they happened to invoke a command that does a startup version check (which only warns *after* they try to use the plugin). A SessionStart hook nudges them at the beginning of the session instead.

## How it works
1. Read `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json` for the installed version.
2. Skip if `~/.cache/pdf-playground/last-version-check` was touched in the last 24h (rate-limit so we never hit GitHub more than daily).
3. `curl -fsSL --max-time 3` the raw `plugin.json` from the `master` branch.
4. Compare with `sort -V` so 1.10.0 sorts after 1.9.0 correctly.
5. Print a single-line warning if outdated. Silent otherwise.
6. Silent failure on any error (missing jq/curl, network timeout, bad JSON) — a broken version check should never slow down or pollute a session.

## Design notes
- **Raw `plugin.json` on master, not GitHub Releases API** — no auth, no rate limits, always reflects the latest published state.
- **24h rate limit** — keeps us well under any sensible GitHub rate limit even for users who open dozens of sessions a day.
- **Silent failure** — "fail open" favors the user: the cost of a noisy SessionStart is higher than the cost of a missed update notification.
- **`jq` + `curl` as optional dependencies** — if either is missing, the hook exits silently instead of erroring.

## Test plan
- [x] Smoke test: installed 1.0.0 vs remote 1.3.0 → prints one-line warning
- [x] Smoke test: installed 1.3.0 vs remote 1.3.0 → silent
- [x] Rate-limit: second call within 24h → silent
- [x] `bash -n` syntax check passes
- [ ] Copilot review
- [ ] Verify hook fires in a real Claude Code session after merge + local plugin update