### PR TITLE
Correct hook-mechanism details in CLAUDE.md (Copilot review on #31)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ Instructions, templates, and workflows.
 
 ## Hooks
 
-Hooks run automatically at specific workflow events. Most are **non-blocking warnings**, but `one-way-door-check` and `enforce-test-first` block intentionally (exit 2) — see per-hook frontmatter for exact behavior.
+Hooks run automatically at specific workflow events. Most are **non-blocking warnings**, but `one-way-door-check` (shell hook, exits 2) and `enforce-test-first` (prompt-based) block intentionally — see each hook's "Hook behavior" section for details.
 
 ### Writing quality
 | Hook | Event | Purpose |


### PR DESCRIPTION
## Summary

Address two factual errors Copilot flagged on #31 (already merged).

1. **Exit 2 over-attribution.** PR #31 wrote "block intentionally (exit 2)" for both hooks, but only `one-way-door-check` is a shell hook that exits 2. `enforce-test-first` is a prompt-based hook — Claude evaluates the criteria and decides whether to block by returning an error message. Different mechanism.

2. **Wrong pointer location.** PR #31 said "see per-hook frontmatter for exact behavior", but frontmatter only has the `description:` field. The actual blocking mechanism is documented in each hook body under `## Hook behavior` (e.g. `one-way-door-check.md:46` is `### When it blocks (exit code 2)`). Updated the pointer.

## Diff

```
- Hooks run automatically at specific workflow events. Most are **non-blocking warnings**, but `one-way-door-check` and `enforce-test-first` block intentionally (exit 2) — see per-hook frontmatter for exact behavior.
+ Hooks run automatically at specific workflow events. Most are **non-blocking warnings**, but `one-way-door-check` (shell hook, exits 2) and `enforce-test-first` (prompt-based) block intentionally — see each hook's "Hook behavior" section for details.
```

Refs #29.

## Test plan

- [x] `enforce-test-first.md` "Implementation notes" section confirms it is prompt-based, not exit-coded
- [x] `one-way-door-check.md:46` confirms exit-code-2 mechanism documented under "Hook behavior", not frontmatter
- [x] Diff is a single-line wording change