### PR TITLE
fix(autocontext): correct slash command names from hyphen to colon form

### DIFF
--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -38,18 +38,18 @@ Claude Code loads the skill automatically on next launch.
 
 ## Quick start
 
-1. Run `/autocontext-setup` to configure your preferences (identity, sensitivity, loading behavior — 10 steps total).
-2. In any project, run `/autocontext-init` to create the `.autocontext/` directory and start accumulating lessons.
+1. Run `/autocontext:setup` to configure your preferences (identity, sensitivity, loading behavior — 10 steps total).
+2. In any project, run `/autocontext:init` to create the `.autocontext/` directory and start accumulating lessons.
 3. Just use Claude Code normally. Autocontext runs in the background.
 
 ## Commands
 
 | Command | What it does |
 |---------|-------------|
-| `/autocontext-setup` | One-time setup wizard for global preferences (10 steps covering identity, test rules, loading, persistence, staleness, injection mode, correction sensitivity, baselines, playbook, and multi-machine support) |
-| `/autocontext-init` | Set up autocontext in the current project |
-| `/autocontext-review` | Review accumulated lessons — approve, edit, delete, or mark as superseded |
-| `/autocontext-status` | See how many lessons you have, their confidence levels, and any pending items |
+| `/autocontext:setup` | One-time setup wizard for global preferences (10 steps covering identity, test rules, loading, persistence, staleness, injection mode, correction sensitivity, baselines, playbook, and multi-machine support) |
+| `/autocontext:init` | Set up autocontext in the current project |
+| `/autocontext:review` | Review accumulated lessons — approve, edit, delete, or mark as superseded |
+| `/autocontext:status` | See how many lessons you have, their confidence levels, and any pending items |
 
 ## How it works under the hood
 
@@ -65,7 +65,7 @@ Autocontext uses Claude Code's hook system to run at five points in every sessio
 
 Lessons are stored in `.autocontext/lessons.json` (git-tracked). When multiple developers use Claude Code on the same repo, their lessons accumulate independently and merge on `git pull`.
 
-The union merge driver (`scripts/merge-driver.py`) handles conflicts by merging lessons from both sides, deduplicating by text, and preserving tombstoned deletions. To set it up, run `/autocontext-init` and select "Yes, set up cross-developer sharing."
+The union merge driver (`scripts/merge-driver.py`) handles conflicts by merging lessons from both sides, deduplicating by text, and preserving tombstoned deletions. To set it up, run `/autocontext:init` and select "Yes, set up cross-developer sharing."
 
 Deleted lessons use a tombstone pattern (`"deleted": true`) rather than hard deletion. This prevents a lesson deleted on one machine from being resurrected by a merge from another.
 

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -38,7 +38,7 @@ Claude Code loads the skill automatically on next launch.
 
 ## Quick start
 
-1. Run `/autocontext:setup` to configure your preferences (identity, sensitivity, loading behavior — 10 steps total).
+1. Run `/autocontext:setup` to configure your preferences (identity, sensitivity, loading behavior — 12 steps total).
 2. In any project, run `/autocontext:init` to create the `.autocontext/` directory and start accumulating lessons.
 3. Just use Claude Code normally. Autocontext runs in the background.
 
@@ -46,7 +46,7 @@ Claude Code loads the skill automatically on next launch.
 
 | Command | What it does |
 |---------|-------------|
-| `/autocontext:setup` | One-time setup wizard for global preferences (10 steps covering identity, test rules, loading, persistence, staleness, injection mode, correction sensitivity, baselines, playbook, and multi-machine support) |
+| `/autocontext:setup` | One-time setup wizard for global preferences (12 steps covering identity, test rules, loading, persistence, staleness, injection mode, correction sensitivity, baselines, playbook, multi-machine support, skill learning, and evolution settings) |
 | `/autocontext:init` | Set up autocontext in the current project |
 | `/autocontext:review` | Review accumulated lessons — approve, edit, delete, or mark as superseded |
 | `/autocontext:status` | See how many lessons you have, their confidence levels, and any pending items |

--- a/autocontext/commands/evolve.md
+++ b/autocontext/commands/evolve.md
@@ -7,10 +7,10 @@ This command improves skill .md files based on lessons accumulated in the global
 ## Argument handling
 
 The user may invoke this command with arguments:
