### PR TITLE
fix: correct skill install path so SKILL.md files load

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,8 +166,9 @@ Claude Code discovers skills at `~/.claude/skills/<skill-name>/SKILL.md` — one
 ```bash
 git clone https://github.com/jamditis/claude-skills-journalism.git ~/projects/claude-skills-journalism
 cd ~/projects/claude-skills-journalism
+mkdir -p ~/.claude/skills
 cp -r source-verification ~/.claude/skills/
-# or: ln -s "$PWD/source-verification" ~/.claude/skills/source-verification
+# or: ln -sfn "$PWD/source-verification" ~/.claude/skills/source-verification
 ```
 
 Cloning the whole repo into `~/.claude/skills/journalism-skills/` nests each `SKILL.md` two levels deep and will not load.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,11 +161,16 @@ Hooks run automatically at specific workflow events. All are **non-blocking warn
 
 ## Installation
 
-Clone to `~/.claude/skills/` for automatic loading:
+Claude Code discovers skills at `~/.claude/skills/<skill-name>/SKILL.md` — one level deep. Clone anywhere, then copy or symlink individual skills into `~/.claude/skills/`:
 
 ```bash
-git clone https://github.com/jamditis/claude-skills-journalism.git ~/.claude/skills/journalism-skills
+git clone https://github.com/jamditis/claude-skills-journalism.git ~/projects/claude-skills-journalism
+cd ~/projects/claude-skills-journalism
+cp -r source-verification ~/.claude/skills/
+# or: ln -s "$PWD/source-verification" ~/.claude/skills/source-verification
 ```
+
+Cloning the whole repo into `~/.claude/skills/journalism-skills/` nests each `SKILL.md` two levels deep and will not load.
 
 ## Multi-machine workflow
 

--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ Skills load automatically when relevant to your work. Claude Code discovers skil
 ```
 git clone https://github.com/jamditis/claude-skills-journalism.git ~/projects/claude-skills-journalism
 cd ~/projects/claude-skills-journalism
+mkdir -p ~/.claude/skills
 
 # Copy individual skills you want:
 cp -r source-verification ~/.claude/skills/
 
-# Or symlink so `git pull` updates them in place:
-ln -s "$PWD/source-verification" ~/.claude/skills/source-verification
+# Or symlink so git pull updates them in place (ln -sfn replaces an existing link):
+ln -sfn "$PWD/source-verification" ~/.claude/skills/source-verification
 ```
 
 Do not clone the repo directly into `~/.claude/skills/journalism-skills/` — that nests each `SKILL.md` two levels deep and Claude Code won't find them.

