### PR TITLE
Reflect blocking hooks in CLAUDE.md hooks-section summary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ Instructions, templates, and workflows.
 
 ## Hooks
 
-Hooks run automatically at specific workflow events. All are **non-blocking warnings**.
+Hooks run automatically at specific workflow events. Most are **non-blocking warnings**, but `one-way-door-check` and `enforce-test-first` block intentionally (exit 2) — see per-hook frontmatter for exact behavior.
 
 ### Writing quality
 | Hook | Event | Purpose |


### PR DESCRIPTION
## Summary

`CLAUDE.md` line 126 claimed: *"Hooks run automatically at specific workflow events. All are **non-blocking warnings**."*

That contradicted the Development table at the bottom of the same section, which already used "Block" in the Purpose column for two hooks:

- `one-way-door-check` — `PreToolUse(Write)`, exits 2 to prevent creation of files representing irreversible architectural decisions
- `enforce-test-first` — `PreToolUse(Edit,Write)`, blocks source edits during bug fixing until a test is written

Both hooks describe themselves as blockers in their own frontmatter `description:` fields.

## Why

PR #28's Copilot review caught the same drift in `.github/copilot-instructions.md` and reworded it there ("most hooks are non-blocking but some block intentionally"). The fix never propagated to `CLAUDE.md`, leaving two parallel docs out of sync.

Logged as #29.

## Fix

Reword the summary sentence to:

- acknowledge that most hooks are non-blocking
- name both intentional blockers
- mention exit 2 as the block mechanism
- point at per-hook frontmatter as the source of truth for exact behavior

The Development table is already accurate, so this is a one-line edit.

## Test plan

- [x] `git diff` confirms a single-line change in CLAUDE.md
- [x] New sentence is consistent with the per-hook frontmatter `description:` fields
- [x] New sentence is consistent with `.github/copilot-instructions.md` rule #4 phrasing
- [ ] Copilot PR review pass