-- `/autocontext-evolve` — default: scan and evolve interactively
-- `/autocontext-evolve --rollback <skill-name>` — restore from backup
-- `/autocontext-evolve --export` — export lessons to JSON
-- `/autocontext-evolve --import <path>` — import lessons from JSON
+- `/autocontext:evolve` — default: scan and evolve interactively
+- `/autocontext:evolve --rollback <skill-name>` — restore from backup
+- `/autocontext:evolve --export` — export lessons to JSON
+- `/autocontext:evolve --import <path>` — import lessons from JSON
 
 Parse the arguments from the user's input. If `--rollback` is present, run the rollback flow. If `--export` or `--import`, run the sync flow. Otherwise, run the default evolution flow.
 

--- a/autocontext/commands/init.md
+++ b/autocontext/commands/init.md
@@ -65,7 +65,7 @@ The script will create the following structure in `.autocontext/`:
 ├── .gitattributes           # (if sharing enabled) Configure merge driver
 ├── cache/                   # Temporary files (not git-tracked)
 │   ├── pending-lessons.json # (if ask_before_persist) Awaiting approval
-│   └── curated-pending.json # From /autocontext-review sessions
+│   └── curated-pending.json # From /autocontext:review sessions
 └── archive/                 # Tombstoned lessons (git-tracked)
     └── superseded.json      # Deleted lessons for reference
 ```
@@ -128,7 +128,7 @@ After all setup is complete, the script generates an initial playbook:
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/generate-playbook.py .autocontext/lessons.json .autocontext/playbook.md
 ```
 
-The playbook is a curated, readable summary of your project's lessons. It's automatically regenerated after each `/autocontext-review` session.
+The playbook is a curated, readable summary of your project's lessons. It's automatically regenerated after each `/autocontext:review` session.
 
 ## Completion summary
 
@@ -137,6 +137,6 @@ Once initialization is complete, you'll see a summary of what was created:
 - Configuration files created
 - Merge driver status (if applicable)
 - Path to playbook.md for reading
-- Next steps: run `/autocontext-review` to curate lessons, or just start coding
+- Next steps: run `/autocontext:review` to curate lessons, or just start coding
 
 You can now use the autocontext plugin in this project. Lessons will automatically accumulate during sessions.

--- a/autocontext/commands/review.md
+++ b/autocontext/commands/review.md
@@ -140,4 +140,4 @@ This summary confirms what changed and gives you confidence that the curation wa
 - **Low-confidence lessons first** — the review order (lowest confidence first) helps you focus on lessons that need validation
 - **Be liberal with approval** — if a lesson is still correct, approve it. This builds signal about what's truly useful.
 - **Supersede instead of delete** — if a lesson is mostly right but needs an update, supersede it rather than deleting. This preserves the learning path.
-- **Regular curation** — run `/autocontext-review` weekly or after major changes to keep lessons fresh and accurate
+- **Regular curation** — run `/autocontext:review` weekly or after major changes to keep lessons fresh and accurate

--- a/autocontext/commands/setup.md
+++ b/autocontext/commands/setup.md
@@ -61,7 +61,7 @@ Choose how new lessons discovered during sessions should be saved.
 **Question:** How should new lessons be persisted at session end?
 
 **Options:**
-- Auto-persist with curator validation (Recommended) — new lessons are automatically added, but marked for review. You can curate them later with `/autocontext-review`.
+- Auto-persist with curator validation (Recommended) — new lessons are automatically added, but marked for review. You can curate them later with `/autocontext:review`.
 - Always ask before persisting — each new lesson prompts for approval before being added.
 - Auto-persist everything — new lessons are immediately added without any review step.
 
@@ -149,7 +149,7 @@ The playbook (`playbook.md`) is a human-readable summary of all active lessons, 
 
 **Options:**
 - Auto-generate (Recommended) — regenerate `playbook.md` on every session start/end. Always up to date.
-- Manual only — only regenerate when you run `/autocontext-review`. Less overhead.
+- Manual only — only regenerate when you run `/autocontext:review`. Less overhead.
 - Disabled — no playbook file generated. Lessons are still loaded but not rendered to markdown.
 
 **Config mapping:**