--- a/README.md
+++ b/README.md
@@ -39,17 +39,20 @@ Then restart Claude Code (close and reopen). See the [PDF Playground README](./p
 
 ### Skills (manual installation)
 
-Skills load automatically when relevant to your work. To install them, clone this repo into your Claude skills directory:
+Skills load automatically when relevant to your work. Claude Code discovers skills at `~/.claude/skills/<skill-name>/SKILL.md` — one level deep. Clone this repo anywhere you like, then copy or symlink the skills you want into `~/.claude/skills/`:
 
 ```
-git clone https://github.com/jamditis/claude-skills-journalism.git ~/.claude/skills/journalism-skills
-```
+git clone https://github.com/jamditis/claude-skills-journalism.git ~/projects/claude-skills-journalism
+cd ~/projects/claude-skills-journalism
 
-Or copy individual skills:
-
-```
+# Copy individual skills you want:
 cp -r source-verification ~/.claude/skills/
+
+# Or symlink so `git pull` updates them in place:
+ln -s "$PWD/source-verification" ~/.claude/skills/source-verification
 ```
+
+Do not clone the repo directly into `~/.claude/skills/journalism-skills/` — that nests each `SKILL.md` two levels deep and Claude Code won't find them.
 
 ### For Claude.ai users
 

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -26,11 +26,15 @@ Over weeks of use, your project builds up a curated knowledge base of project-sp
 ## Install
 
 ```bash
-# As part of claude-skills-journalism:
-git clone https://github.com/jamditis/claude-skills-journalism ~/.claude/skills/journalism-skills
+# Clone claude-skills-journalism anywhere, then install the autocontext
+# skill into ~/.claude/skills/ (Claude Code discovers skills one level deep):
+git clone https://github.com/jamditis/claude-skills-journalism ~/projects/claude-skills-journalism
+mkdir -p ~/.claude/skills
+cp -r ~/projects/claude-skills-journalism/autocontext ~/.claude/skills/
+# or: ln -sfn ~/projects/claude-skills-journalism/autocontext ~/.claude/skills/autocontext
 ```
 
-Claude Code loads the plugin automatically on next launch.
+Claude Code loads the skill automatically on next launch.
 
 ## Quick start
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -970,15 +970,15 @@
                 <!-- Skills (manual) -->
                 <div class="deckle-card p-8">
                     <h3 class="font-display text-xl font-bold mb-4">Install individual skills</h3>
-                    <p class="text-sm text-mist mb-4">Skills load automatically when relevant to your work. Clone the full collection to your Claude skills directory:</p>
+                    <p class="text-sm text-mist mb-4">Skills load automatically when relevant to your work. Claude Code discovers skills at <code>~/.claude/skills/&lt;skill-name&gt;/SKILL.md</code> — one level deep. Clone the repo anywhere, then copy or symlink the skills you want:</p>
                     <div class="bg-ink text-canvas p-6 font-mono text-sm mb-4 overflow-x-auto space-y-1">
-                        <div>git clone https://github.com/jamditis/claude-skills-journalism.git ~/.claude/skills/journalism-skills</div>
-                    </div>
-                    <p class="text-sm text-mist">Or copy just the skills you want:</p>
-                    <div class="bg-ink text-canvas p-6 font-mono text-sm mb-4 overflow-x-auto space-y-1">
+                        <div>git clone https://github.com/jamditis/claude-skills-journalism.git ~/projects/claude-skills-journalism</div>
+                        <div>cd ~/projects/claude-skills-journalism</div>
+                        <div>mkdir -p ~/.claude/skills</div>
                         <div>cp -r source-verification ~/.claude/skills/</div>
+                        <div># or: ln -sfn "$PWD/source-verification" ~/.claude/skills/source-verification</div>
                     </div>
-                    <p class="text-sm text-mist">Skills activate automatically. For example, asking Claude to verify a source will use the source-verification skill.</p>
+                    <p class="text-sm text-mist">Skills activate automatically. For example, asking Claude to verify a source will use the source-verification skill. Don't clone the whole repo into <code>~/.claude/skills/journalism-skills/</code> — that nests each <code>SKILL.md</code> two levels deep and Claude Code won't find them.</p>
                 </div>
             </section>
 


### PR DESCRIPTION
## Summary
- Replace the broken clone-into-`~/.claude/skills/journalism-skills/` instruction in README.md and CLAUDE.md with a working pattern: clone anywhere, then copy or symlink individual skills into `~/.claude/skills/`.
- Add a short note explaining why nesting two levels deep doesn't work (Claude Code's skill discovery only looks at `~/.claude/skills/<name>/SKILL.md`).

## Why
Reported by Marjorie Roswell on the Knight Center MOOC Instructor's Forum ([Erratum #2, d=308032](https://www.kccourses.org/mod/forum/discuss.php?d=308032)). She followed the README instruction on Claude Code 2.1.92, got zero skills loading, and diagnosed the cause correctly: the nested clone puts each `SKILL.md` two directories deep, so the discovery scan misses all of them.

The README already showed the working pattern right below the broken clone line (`cp -r source-verification ~/.claude/skills/`), so the top and bottom of the section contradicted each other. This PR makes them consistent.

Marjorie also made a point worth honoring in the docs: she prefers installing only the skills she actually wants, not the whole bundle. The new wording defaults to per-skill copy/symlink.

## Test plan
- [ ] Verify `cp -r <skill> ~/.claude/skills/` loads the skill in Claude Code
- [ ] Verify `ln -s "$PWD/<skill>" ~/.claude/skills/<skill>` loads the skill and survives `git pull`
- [ ] Confirm the broken pattern (`~/.claude/skills/journalism-skills/`) still does not load, matching Marjorie's report