@@ -181,7 +181,7 @@ When `machines` contains `"auto"`, the session-start hook resolves it to `socket
 
 #### Step 11: Skill learning
 
-Track which skills are active when corrections happen. This enables lessons to accumulate per-skill and eventually improve the skill files via `/autocontext-evolve`.
+Track which skills are active when corrections happen. This enables lessons to accumulate per-skill and eventually improve the skill files via `/autocontext:evolve`.
 
 **Question:** Do you want autocontext to track corrections per-skill?
 
@@ -196,7 +196,7 @@ If "No": set `skill_learning.enabled = false`
 
 #### Step 12: Evolution aggressiveness
 
-Controls the minimum evidence threshold for `/autocontext-evolve` to consider a lesson ready.
+Controls the minimum evidence threshold for `/autocontext:evolve` to consider a lesson ready.
 
 **Question:** How aggressive should skill evolution be?
 
@@ -260,7 +260,7 @@ After answering all questions, write `~/.claude/autocontext.json` with the colle
 
 After writing the config:
 1. Confirm setup is complete with a summary table of all settings
-2. Inform the user they can now run `/autocontext-init` in any project to start using autocontext
-3. Note they can re-run `/autocontext-setup` anytime to change settings
+2. Inform the user they can now run `/autocontext:init` in any project to start using autocontext
+3. Note they can re-run `/autocontext:setup` anytime to change settings
 
-The global config persists across all projects. Per-project `config.json` (created by `/autocontext-init`) inherits from global but can override any value.
+The global config persists across all projects. Per-project `config.json` (created by `/autocontext:init`) inherits from global but can override any value.

--- a/autocontext/commands/status.md
+++ b/autocontext/commands/status.md
@@ -10,7 +10,7 @@ Before displaying stats, the script checks if `.autocontext/` exists. If it does
 
 ```
 Autocontext not initialized for this project.
-Run '/autocontext-init' to set up knowledge tracking.
+Run '/autocontext:init' to set up knowledge tracking.
 ```
 
 Otherwise, the script reads:
@@ -116,7 +116,7 @@ Or if not configured:
 ```
 Merge driver status:
   ✗ Not configured (single-developer mode)
-  To enable, run: /autocontext-init
+  To enable, run: /autocontext:init
 ```
 
 ### 8. Pending lessons
@@ -126,7 +126,7 @@ Shows if there are lessons awaiting curation:
 ```
 Pending lessons:
   3 lessons in .autocontext/cache/pending-lessons.json (from ask_before_persist mode)
-  Run '/autocontext-review' to approve or reject.
+  Run '/autocontext:review' to approve or reject.
 ```
 
 Or if none:
@@ -152,6 +152,6 @@ This skill is read-only. No AskUserQuestion is used. The report is informational
 ## Next steps
 
 Based on the status output, you might:
-- Run `/autocontext-review` if there are lessons with low confidence or pending approval
+- Run `/autocontext:review` if there are lessons with low confidence or pending approval
 - Check stalest lessons to see if they're still valid or should be updated
 - Share the status report with team members if using cross-developer sharing

--- a/docs/autocontext/index.html
+++ b/docs/autocontext/index.html
@@ -140,7 +140,7 @@
                             <div class="flex-1">
                                 <div class="inline-block px-3 py-1 bg-amber-700/10 rounded-full text-[10px] font-bold tracking-[0.2em] uppercase text-amber-800 mb-3">New in v1.1</div>
                                 <h2 class="font-display text-2xl md:text-3xl font-black text-amber-950 leading-tight mb-3">Skill evolution: skills that rewrite themselves</h2>
-                                <p class="text-amber-900/80 text-base md:text-lg max-w-2xl mb-4">AutoContext now tracks which skills are active when corrections happen. Lessons accumulate per-skill with confidence scores. When enough evidence builds up, run <code class="bg-amber-800/10 px-2 py-0.5 rounded text-amber-900 text-sm font-mono">/autocontext-evolve</code> and Claude will rewrite the skill file itself, weaving validated lessons into the existing content.</p>
+                                <p class="text-amber-900/80 text-base md:text-lg max-w-2xl mb-4">AutoContext now tracks which skills are active when corrections happen. Lessons accumulate per-skill with confidence scores. When enough evidence builds up, run <code class="bg-amber-800/10 px-2 py-0.5 rounded text-amber-900 text-sm font-mono">/autocontext:evolve</code> and Claude will rewrite the skill file itself, weaving validated lessons into the existing content.</p>
                                 <div class="flex flex-wrap gap-4 text-sm text-amber-800/70">
                                     <span class="flex items-center gap-1.5"><i data-lucide="check" class="w-4 h-4 text-amber-700"></i> Per-skill lesson tracking</span>
                                     <span class="flex items-center gap-1.5"><i data-lucide="check" class="w-4 h-4 text-amber-700"></i> Claude-powered skill rewriting</span>
@@ -248,7 +248,7 @@
                             </div>
                             <div>
                                 <p class="text-ink font-medium mb-1">You promote it to the global skill store</p>
-                                <p class="text-sm">During <code>/autocontext-review</code>, select "Promote to global" on a high-confidence skill-tagged lesson. It moves from your project's local store to <code>~/.claude/skill-lessons/</code>.</p>
+                                <p class="text-sm">During <code>/autocontext:review</code>, select "Promote to global" on a high-confidence skill-tagged lesson. It moves from your project's local store to <code>~/.claude/skill-lessons/</code>.</p>
                                 <p class="text-xs text-accent mt-1">Now available across all projects that use this skill</p>
                             </div>
                         </div>
@@ -257,7 +257,7 @@
                                 <i data-lucide="wand-2" class="w-5 h-5 text-accent"></i>
                             </div>
                             <div>
-                                <p class="text-ink font-medium mb-1">Run <code>/autocontext-evolve</code> to rewrite the skill</p>
+                                <p class="text-ink font-medium mb-1">Run <code>/autocontext:evolve</code> to rewrite the skill</p>
                                 <p class="text-sm">Claude reads the current skill file and all eligible lessons, then generates an improved version with the lessons woven in naturally. You review a diff and approve, reject, or edit.</p>
                                 <p class="text-xs text-accent mt-1">The skill file itself gets better &#8212; not just a sidecar</p>
                             </div>
@@ -286,9 +286,9 @@
                             <div class="pl-4">Each session &#8594; session-end.sh bumps confidence if unchallenged</div>
                             <div class="pl-4">Multiple sessions &#8594; lesson reaches high confidence (0.85+)</div>
                             <div class="mt-3 text-ink font-semibold">Promote</div>
-                            <div class="pl-4">/autocontext-review &#8594; "Promote to global" &#8594; ~/.claude/skill-lessons/</div>
+                            <div class="pl-4">/autocontext:review &#8594; "Promote to global" &#8594; ~/.claude/skill-lessons/</div>
                             <div class="mt-3 text-ink font-semibold">Evolve</div>
-                            <div class="pl-4">/autocontext-evolve &#8594; scan eligible &#8594; claude -p rewrites skill</div>
+                            <div class="pl-4">/autocontext:evolve &#8594; scan eligible &#8594; claude -p rewrites skill</div>
                             <div class="pl-4">Review diff &#8594; accept/reject/edit &#8594; skill file updated</div>
                             <div class="pl-4">Lessons marked as folded &#8594; backup created</div>
                         </div>
@@ -425,12 +425,12 @@
                         <p class="text-lg text-mist mb-8">Everything runs through slash commands. The hooks do the heavy lifting in the background.</p>
                     </div>
                     <div class="space-y-4">
-                        <div class="feature-card p-5 rounded-xl"><code class="text-accent font-semibold">/autocontext-setup</code><p class="text-mist text-sm mt-2">One-time wizard. 12 steps covering identity, test rules, loading, persistence, staleness, pre-edit warnings, correction sensitivity, performance baselines, playbook generation, multi-machine support, skill learning, and evolution settings.</p></div>
-                        <div class="feature-card p-5 rounded-xl"><code class="text-accent font-semibold">/autocontext-init</code><p class="text-mist text-sm mt-2">Initialize in a project. Creates <code>.autocontext/</code>, optionally seeds from CLAUDE.md.</p></div>
-                        <div class="feature-card p-5 rounded-xl"><code class="text-accent font-semibold">/autocontext-review</code><p class="text-mist text-sm mt-2">Curate lessons interactively. Approve, edit, delete, supersede, or promote to global skill store.</p></div>
-                        <div class="feature-card p-5 rounded-xl"><code class="text-accent font-semibold">/autocontext-status</code><p class="text-mist text-sm mt-2">Quick stats. Lesson counts, confidence averages, stalest lessons, merge driver status.</p></div>
+                        <div class="feature-card p-5 rounded-xl"><code class="text-accent font-semibold">/autocontext:setup</code><p class="text-mist text-sm mt-2">One-time wizard. 12 steps covering identity, test rules, loading, persistence, staleness, pre-edit warnings, correction sensitivity, performance baselines, playbook generation, multi-machine support, skill learning, and evolution settings.</p></div>
+                        <div class="feature-card p-5 rounded-xl"><code class="text-accent font-semibold">/autocontext:init</code><p class="text-mist text-sm mt-2">Initialize in a project. Creates <code>.autocontext/</code>, optionally seeds from CLAUDE.md.</p></div>
+                        <div class="feature-card p-5 rounded-xl"><code class="text-accent font-semibold">/autocontext:review</code><p class="text-mist text-sm mt-2">Curate lessons interactively. Approve, edit, delete, supersede, or promote to global skill store.</p></div>
+                        <div class="feature-card p-5 rounded-xl"><code class="text-accent font-semibold">/autocontext:status</code><p class="text-mist text-sm mt-2">Quick stats. Lesson counts, confidence averages, stalest lessons, merge driver status.</p></div>
                         <div class="feature-card p-5 rounded-xl border-2 border-accent/20" style="background: linear-gradient(135deg, rgba(26, 107, 90, 0.05) 0%, white 100%);">
-                            <div class="flex items-center gap-2"><code class="text-accent font-semibold">/autocontext-evolve</code><span class="text-[9px] font-bold tracking-wider uppercase bg-accent/10 text-accent px-2 py-0.5 rounded">new</span></div>
+                            <div class="flex items-center gap-2"><code class="text-accent font-semibold">/autocontext:evolve</code><span class="text-[9px] font-bold tracking-wider uppercase bg-accent/10 text-accent px-2 py-0.5 rounded">new</span></div>
                             <p class="text-mist text-sm mt-2">Fold validated lessons into skill files. Claude rewrites the skill with lessons woven in naturally. Supports <code>--rollback</code>, <code>--export</code>, and <code>--import</code> for backup and cross-machine sync.</p>
                         </div>
                     </div>
@@ -456,8 +456,8 @@
                     <div class="feature-card p-8 rounded-xl">
                         <div class="flex items-center gap-4 mb-4"><span class="w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">3</span><h3 class="font-display text-xl font-bold">Set up and initialize</h3></div>
                         <p class="text-mist mb-4">Run the setup wizard, then initialize in your project.</p>
-                        <pre><code>/autocontext-setup    # one-time global config
-/autocontext-init     # per-project initialization</code></pre>
+                        <pre><code>/autocontext:setup    # one-time global config
+/autocontext:init     # per-project initialization</code></pre>
                     </div>
                 </div>
             </div>
@@ -478,7 +478,7 @@
                     </div>
                     <div class="feature-card p-5 rounded-xl">
                         <h3 class="font-display text-base font-bold mb-1">Claude-powered rewriting</h3>
-                        <p class="text-mist text-sm">Run <code>/autocontext-evolve</code> and Claude rewrites the skill file with validated lessons woven in naturally. Review the diff before accepting.</p>
+                        <p class="text-mist text-sm">Run <code>/autocontext:evolve</code> and Claude rewrites the skill file with validated lessons woven in naturally. Review the diff before accepting.</p>
                     </div>
                     <div class="feature-card p-5 rounded-xl">
                         <h3 class="font-display text-base font-bold mb-1">Backup and rollback</h3>
@@ -490,7 +490,7 @@
                     </div>
                     <div class="feature-card p-5 rounded-xl">
                         <h3 class="font-display text-base font-bold mb-1">Fully opt-in</h3>
-                        <p class="text-mist text-sm">Disabled by default. Enable via <code>/autocontext-setup</code> step 11, or set <code>skill_learning.enabled: true</code> in config. Zero overhead if you don't use it.</p>
+                        <p class="text-mist text-sm">Disabled by default. Enable via <code>/autocontext:setup</code> step 11, or set <code>skill_learning.enabled: true</code> in config. Zero overhead if you don't use it.</p>
                     </div>
                 </div>
             </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -322,7 +322,7 @@
                             <div class="flex-1">
                                 <div class="inline-block px-3 py-1 bg-white/15 rounded-full text-[10px] font-bold tracking-[0.3em] uppercase text-white/90 mb-4">New in v1.1</div>
                                 <h2 class="font-display text-3xl md:text-4xl font-black text-white leading-tight mb-3">Skills that improve themselves.</h2>
-                                <p class="text-white/75 text-base md:text-lg max-w-xl">AutoContext now tracks which skills are active when you correct Claude. Lessons accumulate per-skill, and <code class="bg-white/10 px-2 py-0.5 rounded text-white/90 text-sm">/autocontext-evolve</code> folds them back into the skill files. Your skills get better every time you use them.</p>
+                                <p class="text-white/75 text-base md:text-lg max-w-xl">AutoContext now tracks which skills are active when you correct Claude. Lessons accumulate per-skill, and <code class="bg-white/10 px-2 py-0.5 rounded text-white/90 text-sm">/autocontext:evolve</code> folds them back into the skill files. Your skills get better every time you use them.</p>
                             </div>
                             <div class="flex-shrink-0">
                                 <span class="inline-flex items-center gap-2 bg-white text-[#1a6b5a] font-bold text-sm px-6 py-3 rounded-lg group-hover:bg-white/90 transition-colors">Learn more <span class="group-hover:translate-x-1 transition-transform">&rarr;</span></span>
@@ -346,7 +346,7 @@
                             <span class="featured-badge" style="background: linear-gradient(135deg, #1a6b5a 0%, #135346 100%);">Self-improving</span>
                         </div>
                         <h3 class="font-display text-lg font-bold mb-2 group-hover:text-[#1a6b5a] transition-colors">autocontext</h3>
-                        <p class="text-sm text-mist leading-relaxed">Cross-session knowledge persistence with skill evolution. Lessons accumulate per-skill, and <code class="text-xs">/autocontext-evolve</code> folds them back into skill files.</p>
+                        <p class="text-sm text-mist leading-relaxed">Cross-session knowledge persistence with skill evolution. Lessons accumulate per-skill, and <code class="text-xs">/autocontext:evolve</code> folds them back into skill files.</p>
                         <div class="flex flex-wrap gap-2 mt-3">
                             <span class="text-[8px] bg-[#1a6b5a]/10 text-[#1a6b5a] px-2 py-1 rounded font-semibold">Skill evolution</span>
                             <span class="text-[8px] bg-[#1a6b5a]/10 text-[#1a6b5a] px-2 py-1 rounded font-semibold">Hooks</span>


### PR DESCRIPTION
## Summary

The autocontext plugin documented its slash commands as `/autocontext-setup`, `/autocontext-init`, etc. since v1.0. Claude Code's plugin system namespaces commands as `/<plugin>:<command>`, so the actual working names are `/autocontext:setup`, `/autocontext:init`, `/autocontext:review`, `/autocontext:status`, `/autocontext:evolve`. The hyphen form has never resolved — users following the docs got "command not recognized" on every attempt.

The most insidious case was inside the `commands/*.md` files themselves: when a user runs `/autocontext:setup`, Claude reads `setup.md`, sees instructions referencing `/autocontext-review`, and parrots the wrong name back. So the broken docs self-perpetuated through the plugin runtime.

Found while answering a Knight Center MOOC student who hit this wall on Windows.

## Changes

All hyphen-form references in user-facing files swapped to colon form:

| File | Refs fixed |
|---|---|
| `autocontext/README.md` | 7 |
| `autocontext/commands/init.md` | 3 |
| `autocontext/commands/evolve.md` | 4 |
| `autocontext/commands/review.md` | 1 |
| `autocontext/commands/setup.md` | 7 |
| `autocontext/commands/status.md` | 4 |
| `docs/autocontext/index.html` | 14 |
| `docs/index.html` | 2 |

Total: **8 files, 42 references**, +/- balanced (every change is a single character: `-` → `:`).

Also corrects the setup wizard step count in `autocontext/README.md` from "10 steps" to "12 steps" — `commands/setup.md` was extended with skill learning (step 11) and evolution aggressiveness (step 12), and the README never caught up. Caught by Copilot review.

## Deliberately left alone

Historical artifacts kept as records of what shipped at the time:

- `CHANGELOG.md` (4 refs)
- `docs/superpowers/plans/2026-03-14-skill-evolution.md` (16 refs)
- `docs/superpowers/specs/2026-03-14-skill-evolution-design.md` (18 refs)

## Test plan

- [ ] Confirm `/autocontext:setup` tab-completes in a fresh Claude Code session with the plugin installed
- [ ] Confirm `/autocontext:init`, `/autocontext:review`, `/autocontext:status`, `/autocontext:evolve` all resolve
- [ ] Spot-check the rendered docs site (jamditis.github.io/claude-skills-journalism/autocontext) shows colon form
- [ ] Verify the CHANGELOG was not touched
