### PR TITLE
superjawn Batch 1: scaffold plugin + foundation skills with research phase

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -39,6 +39,17 @@
       },
       "source": "./pdf-playground",
       "category": "Productivity"
+    },
+    {
+      "name": "superjawn",
+      "description": "Research-augmented skills derived from obra/superpowers — default-on research phase per skill",
+      "version": "0.1.0",
+      "author": {
+        "name": "Joe Amditis",
+        "email": "jamditis@gmail.com"
+      },
+      "source": "./superjawn",
+      "category": "Productivity"
     }
   ]
 }

--- a/plans/2026-05-05-superjawn-batch-1.md
+++ b/plans/2026-05-05-superjawn-batch-1.md
@@ -1,0 +1,1092 @@
+# superjawn Batch 1 implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bootstrap the `superjawn` plugin inside `claude-skills-journalism` and port the foundation triad of skills (`brainstorming`, `writing-plans`, `executing-plans`) with a default-on research phase wired into each.
+
+**Architecture:** New plugin directory `superjawn/` registered in the existing marketplace. Upstream MIT-licensed skill files copied into `superjawn/skills/<name>/`, modified to add a `## Research phase` section per the design spec's Section 2 taxonomy, with cross-references to ported skills rewritten to `superjawn:` namespace and references to not-yet-ported skills temporarily kept at `superpowers:` (dual-namespace mode). Both upstream `superpowers` and `superjawn` plugins stay enabled during the migration; upstream gets disabled only at v1.0.0.
+
+**Tech Stack:** Markdown (skill files), JSON (plugin manifest + marketplace), bash (smoke tests).
+
+**Source spec:** `specs/2026-05-05-superjawn-research-phases-design.md` (commit `ef80468` on branch `docs/superjawn-research-phases-spec`).
+
+**Scope:** Plugin scaffold + Batch 1 only. Batches 2–5 each get their own plan generated after Batch 1 lands and is validated.
+
+---
+
+## File structure
+
+**Created in this plan:**
+
+```
+superjawn/
+├── .claude-plugin/
+│   └── plugin.json                                    # Plugin manifest
+├── LICENSE                                            # MIT, dual copyright Jesse Vincent + Joe Amditis
+├── CREDITS.md                                         # Upstream attribution + baseline tracking
+├── README.md                                          # Description, install, disable-upstream notes
+└── skills/
+    ├── brainstorming/
+    │   ├── SKILL.md                                   # Modified copy of upstream
+    │   ├── visual-companion.md                        # Verbatim copy of upstream
+    │   ├── spec-document-reviewer-prompt.md           # Verbatim copy of upstream
+    │   └── scripts/
+    │       ├── frame-template.html                    # Verbatim
+    │       ├── helper.js                              # Verbatim
+    │       ├── server.cjs                             # Verbatim
+    │       ├── start-server.sh                        # Verbatim
+    │       └── stop-server.sh                         # Verbatim
+    ├── writing-plans/
+    │   ├── SKILL.md                                   # Modified copy of upstream
+    │   └── plan-document-reviewer-prompt.md           # Verbatim copy
+    └── executing-plans/
+        └── SKILL.md                                   # Modified copy of upstream
+```
+
+**Modified in this plan:**
+
+```
+.claude-plugin/marketplace.json                        # Add superjawn entry
+```
+
+**Responsibility split:**
+- `plugin.json` declares the plugin to Claude Code's plugin loader
+- `LICENSE` + `CREDITS.md` carry the MIT obligations
+- `README.md` is human documentation
+- Each `SKILL.md` is the agent-facing skill text Claude reads at invocation
+- The non-SKILL files inside each skill directory are reference material the SKILL.md links to (visual companion, reviewer prompts, browser-companion server scripts) — copied verbatim because they don't need research-phase additions
+
+---
+
+## Task 1: Scaffold plugin directory + manifest
+
+**Files:**
+- Create: `superjawn/.claude-plugin/plugin.json`
+
+- [ ] **Step 1: Create directory structure**
+
+```bash
+cd ~/projects/claude-skills-journalism
+mkdir -p superjawn/.claude-plugin superjawn/skills
+```
+
+- [ ] **Step 2: Create plugin manifest**
+
+Write `superjawn/.claude-plugin/plugin.json`:
+
+```json
+{
+  "name": "superjawn",
+  "version": "0.1.0",
+  "description": "Research-augmented skills derived from obra/superpowers — adds default-on research phases to each skill in the workflow",
+  "author": {
+    "name": "Joe Amditis",
+    "email": "jamditis@gmail.com"
+  }
+}
+```
+
+- [ ] **Step 3: Verify file is valid JSON**
+
+```bash
+python3 -c "import json; json.load(open('superjawn/.claude-plugin/plugin.json'))"
+```
+
+Expected: no output (success). Any output = parse error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add superjawn/.claude-plugin/plugin.json
+git commit -m "feat(superjawn): scaffold plugin manifest"
+```
+
+---
+
+## Task 2: Add LICENSE and CREDITS.md
+
+**Files:**
+- Create: `superjawn/LICENSE`
+- Create: `superjawn/CREDITS.md`
+
+- [ ] **Step 1: Write LICENSE (MIT, dual copyright)**
+
+Write `superjawn/LICENSE`:
+
+```
+MIT License
+
+Copyright (c) 2025 Jesse Vincent (original superpowers skills)
+Copyright (c) 2026 Joe Amditis (superjawn modifications)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+- [ ] **Step 2: Write CREDITS.md**
+
+Write `superjawn/CREDITS.md`:
+
+```markdown
+# Credits
+
+`superjawn` is a research-augmented variant of the [superpowers](https://github.com/obra/superpowers) plugin by Jesse Vincent. Original work is MIT-licensed; modifications carry the same license.
+
+## Upstream baseline
+
+Synced against upstream `obra/superpowers` v5.0.7 (commit: <fill in upstream commit SHA at first port>) on 2026-05-05.
+
+## Upstream changes ported since baseline
+
+(none yet — list each port as it lands, with link to upstream commit)
+
+## Modifications from upstream
+
+Each skill in this plugin adds a `## Research phase` section relative to the upstream version. See `specs/2026-05-05-superjawn-research-phases-design.md` for the design rationale.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add superjawn/LICENSE superjawn/CREDITS.md
+git commit -m "feat(superjawn): add LICENSE and upstream attribution"
+```
+
+---
+
+## Task 3: Add README.md
+
+**Files:**
+- Create: `superjawn/README.md`
+
+- [ ] **Step 1: Write README**
+
+Write `superjawn/README.md`:
+
+```markdown
+# superjawn
+
+Research-augmented Claude Code skills derived from [obra/superpowers](https://github.com/obra/superpowers) v5.0.7. Each skill grows a default-on research phase tailored to its stage of the workflow — gather trends, pitfalls, patterns, and discourse before building or proposing.
+
+## Skills
+
+| Skill | Status |
+|---|---|
+| `brainstorming` | Ported (Batch 1) |
+| `writing-plans` | Ported (Batch 1) |
+| `executing-plans` | Ported (Batch 1) |
+| `systematic-debugging` | Pending (Batch 2) |
+| `test-driven-development` | Pending (Batch 2) |
+| `verification-before-completion` | Pending (Batch 2) |
+| `receiving-code-review` | Pending (Batch 3) |
+| `requesting-code-review` | Pending (Batch 3) |
+| `subagent-driven-development` | Pending (Batch 4) |
+| `dispatching-parallel-agents` | Pending (Batch 4) |
+| `using-git-worktrees` | Pending (Batch 4) |
+| `finishing-a-development-branch` | Pending (Batch 5) |
+| `using-superjawn` | Pending (Batch 5) |
+| `writing-skills` | Pending (Batch 5) |
+
+## Coexistence with upstream
+
+During the rollout (v0.1.0 through v0.5.0), keep both `superpowers` and `superjawn` plugins installed. Skills not yet ported still resolve via `superpowers:<skill>`. At v1.0.0, after at least 2 weeks of real use of the full set, disable the upstream `superpowers` plugin in your Claude Code config.
+
+## Research phase
+
+Every ported skill includes a `## Research phase` section. By default, the research runs via subagent dispatch (`Explore` for codebase questions, `general-purpose` for web/discourse). Findings are written into the skill's existing artifact (spec, plan, debug log). Skipping research requires an explicit, justified line in the artifact — see each skill's Skip protocol.
+
+## Credits
+
+See `CREDITS.md`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add superjawn/README.md
+git commit -m "docs(superjawn): add README with skill status table and coexistence notes"
+```
+
+---
+
+## Task 4: Register superjawn in marketplace.json
+
+**Files:**
+- Modify: `.claude-plugin/marketplace.json`
+
+- [ ] **Step 1: Read current marketplace.json**
+
+```bash
+cat .claude-plugin/marketplace.json | python3 -m json.tool | head -40
+```
+
+Note the existing plugin entries (autocontext, pdf-design, pdf-playground) — superjawn entry will follow the same shape.
+
+- [ ] **Step 2: Add superjawn entry**
+
+Edit `.claude-plugin/marketplace.json`. Inside the `"plugins"` array, add a new object after the existing entries:
+
+```json
+    {
+      "name": "superjawn",
+      "description": "Research-augmented skills derived from obra/superpowers — default-on research phase per skill",
+      "version": "0.1.0",
+      "author": {
+        "name": "Joe Amditis",
+        "email": "jamditis@gmail.com"
+      },
+      "source": "./superjawn",
+      "category": "Productivity"
+    }
+```
+
+Insert with a leading comma after the previous entry's closing brace.
+
+- [ ] **Step 3: Verify JSON parses**
+
+```bash
+python3 -c "import json; m = json.load(open('.claude-plugin/marketplace.json')); names = [p['name'] for p in m['plugins']]; print(names)"
+```
+
+Expected output: `['autocontext', 'pdf-design', 'pdf-playground', 'superjawn']`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude-plugin/marketplace.json
+git commit -m "feat(marketplace): register superjawn plugin"
+```
+
+---
+
+## Task 5: Install superjawn locally and verify it loads
+
+**Files:** None (install-only step)
+
+- [ ] **Step 1: Install plugin from local path**
+
+```bash
+claude plugin install ~/projects/claude-skills-journalism/superjawn
+```
+
+Expected: success message naming `superjawn` v0.1.0.
+
+- [ ] **Step 2: Verify it appears in plugin list**
+
+```bash
+claude plugin list | grep superjawn
+```
+
+Expected: one line showing `superjawn 0.1.0`.
+
+- [ ] **Step 3: Verify zero skills currently registered**
+
+The plugin manifest is loaded but no skills exist yet. The model should not see any `superjawn:<skill>` triggers. To confirm, start a fresh `claude` session and check the available-skills list — `superjawn:` should not appear.
+
+If `superjawn:` skills are listed despite empty `skills/` directory, debug before continuing.
+
+---
+
+## Task 6: Port `brainstorming` — copy upstream files
+
+**Files:**
+- Create: `superjawn/skills/brainstorming/` (full upstream tree)
+
+- [ ] **Step 1: Copy upstream brainstorming directory**
+
+```bash
+cp -r ~/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.7/skills/brainstorming \
+      ~/projects/claude-skills-journalism/superjawn/skills/brainstorming
+```
+
+- [ ] **Step 2: Verify all 8 files copied**
+
+```bash
+find superjawn/skills/brainstorming -type f | sort
+```
+
+Expected (8 files):
+
+```
+superjawn/skills/brainstorming/SKILL.md
+superjawn/skills/brainstorming/scripts/frame-template.html
+superjawn/skills/brainstorming/scripts/helper.js
+superjawn/skills/brainstorming/scripts/server.cjs
+superjawn/skills/brainstorming/scripts/start-server.sh
+superjawn/skills/brainstorming/scripts/stop-server.sh
+superjawn/skills/brainstorming/spec-document-reviewer-prompt.md
+superjawn/skills/brainstorming/visual-companion.md
+```
+
+If any are missing, re-run Step 1 and check for cp errors.
+
+- [ ] **Step 3: Verify SKILL.md is unchanged from upstream**
+
+```bash
+diff superjawn/skills/brainstorming/SKILL.md \
+     ~/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.7/skills/brainstorming/SKILL.md
+```
+
+Expected: no output (files identical at this point — modifications come in next task).
+
+---
+
+## Task 7: Port `brainstorming` — add MIT attribution + research phase
+
+**Files:**
+- Modify: `superjawn/skills/brainstorming/SKILL.md`
+
+The existing brainstorming SKILL.md has a checklist with 9 items at "## Checklist". The research phase fits BETWEEN item 3 ("Ask clarifying questions") and item 4 ("Propose 2-3 approaches"). The skill's process flow `digraph` also needs a new `Research phase` node added between those two.
+
+- [ ] **Step 1: Add MIT attribution comment to SKILL.md**
+
+Edit `superjawn/skills/brainstorming/SKILL.md`. Add this HTML comment immediately AFTER the YAML frontmatter (after the closing `---`) and BEFORE the `# Brainstorming Ideas Into Designs` heading:
+
+```html
+<!--
+Adapted from obra/superpowers brainstorming skill (v5.0.7), MIT-licensed,
+copyright 2025 Jesse Vincent. Modifications copyright 2026 Joe Amditis.
+Modifications add a default-on research phase between clarifying questions
+and approach proposal, plus updates to cross-references and process flow.
+See CREDITS.md.
+-->
+```
+
+- [ ] **Step 2: Insert research phase as checklist item 4 (renumber subsequent)**
+
+Find the `## Checklist` section. Item 3 currently reads `3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria`. Item 4 currently reads `4. **Propose 2-3 approaches** — with trade-offs and your recommendation`.
+
+Insert a new item 4 between them, and renumber existing items 4–9 to become 5–10:
+
+```markdown
+4. **Research phase** — gather outside context (default-on; skip only with explicit justification). See "Research phase" section below.
+```
+
+- [ ] **Step 3: Add the Research phase section body**
+
+Find the section break that comes BEFORE `## Process Flow` in the existing SKILL.md. Insert the following new section there:
+
+````markdown
+## Research phase
+
+After clarifying questions, before proposing approaches, gather outside context. This is **default-on**: skip only with explicit, justified statement.
+
+### 1. Pick research kinds
+
+From the menu — trends + discourse, patterns, pitfalls, authoritative verification, user-context.
+
+For brainstorming, the **defaults are: web (trends + discourse) and codebase (prior art)**. Add others if the topic warrants — e.g. authoritative verification when an external API is in scope, or user-context when prior decisions in memory are relevant.
+
+### 2. Dispatch
+
+Subagent by default:
+- `Explore` for codebase / prior-art questions ("does this repo already have something like X?", "what's the convention for Y here?")
+- `general-purpose` for web / discourse / verification ("what's the current best practice for Z?", "what pitfalls do people hit with W?")
+- Run multiple in parallel when the kinds are independent
+
+Inline only for light-touch research (single grep, memory check).
+
+### 3. Record findings
+
+Write 3–5 tight bullets into the spec doc under a new `## Research notes` section. Include load-bearing links/refs and anything considered-but-ruled-out so future-you knows it was checked.
+
+### 4. Skip protocol
+
+If skipping, write one line into the spec doc: `Skipped research because <reason>. <Verifiable pointer if applicable>.`
+
+**Valid reasons:**
+- Trivial scope (typo, comment edit, single-line config)
+- Fresh prior research — same topic in current session OR within last 7 days with verifiable spec/plan pointer
+- User explicit (quote the phrase)
+- Repeat of identical task (with pointer to prior instance)
+
+**Invalid reasons:** "I think I know", "seems straightforward", "moving fast", "user wants this done quickly", "already familiar with this codebase". If those are tempting, do the research.
+````
+
+- [ ] **Step 4: Update the process flow `digraph` to include Research phase node**
+
+Find the `digraph brainstorming { ... }` block in the SKILL.md. Currently it has edges: `"Ask clarifying questions" -> "Propose 2-3 approaches"`. Replace that edge with two edges via a new `Research phase` node, and add visual companion's existing flow connections.
+
+Old edge:
+
+```
+"Ask clarifying questions" -> "Propose 2-3 approaches";
+```
+
+New edges (replacing the old one):
+
+```
+"Research phase" [shape=box];
+"Ask clarifying questions" -> "Research phase";
+"Research phase" -> "Propose 2-3 approaches";
+```
+
+Insert the node declaration `"Research phase" [shape=box];` near the other shape declarations at the top of the digraph.
+
+- [ ] **Step 5: Update spec self-review section to check research-findings/skip-line presence**
+
+Find the "**Spec Self-Review:**" subsection. Add a fifth item to the numbered list (after the "Ambiguity check" item):
+
+```markdown
+5. **Research phase check:** Does the spec contain either a `## Research notes` section with findings, or a one-line `Skipped research because <reason>` declaration? If neither, the brainstorming flow didn't run correctly — go back to the research phase before continuing.
+```
+
+- [ ] **Step 6: Verify edits parse as valid markdown**
+
+```bash
+# Quick sanity check — confirm SKILL.md still has the expected sections
+grep -c "^## " superjawn/skills/brainstorming/SKILL.md
+```
+
+Expected: count is 1 higher than the upstream count (we added `## Research phase`).
+
+```bash
+grep -c "^## " ~/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.7/skills/brainstorming/SKILL.md
+```
+
+Compare the two — superjawn should be exactly +1.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add superjawn/skills/brainstorming/
+git commit -m "feat(superjawn): port brainstorming with research phase
+
+Adds default-on research phase between clarifying questions and approach
+proposal. Subagent dispatch (Explore + general-purpose). Findings recorded
+in spec doc; skip protocol with valid/invalid reason whitelist.
+
+Process flow digraph updated. Spec self-review check added."
+```
+
+---
+
+## Task 8: Port `brainstorming` — rewrite cross-references
+
+**Files:**
+- Modify: `superjawn/skills/brainstorming/SKILL.md`
+
+Cross-refs from brainstorming go to `writing-plans` (which IS being ported in this batch — rewrite to `superjawn:writing-plans`) and possibly other skills (which are NOT yet ported — keep at `superpowers:` for now per dual-namespace mode).
+
+- [ ] **Step 1: Inventory existing cross-refs**
+
+```bash
+grep -nE "(superpowers:|writing-plans|frontend-design|mcp-builder)" \
+  superjawn/skills/brainstorming/SKILL.md
+```
+
+Note each line. Expected refs to update: `writing-plans` mentions (with or without prefix). Refs to `frontend-design` / `mcp-builder` should stay as written (those skills are out of scope for superjawn; they live in upstream or other plugins).
+
+- [ ] **Step 2: Rewrite refs to ported skills**
+
+For each line found that references `writing-plans`, rewrite to `superjawn:writing-plans`. Specifically:
+
+- "invoke writing-plans skill" → "invoke superjawn:writing-plans skill"
+- "the writing-plans skill" → "the superjawn:writing-plans skill"
+- Any `superpowers:writing-plans` → `superjawn:writing-plans`
+
+Do NOT rewrite refs to `frontend-design`, `mcp-builder`, or other non-superjawn skills.
+
+- [ ] **Step 3: Verify the rewrite**
+
+```bash
+grep -n "writing-plans" superjawn/skills/brainstorming/SKILL.md
+```
+
+Every line should now show `superjawn:writing-plans` (no bare `writing-plans` and no `superpowers:writing-plans`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add superjawn/skills/brainstorming/SKILL.md
+git commit -m "refactor(superjawn): rewrite brainstorming cross-refs to superjawn namespace"
+```
+
+---
+
+## Task 9: Smoke-test `superjawn:brainstorming`
+
+**Files:** None (validation step)
+
+- [ ] **Step 1: Restart the Claude session so the plugin reload picks up the new skill**
+
+Open a fresh `claude` session in `~/projects/claude-skills-journalism`. The available-skills list should now include `superjawn:brainstorming`.
+
+- [ ] **Step 2: Invoke on a tiny real task**
+
+Pick something trivial — e.g. "I want to add a one-line ASCII art header to a script." Invoke `superjawn:brainstorming` on it.
+
+- [ ] **Step 3: Verify the research phase fires**
+
+The skill should:
+1. Check project context
+2. Ask clarifying questions
+3. **Reach the research phase** (this is the new behavior)
+4. EITHER dispatch subagents and record findings, OR write a skip line because the task is trivial
+
+Expected outcome: visible evidence that step 3 happened. If the skill jumped from clarifying questions to approach proposal without a research-phase or skip line, the additions didn't take effect — debug before continuing.
+
+- [ ] **Step 4: If skip path — verify skip line format**
+
+The skip line should be exactly: `Skipped research because trivial scope. <Verifiable pointer if applicable>.` Recorded in the spec doc.
+
+If wrong format, the skip protocol section needs revision.
+
+- [ ] **Step 5: Document the smoke test**
+
+Append to `CREDITS.md` under a new `## Smoke tests` heading:
+
+```markdown
+## Smoke tests
+
+- 2026-05-XX: `superjawn:brainstorming` invoked on trivial task; research phase fired correctly; skip line recorded with valid format.
+```
+
+(Use the actual date of the test.)
+
+- [ ] **Step 6: Commit smoke-test note**
+
+```bash
+git add superjawn/CREDITS.md
+git commit -m "docs(superjawn): record brainstorming smoke test pass"
+```
+
+---
+
+## Task 10: Port `writing-plans` — copy upstream files
+
+**Files:**
+- Create: `superjawn/skills/writing-plans/` (full upstream tree)
+
+- [ ] **Step 1: Copy upstream writing-plans directory**
+
+```bash
+cp -r ~/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.7/skills/writing-plans \
+      ~/projects/claude-skills-journalism/superjawn/skills/writing-plans
+```
+
+- [ ] **Step 2: Verify both files copied**
+
+```bash
+find superjawn/skills/writing-plans -type f | sort
+```
+
+Expected (2 files):
+
+```
+superjawn/skills/writing-plans/SKILL.md
+superjawn/skills/writing-plans/plan-document-reviewer-prompt.md
+```
+
+- [ ] **Step 3: Verify SKILL.md matches upstream**
+
+```bash
+diff superjawn/skills/writing-plans/SKILL.md \
+     ~/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.7/skills/writing-plans/SKILL.md
+```
+
+Expected: no output.
+
+---
+
+## Task 11: Port `writing-plans` — add MIT attribution + research phase
+
+**Files:**
+- Modify: `superjawn/skills/writing-plans/SKILL.md`
+
+writing-plans research stage is "Before drafting plan steps". Default kinds are web (pitfalls in chosen approach), codebase (similar features), and authoritative verification (live API smoke if external systems are in scope).
+
+- [ ] **Step 1: Add MIT attribution comment**
+
+Edit `superjawn/skills/writing-plans/SKILL.md`. Add this HTML comment immediately after the YAML frontmatter and before the `# Writing Plans` heading:
+
+```html
+<!--
+Adapted from obra/superpowers writing-plans skill (v5.0.7), MIT-licensed,
+copyright 2025 Jesse Vincent. Modifications copyright 2026 Joe Amditis.
+Modifications add a default-on research phase before plan drafting, plus
+updates to cross-references and self-review.
+See CREDITS.md.
+-->
+```
+
+- [ ] **Step 2: Insert Research phase section**
+
+Find the `## Scope Check` section near the top of the SKILL.md. Insert a new `## Research phase` section AFTER `## Scope Check` and BEFORE `## File Structure`:
+
+````markdown
+## Research phase
+
+Before drafting plan steps, gather outside context. **Default-on**: skip only with explicit justification.
+
+### 1. Pick research kinds
+
+For writing-plans, defaults are:
+- **Web (pitfalls in chosen approach):** What's gone wrong for others doing this kind of plan? Recent post-mortems, GitHub issues, conference talks?
+- **Codebase (similar features):** Has this codebase done something similar before? What patterns can be reused?
+- **Authoritative verification:** If the plan involves external APIs/services/standards, hit the real source — current docs, live curl, current spec — to confirm the plan's assumptions.
+
+Add user-context if a prior plan or session is relevant.
+
+### 2. Dispatch
+
+Subagent by default:
+- `Explore` for codebase / similar-feature search
+- `general-purpose` for web research and live API verification
+- Run in parallel when independent
+
+Inline for trivial plans (single-file edits, mechanical changes).
+
+### 3. Record findings
+
+Write 3–5 tight bullets into a new `## Research notes` section AT THE TOP of the plan doc, immediately after the plan header. Include load-bearing references and anything considered-but-ruled-out.
+
+### 4. Skip protocol
+
+Same as brainstorming. If skipping, write one line into the plan doc:
+
+`Skipped research because <reason>. <Verifiable pointer if applicable>.`
+
+Valid reasons: trivial scope, fresh prior research within 7 days, user explicit, repeat of identical task. Invalid reasons: "I think I know", "seems straightforward", "moving fast".
+````
+
+- [ ] **Step 3: Update Self-Review to check research-findings/skip-line presence**
+
+Find the `## Self-Review` section. Add a fourth check after the "Type consistency" check:
+
+```markdown
+**4. Research phase check:** Does the plan contain either a `## Research notes` section with findings, or a `Skipped research because <reason>` declaration? If neither, the plan was drafted without the research step — return to the research phase.
+```
+
+- [ ] **Step 4: Verify section count**
+
+```bash
+grep -c "^## " superjawn/skills/writing-plans/SKILL.md
+grep -c "^## " ~/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.7/skills/writing-plans/SKILL.md
+```
+
+superjawn count should be +1 (we added `## Research phase`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add superjawn/skills/writing-plans/
+git commit -m "feat(superjawn): port writing-plans with research phase
+
+Adds default-on research phase between scope check and file structure.
+Subagent dispatch with web/codebase/authoritative defaults. Findings
+recorded at top of plan doc. Self-review check added."
+```
+
+---
+
+## Task 12: Port `writing-plans` — rewrite cross-references
+
+**Files:**
+- Modify: `superjawn/skills/writing-plans/SKILL.md`
+
+writing-plans references `superpowers:subagent-driven-development` and `superpowers:executing-plans`. executing-plans IS being ported in this batch — rewrite. subagent-driven-development is NOT (Batch 4) — keep at `superpowers:` for now.
+
+- [ ] **Step 1: Inventory existing cross-refs**
+
+```bash
+grep -nE "superpowers:|subagent-driven-development|executing-plans" \
+  superjawn/skills/writing-plans/SKILL.md
+```
+
+- [ ] **Step 2: Rewrite refs to ported skills**
+
+- `superpowers:executing-plans` → `superjawn:executing-plans` (executing-plans is in this batch)
+- `superpowers:subagent-driven-development` → leave as-is (Batch 4 — not yet ported)
+- Bare `executing-plans` mentions → `superjawn:executing-plans` only when context makes the namespace clear
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep -n "executing-plans" superjawn/skills/writing-plans/SKILL.md
+```
+
+Every reference should now be `superjawn:executing-plans` (no bare or `superpowers:` form).
+
+```bash
+grep -n "subagent-driven-development" superjawn/skills/writing-plans/SKILL.md
+```
+
+References should still be `superpowers:subagent-driven-development` (kept until Batch 4 ships).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add superjawn/skills/writing-plans/SKILL.md
+git commit -m "refactor(superjawn): rewrite writing-plans cross-refs (executing-plans → superjawn)"
+```
+
+---
+
+## Task 13: Smoke-test `superjawn:writing-plans`
+
+**Files:** None (validation step)
+
+- [ ] **Step 1: Fresh Claude session**
+
+Restart `claude` so the new skill is registered.
+
+- [ ] **Step 2: Invoke on a tiny real task**
+
+Pick a small spec — e.g. the 2-line README change above. Invoke `superjawn:writing-plans` referencing that spec. (You can use any small spec doc as input.)
+
+- [ ] **Step 3: Verify research phase fires**
+
+The skill should reach the research phase before file-structure mapping. EITHER dispatch subagents (web/codebase) OR write a skip line into the plan doc.
+
+- [ ] **Step 4: Verify findings location**
+
+If research happened: findings are in `## Research notes` at the top of the plan doc.
+If skipped: skip line is in the plan doc, not buried elsewhere.
+
+- [ ] **Step 5: Document the smoke test**
+
+Append to `CREDITS.md`:
+
+```markdown
+- 2026-05-XX: `superjawn:writing-plans` invoked on trivial spec; research phase fired correctly; findings recorded in plan doc.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add superjawn/CREDITS.md
+git commit -m "docs(superjawn): record writing-plans smoke test pass"
+```
+
+---
+
+## Task 14: Port `executing-plans` — copy upstream file
+
+**Files:**
+- Create: `superjawn/skills/executing-plans/SKILL.md`
+
+- [ ] **Step 1: Copy upstream executing-plans directory**
+
+```bash
+cp -r ~/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.7/skills/executing-plans \
+      ~/projects/claude-skills-journalism/superjawn/skills/executing-plans
+```
+
+- [ ] **Step 2: Verify file copied**
+
+```bash
+find superjawn/skills/executing-plans -type f | sort
+```
+
+Expected (1 file):
+
+```
+superjawn/skills/executing-plans/SKILL.md
+```
+
+- [ ] **Step 3: Verify content matches upstream**
+
+```bash
+diff superjawn/skills/executing-plans/SKILL.md \
+     ~/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.7/skills/executing-plans/SKILL.md
+```
+
+Expected: no output.
+
+---
+
+## Task 15: Port `executing-plans` — add MIT attribution + research phase
+
+**Files:**
+- Modify: `superjawn/skills/executing-plans/SKILL.md`
+
+executing-plans research stage is "Before each step's implementation". Default kind is **authoritative re-verification** (drift check) — has the API/file/state changed since the plan was written?
+
+- [ ] **Step 1: Add MIT attribution comment**
+
+Edit `superjawn/skills/executing-plans/SKILL.md`. Add HTML comment after frontmatter, before `# Executing Plans` heading:
+
+```html
+<!--
+Adapted from obra/superpowers executing-plans skill (v5.0.7), MIT-licensed,
+copyright 2025 Jesse Vincent. Modifications copyright 2026 Joe Amditis.
+Modifications add a per-step research phase (drift check before execution).
+See CREDITS.md.
+-->
+```
+
+- [ ] **Step 2: Insert per-step Research phase section**
+
+Find a logical insertion point in the existing executing-plans flow — typically after a section describing how to begin a task and before actual implementation steps. Insert:
+
+````markdown
+## Research phase (per task)
+
+Before implementing each task in the plan, run a quick drift check. **Default-on**: skip only with explicit justification per task.
+
+### 1. What to verify
+
+The plan was written at a point in time. Before each task, verify:
+- **Authoritative state:** If the task touches an external API or file the plan references, confirm the API contract or file content hasn't changed. Live curl, file read, version check.
+- **Codebase drift:** If the task assumes a function/module exists at a specific path, grep to confirm it still does.
+- **Repo state:** Has anyone landed conflicting work on the branch since the plan was drafted?
+
+### 2. Dispatch
+
+Inline for single-file or single-API checks. `general-purpose` subagent only when the verification spans multiple sources.
+
+### 3. Record findings
+
+Append a short note to the execution journal (or PR description) for each task:
+
+```
+Task N drift check: <PASS / FAIL> — <one-line summary>
+```
+
+If FAIL, escalate before implementing — the plan may need revision.
+
+### 4. Skip protocol
+
+Skip per-task research is allowed when:
+- Task is purely additive within a file the previous task just created (no external state to verify)
+- Plan was drafted within the current session and nothing has changed
+- Task is a pure mechanical commit/rebase step
+
+If skipping, write one line in the journal: `Task N research skipped because <reason>.`
+````
+
+- [ ] **Step 3: Verify section count**
+
+```bash
+grep -c "^## " superjawn/skills/executing-plans/SKILL.md
+grep -c "^## " ~/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.7/skills/executing-plans/SKILL.md
+```
+
+superjawn count should be +1.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add superjawn/skills/executing-plans/
+git commit -m "feat(superjawn): port executing-plans with per-task drift-check research
+
+Adds per-task research phase (authoritative re-verification of external
+state) before implementation. Inline by default; subagent for multi-source
+checks. Findings recorded in execution journal."
+```
+
+---
+
+## Task 16: Port `executing-plans` — rewrite cross-references
+
+**Files:**
+- Modify: `superjawn/skills/executing-plans/SKILL.md`
+
+- [ ] **Step 1: Inventory existing cross-refs**
+
+```bash
+grep -nE "superpowers:|writing-plans|subagent-driven-development|verification-before-completion" \
+  superjawn/skills/executing-plans/SKILL.md
+```
+
+- [ ] **Step 2: Rewrite refs to ported skills**
+
+- Refs to `writing-plans` → `superjawn:writing-plans` (Batch 1, ported)
+- Refs to `subagent-driven-development` → leave as `superpowers:` (Batch 4, not yet ported)
+- Refs to `verification-before-completion` → leave as `superpowers:` (Batch 2, not yet ported)
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep -nE "(superpowers:|superjawn:)(writing-plans|subagent|verification)" \
+  superjawn/skills/executing-plans/SKILL.md
+```
+
+Every match should be on the right side of the dual-namespace rule above.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add superjawn/skills/executing-plans/SKILL.md
+git commit -m "refactor(superjawn): rewrite executing-plans cross-refs (writing-plans → superjawn)"
+```
+
+---
+
+## Task 17: Smoke-test `superjawn:executing-plans`
+
+**Files:** None (validation step)
+
+- [ ] **Step 1: Fresh Claude session**
+
+- [ ] **Step 2: Invoke on a tiny real plan**
+
+Pick a single-task plan — e.g. "Add one line to README.md saying 'See CREDITS.md.'" Invoke `superjawn:executing-plans` against it.
+
+- [ ] **Step 3: Verify per-task drift check fires**
+
+Before implementing, the skill should verify:
+- The README.md file exists at the expected path
+- No conflicting changes on the branch
+
+- [ ] **Step 4: Verify journal entry**
+
+After the task is implemented (or skipped), confirm the journal has a `Task 1 drift check: PASS — <summary>` line or a skip declaration.
+
+- [ ] **Step 5: Document the smoke test**
+
+Append to `CREDITS.md`:
+
+```markdown
+- 2026-05-XX: `superjawn:executing-plans` invoked on trivial plan; per-task drift check fired correctly.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add superjawn/CREDITS.md
+git commit -m "docs(superjawn): record executing-plans smoke test pass"
+```
+
+---
+
+## Task 18: End-of-batch verification
+
+**Files:** None (verification step)
+
+- [ ] **Step 1: All three skills register**
+
+In a fresh `claude` session, verify the available-skills list shows all three:
+
+- `superjawn:brainstorming`
+- `superjawn:writing-plans`
+- `superjawn:executing-plans`
+
+- [ ] **Step 2: Cross-references all resolve**
+
+For each ported skill, every `superjawn:<skill>` reference inside the SKILL.md must resolve to a real ported skill, AND every `superpowers:<skill>` reference must resolve to a real upstream skill.
+
+```bash
+# Find all superjawn: refs across batch 1
+grep -rEh "superjawn:[a-z-]+" superjawn/skills/ | grep -oE "superjawn:[a-z-]+" | sort -u
+
+# Find all superpowers: refs across batch 1
+grep -rEh "superpowers:[a-z-]+" superjawn/skills/ | grep -oE "superpowers:[a-z-]+" | sort -u
+```
+
+Manually verify each `superjawn:` ref appears in the Batch 1 ported set, and each `superpowers:` ref exists in the upstream `~/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.7/skills/` directory.
+
+- [ ] **Step 3: Both plugins still function side-by-side**
+
+In a fresh session, invoke `superpowers:brainstorming` (the upstream version) and verify it still works as before. Then invoke `superjawn:brainstorming` and verify it reaches the research phase. They should not interfere with each other.
+
+- [ ] **Step 4: Bump plugin version**
+
+Edit `superjawn/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` — bump the superjawn version from `0.1.0` to `0.1.0` (it stays — this is the v0.1.0 cut). If you've made enough changes that you want a v0.1.1, bump now.
+
+(Decision deferred to engineer at this point: hold at 0.1.0 if Batch 1 is the v0.1.0 release, or bump if there's been iteration since last tag.)
+
+- [ ] **Step 5: Push branch and open PR**
+
+```bash
+git push -u origin docs/superjawn-research-phases-spec
+gh pr create --title "superjawn Batch 1: scaffold plugin + foundation skills with research phase" \
+             --body "$(cat <<'EOF'
+## Summary
+
+Bootstraps the `superjawn` plugin and ports the foundation triad of superpowers skills (`brainstorming`, `writing-plans`, `executing-plans`) with a default-on research phase per the design spec.
+
+Spec: `specs/2026-05-05-superjawn-research-phases-design.md`
+Plan: `plans/2026-05-05-superjawn-batch-1.md`
+
+## What's in this PR
+
+- Plugin scaffold: `plugin.json`, `LICENSE`, `CREDITS.md`, `README.md`
+- Marketplace registration: `superjawn` entry in `marketplace.json`
+- Three skills ported with research phase additions:
+  - `brainstorming`: research between clarifying questions and approach proposal
+  - `writing-plans`: research before plan drafting
+  - `executing-plans`: per-task drift check before implementation
+- Cross-references in dual-namespace mode: ported skills use `superjawn:`, not-yet-ported skills keep `superpowers:`
+- Smoke tests passed for all three skills
+
+## Test plan
+
+- [x] Plugin loads in fresh Claude session
+- [x] All three skills appear in available-skills list under `superjawn:`
+- [x] Cross-references resolve correctly (manually verified per skill)
+- [x] Both plugins coexist without interference
+- [x] Smoke test per skill confirmed research phase fires
+
+## Out of scope
+
+- Batches 2–5 each get their own implementation plan after this PR merges and proves the pattern.
+- v1.0.0 (disable upstream `superpowers`) is gated on at least 2 weeks of real use after Batch 5 ships.
+EOF
+)"
+```
+
+Note: PR title and body intentionally have zero AI attribution per global rules.
+
+---
+
+## Self-review
+
+### Spec coverage check
+
+| Spec section | Plan task(s) covering it |
+|---|---|
+| §1 Plugin architecture (location, layout, cross-refs, coexistence, versioning) | Tasks 1–5 (scaffold, manifest, license, README, marketplace registration, install verification) |
+| §2 Per-skill research taxonomy (3 of 14 skills covered in Batch 1) | Tasks 7, 11, 15 (research-phase insertion per skill, kinds and stage from §2 table) |
+| §3 Common research-step shape | Tasks 7, 11, 15 (template substituted per skill: stage, kinds, subagent, artifact) |
+| §4 Skip-justification protocol | Tasks 7, 11, 15 (skip rules baked into each skill's research-phase section) |
+| §5 Rollout sequence (this is plan #1 of 5) | Plan covers Batch 1; Batches 2–5 explicitly deferred to subsequent plans (Task 18 PR body says so) |
+| §6 Upstream drift management | `CREDITS.md` baseline tracking established in Task 2; quarterly check cadence is operational, not part of this plan |
+
+### Placeholder scan
+
+- "fill in upstream commit SHA at first port" in `CREDITS.md` — intentional placeholder, surfaced as a clear instruction. Engineer fills it during Task 2 by running `cd ~/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.7 && git rev-parse HEAD 2>/dev/null` (or noting "tagged release v5.0.7" if the cache isn't a git checkout).
+- "the actual date of the test" in Tasks 9/13/17 — intentional, instructs engineer to substitute current date.
+- No "TBD", "TODO", "implement later", or "similar to Task N" patterns.
+
+### Type consistency check
+
+- "Skipped research because" phrase used identically across Tasks 7, 11, 15.
+- "Research notes" section name used consistently (brainstorming and writing-plans both use this; executing-plans uses "execution journal" which is its skill-specific artifact per spec §2).
+- Cross-ref rule consistent: ported-in-this-batch → `superjawn:`, not-yet-ported → `superpowers:`.
+- "Drift check" phrasing used consistently for executing-plans.
+
+No type/naming drift found.
+
+### Engineer-readability check
+
+Each task has explicit file paths, exact commands, expected outputs. The HTML attribution comment is repeated verbatim in Tasks 7/11/15 rather than referenced ("similar to Task N") so an engineer reading tasks out of order has the full text.
+
+---
+
+## Execution handoff
+
+**Plan complete and saved to `plans/2026-05-05-superjawn-batch-1.md`.**
+
+Two execution options for this plan (per the writing-plans skill):
+
+1. **Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks, fast iteration. Best when iterating on the research-phase wording is likely.
+2. **Inline Execution** — execute tasks in this session using `superpowers:executing-plans`, batch execution with checkpoints. Faster when the wording is settled.
+
+Which approach?

--- a/plans/2026-05-05-superjawn-batch-1.md
+++ b/plans/2026-05-05-superjawn-batch-1.md
@@ -548,7 +548,7 @@ For each line found that references `writing-plans`, rewrite to `superjawn:writi
 - "the writing-plans skill" → "the superjawn:writing-plans skill"
 - Any `superpowers:writing-plans` → `superjawn:writing-plans`
 
-Do NOT rewrite refs to `frontend-design`, `mcp-builder`, or other non-superjawn skills.
+**Do NOT add a namespace prefix to `frontend-design` or `mcp-builder` mentions.** These appear in the upstream brainstorming SKILL.md as generic illustrative examples of "implementation skills not to invoke after brainstorming," not as references to specific plugin skills. Verification against upstream `superpowers` v5.0.7 confirms neither name exists in that plugin (`frontend-design` is a separate top-level plugin `frontend-design:frontend-design`; `mcp-builder` doesn't resolve in the current plugin marketplace at all). Leave them bare so the sentence reads as "any of these *kinds* of skills" rather than as fully-qualified references that don't exist.
 
 - [ ] **Step 3: Verify the rewrite**
 

--- a/plans/2026-05-05-superjawn-batch-1.md
+++ b/plans/2026-05-05-superjawn-batch-1.md
@@ -278,13 +278,23 @@ git commit -m "feat(marketplace): register superjawn plugin"
 
 **Files:** None (install-only step)
 
-- [ ] **Step 1: Install plugin from local path**
+- [ ] **Step 1: Install plugin from the existing marketplace**
+
+The `claude-skills-journalism` marketplace is already registered (verifiable via `claude plugin list` showing `autocontext@claude-skills-journalism` and other plugins from this repo). The CLI uses `<plugin>@<marketplace>` form, not a path:
 
 ```bash
-claude plugin install ~/projects/claude-skills-journalism/superjawn
+claude plugin install superjawn@claude-skills-journalism
 ```
 
 Expected: success message naming `superjawn` v0.1.0.
+
+If the marketplace isn't registered (e.g. on a fresh machine), add it first:
+
+```bash
+claude plugin marketplace add ~/projects/claude-skills-journalism
+```
+
+Then re-run the install command above.
 
 - [ ] **Step 2: Verify it appears in plugin list**
 

--- a/plans/2026-05-05-superjawn-batch-1.md
+++ b/plans/2026-05-05-superjawn-batch-1.md
@@ -357,10 +357,11 @@ Expected: no output (files identical at this point — modifications come in nex
 
 ---
 
-## Task 7: Port `brainstorming` — add MIT attribution + research phase
+## Task 7: Port `brainstorming` — add MIT attribution + research phase + visual companion branding
 
 **Files:**
 - Modify: `superjawn/skills/brainstorming/SKILL.md`
+- Modify: `superjawn/skills/brainstorming/scripts/frame-template.html`
 
 The existing brainstorming SKILL.md has a checklist with 9 items at "## Checklist". The research phase fits BETWEEN item 3 ("Ask clarifying questions") and item 4 ("Propose 2-3 approaches"). The skill's process flow `digraph` also needs a new `Research phase` node added between those two.
 
@@ -457,7 +458,23 @@ Find the "**Spec Self-Review:**" subsection. Add a fifth item to the numbered li
 5. **Research phase check:** Does the spec contain either a `## Research notes` section with findings, or a one-line `Skipped research because <reason>` declaration? If neither, the brainstorming flow didn't run correctly — go back to the research phase before continuing.
 ```
 
-- [ ] **Step 6: Verify edits parse as valid markdown**
+- [ ] **Step 6: Update visual companion header to dual-link**
+
+Edit `superjawn/skills/brainstorming/scripts/frame-template.html`. Around line 199 the upstream header reads:
+
+```html
+<h1><a href="https://github.com/obra/superpowers" target="_blank" rel="noopener">Superpowers Brainstorming</a></h1>
+```
+
+Replace with the dual-link form (superjawn-primary, parenthetical upstream attribution):
+
+```html
+<h1><a href="https://github.com/jamditis/claude-skills-journalism/tree/master/superjawn" target="_blank" rel="noopener">superjawn Brainstorming</a> <span style="font-size: 0.7em; opacity: 0.7;">(forked from <a href="https://github.com/obra/superpowers" target="_blank" rel="noopener">superpowers</a>)</span></h1>
+```
+
+This shows "superjawn Brainstorming" linked to your repo as the primary identity, with a smaller parenthetical "forked from superpowers" link pointing at upstream. Best-of-both attribution.
+
+- [ ] **Step 7: Verify edits parse as valid markdown**
 
 ```bash
 # Quick sanity check — confirm SKILL.md still has the expected sections
@@ -472,7 +489,16 @@ grep -c "^## " ~/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.7
 
 Compare the two — superjawn should be exactly +1.
 
-- [ ] **Step 7: Commit**
+Also verify the HTML edit didn't break the file:
+
+```bash
+grep -c "<h1>" superjawn/skills/brainstorming/scripts/frame-template.html
+grep "github.com" superjawn/skills/brainstorming/scripts/frame-template.html
+```
+
+Expected: one `<h1>` tag, two GitHub URLs visible (jamditis/claude-skills-journalism and obra/superpowers).
+
+- [ ] **Step 8: Commit**
 
 ```bash
 git add superjawn/skills/brainstorming/
@@ -482,17 +508,28 @@ Adds default-on research phase between clarifying questions and approach
 proposal. Subagent dispatch (Explore + general-purpose). Findings recorded
 in spec doc; skip protocol with valid/invalid reason whitelist.
 
-Process flow digraph updated. Spec self-review check added."
+Process flow digraph updated. Spec self-review check added.
+
+Visual companion header rebranded to dual-link form: superjawn primary,
+parenthetical 'forked from superpowers' attribution."
 ```
 
 ---
 
-## Task 8: Port `brainstorming` — rewrite cross-references
+## Task 8: Port `brainstorming` — rewrite cross-references (with explicit non-renames)
 
 **Files:**
 - Modify: `superjawn/skills/brainstorming/SKILL.md`
 
 Cross-refs from brainstorming go to `writing-plans` (which IS being ported in this batch — rewrite to `superjawn:writing-plans`) and possibly other skills (which are NOT yet ported — keep at `superpowers:` for now per dual-namespace mode).
+
+**EXPLICIT NON-RENAMES** — DO NOT mechanically grep-replace `superpowers` → `superjawn`. The following strings refer to user-data layouts and project conventions that are SHARED across forks, not to skill identifiers, and must remain unchanged:
+
+- `.superpowers/` (runtime directory, e.g. `<project>/.superpowers/brainstorm/<session-id>/`) — referenced in `start-server.sh`, `stop-server.sh`, `visual-companion.md`. Renaming would break any user with existing brainstorm sessions.
+- `docs/superpowers/specs/` (project spec directory) — referenced in `SKILL.md` and `spec-document-reviewer-prompt.md`. Renaming would force every superjawn user to choose a different spec home and break continuity with prior work.
+- `https://github.com/obra/superpowers` (upstream attribution link) — Task 7 already handled the visual-companion header rebranding to dual-link form. Any other occurrences of this URL are pure attribution and stay as-is.
+
+Only the `superpowers:<skill-name>` namespaced references inside SKILL.md get rewritten. Bare-name references to `writing-plans` (skill name, not directory path) also get rewritten. Everything else stays.
 
 - [ ] **Step 1: Inventory existing cross-refs**
 

--- a/plans/2026-05-05-superjawn-batch-1.md
+++ b/plans/2026-05-05-superjawn-batch-1.md
@@ -274,41 +274,42 @@ git commit -m "feat(marketplace): register superjawn plugin"
 
 ---
 
-## Task 5: Install superjawn locally and verify it loads
+## Task 5: Validate manifest (live install deferred to post-merge)
 
-**Files:** None (install-only step)
+**Files:** None (validation step)
 
-- [ ] **Step 1: Install plugin from the existing marketplace**
+**Discovery during execution (2026-05-05):** The `claude-skills-journalism` marketplace pulls from the GitHub remote (`https://github.com/jamditis/claude-skills-journalism.git`), cached at `~/.claude/plugins/marketplaces/claude-skills-journalism/`. `claude plugin install` reads only from that cache — it cannot see local feature-branch edits before they're pushed and merged. Live install verification therefore can't run until this PR merges to master and the marketplace cache refreshes.
 
-The `claude-skills-journalism` marketplace is already registered (verifiable via `claude plugin list` showing `autocontext@claude-skills-journalism` and other plugins from this repo). The CLI uses `<plugin>@<marketplace>` form, not a path:
+The substitute is `claude plugin validate <plugin-dir>`, which confirms the manifest would install correctly without actually pulling it through the marketplace.
+
+- [ ] **Step 1: Validate the plugin manifest**
 
 ```bash
+cd /home/jamditis/projects/claude-skills-journalism
+claude plugin validate ./superjawn
+```
+
+Expected: `✔ Validation passed`. Any failure means the manifest has a problem — fix before continuing.
+
+- [ ] **Step 2: Verify the marketplace entry agrees with `plugin.json`**
+
+```bash
+claude plugin tag --dry-run ./superjawn
+```
+
+Expected: success, with no version-mismatch warnings for superjawn (other plugins in the marketplace may have pre-existing drift — see issue #33; ignore those for this task).
+
+- [ ] **Step 3: Defer live install verification until post-merge**
+
+Once this PR merges to master, run on a fresh machine or after a marketplace update:
+
+```bash
+claude plugin marketplace update claude-skills-journalism
 claude plugin install superjawn@claude-skills-journalism
+claude plugin list | grep superjawn      # should show: superjawn 0.1.0
 ```
 
-Expected: success message naming `superjawn` v0.1.0.
-
-If the marketplace isn't registered (e.g. on a fresh machine), add it first:
-
-```bash
-claude plugin marketplace add ~/projects/claude-skills-journalism
-```
-
-Then re-run the install command above.
-
-- [ ] **Step 2: Verify it appears in plugin list**
-
-```bash
-claude plugin list | grep superjawn
-```
-
-Expected: one line showing `superjawn 0.1.0`.
-
-- [ ] **Step 3: Verify zero skills currently registered**
-
-The plugin manifest is loaded but no skills exist yet. The model should not see any `superjawn:<skill>` triggers. To confirm, start a fresh `claude` session and check the available-skills list — `superjawn:` should not appear.
-
-If `superjawn:` skills are listed despite empty `skills/` directory, debug before continuing.
+Then in a fresh `claude` session, confirm `superjawn:` skill triggers DO appear after Tasks 6–17 ship (since skills are populated then). Document the result in the post-merge follow-up.
 
 ---
 

--- a/specs/2026-05-05-superjawn-research-phases-design.md
+++ b/specs/2026-05-05-superjawn-research-phases-design.md
@@ -1,0 +1,212 @@
+# superjawn — research-phase additions to superpowers skills
+
+**Status:** design approved, awaiting implementation plan
+**Date:** 2026-05-05
+**Author:** Joe Amditis (with brainstorming session)
+**Repo:** `claude-skills-journalism`
+**New plugin:** `superjawn/`
+
+## Goal
+
+Add a default-on research phase to all 14 skills currently shipped by the upstream `superpowers` plugin (obra/superpowers, MIT, currently v5.0.7), recreated as a new plugin `superjawn` inside the existing `claude-skills-journalism` marketplace.
+
+The research phase realizes the "research-first approach" already documented in `~/.claude/CLAUDE.md` — "let me check the latest trends, possible pitfalls, patterns, and discourse surrounding this topic before we start actually building or proposing solutions." Each skill gets a tailored research step at the right stage of its existing flow, dispatched via subagent by default, with findings written into the skill's existing artifact.
+
+## Decision log
+
+Locked during brainstorming on 2026-05-05:
+
+| Question | Decision |
+|---|---|
+| Kind of research | All four — web/best-practices, codebase/prior-art, authoritative verification, user-context — situational and skill-dependent |
+| Scope | All 14 superpowers skills |
+| Rigidity | Default-on with explicit skip (justified, surfaced) |
+| Mechanism | Subagent dispatch by default; inline only for light-touch |
+| Output destination | Findings written into the skill's existing artifact (spec, plan, debug log) |
+| Delivery approach | Approach D — new plugin `superjawn/` inside `claude-skills-journalism`; copy upstream MIT-licensed skills with attribution; rewrite cross-references; disable upstream `superpowers` once migration complete |
+| Plugin name | `superjawn` |
+
+## Section 1 — Plugin architecture
+
+**Location:** New plugin directory at `~/projects/claude-skills-journalism/superjawn/`, registered in `marketplace.json` alongside `autocontext`, `pdf-design`, `pdf-playground`.
+
+**Layout:** Standard plugin shape — `.claude-plugin/plugin.json`, `skills/<skill-name>/SKILL.md` × 14, plus top-level `LICENSE` and `CREDITS.md` attributing Jesse Vincent / `obra/superpowers` (MIT preserved).
+
+**Cross-references:** Every `superpowers:<skill>` reference inside the skill text gets rewritten to `superjawn:<skill>`. One-time pass during port.
+
+**Coexistence:** During build, both `superpowers` and `superjawn` plugins installed; manually invoke `superjawn:<skill>` for testing. After all 14 skills ship (v0.5.0), live with both enabled for at least 2 weeks of real use. Disable upstream `superpowers` only at v1.0.0, once superjawn has proven itself in practice. (See Section 5 for the version-by-version breakdown.)
+
+**Versioning:** Track upstream-source version in `CREDITS.md` (currently 5.0.7). Manual diff-and-port pass when upstream ships changes worth pulling in. No automatic rebase.
+
+## Section 2 — Per-skill research taxonomy
+
+| Skill | Research stage | Default kinds | Subagent | Findings land in |
+|---|---|---|---|---|
+| `brainstorming` | After clarifying questions, before approaches | Web (trends + discourse), codebase (prior art) | general-purpose + Explore (parallel) | Spec doc, new `## Research notes` section |
+| `writing-plans` | Before drafting plan steps | Web (pitfalls in chosen approach), codebase (similar features), authoritative (live API smoke) | general-purpose + Explore | Plan doc, top section |
+| `executing-plans` | Before each step's implementation | Authoritative re-verification (drift check) | general-purpose, scoped to current step | Execution journal entry |
+| `subagent-driven-development` | Per-subagent, before each task starts | Codebase (independence verification), authoritative (per-task) | Each subagent does its own | Subagent's report |
+| `systematic-debugging` | At hypothesis formation | Web (error-string search, GitHub issues), codebase (prior bugs in this area) | general-purpose + Explore | Debug log, hypothesis section |
+| `test-driven-development` | Before writing the red test | Web (testing patterns for this code shape), codebase (existing test conventions) | general-purpose + Explore | Test file header comment + draft notes |
+| `using-git-worktrees` | Before creating worktree | User-context (existing worktrees? unfinished branches?) | Inline | Inline log line |
+| `dispatching-parallel-agents` | Before fan-out | Codebase (verify task independence — no hidden shared state) | Explore | Dispatch plan |
+| `finishing-a-development-branch` | Before integration choice | Codebase (competing PRs on adjacent code), user-context (recent decisions) | Inline | Inline summary |
+| `receiving-code-review` | Per comment, before responding | Authoritative (verify reviewer's claim), codebase (current behavior) | general-purpose | Comment-response draft |
+| `requesting-code-review` | Before requesting | User-context (review-scope conventions, reviewer preferences) | Inline | Inline |
+| `using-superjawn` | Before invoking another skill | User-context (recent feedback memory about this skill) | Inline (memory check) | Inline |
+| `verification-before-completion` | At verification step | Authoritative (what command actually proves this?) | general-purpose | Verification evidence block |
+| `writing-skills` | Before drafting skill | Codebase (overlapping skills in plugin), user-context (description conventions) | Explore | Skill draft metadata |
+
+**Light-touch flags:** `using-superjawn`, `finishing-a-development-branch`, `requesting-code-review`, `using-git-worktrees`, `dispatching-parallel-agents` have thin research fits — research is a brief inline check, not a subagent dispatch. Skill text says so explicitly rather than padding cargo-cult research into the flow.
+
+**Cross-cutting principles:**
+- All research is default-on with explicit skip
+- Research output is always written into the skill's existing artifact, never to a separate file
+- Subagent-by-default uses existing `Explore` / `general-purpose` agent types only
+
+## Section 3 — Common research-step shape
+
+Reusable template inserted into each skill's `## Research phase` section, with skill-specific substitutions (stage trigger, default kinds, subagent recommendation, artifact name).
+
+```
+## Research phase
+
+[Skill-specific stage: e.g. "After clarifying questions, before proposing approaches"]
+
+This is default-on. Skip only with explicit justification.
+
+### 1. Pick research kinds
+From the menu — trends + discourse, patterns, pitfalls, authoritative verification, user-context.
+For this skill, defaults are: <kinds from Section 2>. Add others if the topic warrants.
+
+### 2. Dispatch
+Subagent by default:
+  - Explore for codebase / prior-art
+  - general-purpose for web / discourse / verification
+  - Parallel when kinds are independent
+Inline only for light-touch research (memory check, single grep).
+
+### 3. Record findings
+Write 3-5 tight bullets into <skill-specific artifact>. Include load-bearing
+links/refs and anything considered-but-ruled-out so future-you knows it was checked.
+
+### 4. Skip protocol
+If skipping, write one line: "Skipped research because <reason>."
+Valid reasons: trivial scope, fresh prior research in memory, user said skip.
+Invalid reasons: "I think I know", "seems straightforward", "moving fast" —
+if those are tempting, do the research.
+```
+
+**Integration with existing skill flow:** The `## Research phase` section gets inserted into each skill's existing `## Checklist` or `## Process` block as a new numbered step at the right stage. Existing process flow diagrams (the dot graphs in brainstorming, debugging, etc.) get one new node added — `"Research phase"` — with edges into and out of the right neighbors.
+
+## Section 4 — Skip-justification protocol
+
+**Skip line format:**
+
+```
+Skipped research because <reason>. <Verifiable pointer if applicable>.
+```
+
+One line, written into the same artifact where findings would have gone. Audit-trail by design.
+
+**Valid skip reasons (whitelist — these four, nothing else):**
+
+1. **Trivial scope.** Typo fix, log-message wording, comment edit, single-character config change, removing a debug print.
+2. **Fresh prior research.** Same topic researched in a recent session, findings still apply. "Recent" = either (a) the current session, or (b) within the last 7 calendar days with a verifiable spec/plan/log pointer. **Must include the pointer** — if it doesn't resolve, the skip is invalid. Beyond 7 days, repeat the research even if you remember the prior findings, because the landscape (codebase, libraries, docs) drifts.
+3. **User explicit.** User said "skip research" or equivalent. **Must quote the phrase.**
+4. **Repeat of identical task.** Same operation as a previous successful run, with a pointer to the prior instance.
+
+**Invalid skip reasons (called out explicitly in skill text):**
+
+- "I think I know" / "I have prior knowledge"
+- "Seems straightforward" / "obvious fix"
+- "Moving fast" / "tight timeline"
+- "User wants this done quickly"
+- "Already familiar with this codebase"
+
+**Audit:** Each skill's existing self-review step gains a check: "Is there a research-findings section or a valid skip line? If neither, the skill didn't run correctly."
+
+**Override:** If the user objects to a skip, the skill reverts to step 1 of the research phase.
+
+**Drift visibility:** Skip lines written into artifacts make patterns visible during spec/plan review.
+
+## Section 5 — Rollout sequence
+
+**Build batches (5 batches, ~3 skills each, one PR per batch):**
+
+1. **Foundation:** `brainstorming`, `writing-plans`, `executing-plans`
+2. **Debugging + testing:** `systematic-debugging`, `test-driven-development`, `verification-before-completion`
+3. **Code review:** `receiving-code-review`, `requesting-code-review`
+4. **Parallelism + isolation:** `subagent-driven-development`, `dispatching-parallel-agents`, `using-git-worktrees`
+5. **Meta + integration:** `finishing-a-development-branch`, `using-superjawn`, `writing-skills`
+
+**Per-skill build steps:**
+
+1. Copy upstream `SKILL.md` into `superjawn/skills/<name>/SKILL.md`
+2. Add MIT attribution comment at top with original source URL
+3. Insert `## Research phase` section at the stage from Section 2
+4. Rewrite cross-references (`superpowers:` → `superjawn:`)
+5. Update process flow diagram (dot graph) to include the new node
+6. Self-test on a small real task; confirm research phase fires and findings record correctly
+
+**Plugin install during build:** Local plugin path for fast iteration. Both upstream and superjawn installed; manually invoke `superjawn:<skill>` to test. After batch 5, disable upstream `superpowers`.
+
+**Versioning:**
+
+- `v0.1.0` — batch 1 shipped
+- `v0.2.0`–`v0.4.0` — batches 2–4
+- `v0.5.0` — batch 5 (all 14 in place, upstream still enabled)
+- `v1.0.0` — upstream disabled, 2+ weeks of real use, no critical issues
+
+**Per-batch testing:**
+
+- Cross-ref resolution: every `superjawn:` reference must resolve
+- Research phase fires: pick one small real task per skill, verify findings or skip line appear in the artifact
+- Skip protocol works: deliberately invoke on a trivial task, verify skip line is correct and audit-visible
+
+## Section 6 — Upstream drift management
+
+**Cadence:** Quarterly check (4×/year). Faster only on major upstream releases.
+
+**Diff mechanism:** `diff -ru` between upstream cache and `superjawn/skills/`, or compare upstream's `CHANGELOG.md` since the version recorded in `CREDITS.md`.
+
+**Baseline tracking in `CREDITS.md`:**
+
+```
+Synced against upstream obra/superpowers v5.0.7 (commit <fill in commit SHA at port time>) on 2026-05-05.
+Upstream changes since baseline: <list each port as it lands>
+```
+
+**Triage — what's worth porting:**
+
+- New skills upstream adds → port if relevant
+- Bug fixes to existing skills → port
+- Process improvements that don't conflict with research-phase additions → port
+- Re-flows of skill checklists that conflict → manually merge research phase back in
+
+**Skip:**
+
+- Pure copy edits (typos, formatting)
+- New visual-companion features etc. unless they'll be used
+- Anything that contradicts the research-phase design
+
+**Process when porting:**
+
+- One PR per upstream change
+- PR title: `port: <upstream commit summary>`
+- PR body links to upstream commit
+- Run per-skill test from Section 5 after porting
+
+**Drift-detection signal:** If a quarterly check finds upstream has diverged a lot (e.g. >1k LOC of skill changes in 90 days), escalate to a re-evaluation of approach.
+
+## Open questions / deferred decisions
+
+- Specific phrasing of the `## Research phase` text per skill — settled during implementation plan
+- Whether to add a parallel `superjawn-hooks/` plugin that enforces research-phase compliance via PreToolUse/PostToolUse hooks — out of scope for v1, revisit if drift becomes visible
+- Distribution beyond the marketplace (e.g. announcing to other CCM/journalism users) — deferred until v1.0.0
+
+## Next steps
+
+1. User reviews this spec
+2. On approval, invoke `superjawn:writing-plans` (once it exists) — or until then, `superpowers:writing-plans` — to produce the implementation plan
+3. Execute batch 1 first as a validation slice; pause after each batch for real-use feedback before next

--- a/superjawn/.claude-plugin/plugin.json
+++ b/superjawn/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "superjawn",
+  "version": "0.1.0",
+  "description": "Research-augmented skills derived from obra/superpowers — adds default-on research phases to each skill in the workflow",
+  "author": {
+    "name": "Joe Amditis",
+    "email": "jamditis@gmail.com"
+  }
+}

--- a/superjawn/CREDITS.md
+++ b/superjawn/CREDITS.md
@@ -4,7 +4,7 @@
 
 ## Upstream baseline
 
-Synced against upstream `obra/superpowers` v5.0.7 (commit: <fill in upstream commit SHA at first port>) on 2026-05-05.
+Synced against upstream `obra/superpowers` v5.0.7 (release tag) on 2026-05-05. The cached snapshot at `~/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.7/` is a release tarball, not a git checkout, so no commit SHA is available. Future syncs should pin to whichever upstream tag is current.
 
 ## Upstream changes ported since baseline
 

--- a/superjawn/CREDITS.md
+++ b/superjawn/CREDITS.md
@@ -13,3 +13,5 @@ Synced against upstream `obra/superpowers` v5.0.7 (release tag) on 2026-05-05. T
 ## Modifications from upstream
 
 Each skill in this plugin adds a `## Research phase` section relative to the upstream version. See `specs/2026-05-05-superjawn-research-phases-design.md` for the design rationale.
+
+Visual companion scripts (`skills/brainstorming/scripts/{helper.js,server.cjs,start-server.sh,stop-server.sh}`) diverge from upstream v5.0.7 with security and correctness fixes flagged during PR #34 review: XSS-safe DOM construction in `helper.js` (replaces `innerHTML` with `createElement`+`textContent`+`replaceChildren`), an inbound WebSocket frame size cap in `server.cjs` (rejects payloads above 1 MiB before allocating), `exec`-based PID preservation in `start-server.sh` foreground mode (so `server.pid` matches the node process), and SESSION_DIR validation in `stop-server.sh` (rejects paths outside `/tmp/brainstorm-*` or `*/.superpowers/brainstorm/*`). Carry these forward when syncing future upstream releases.

--- a/superjawn/CREDITS.md
+++ b/superjawn/CREDITS.md
@@ -1,0 +1,15 @@
+# Credits
+
+`superjawn` is a research-augmented variant of the [superpowers](https://github.com/obra/superpowers) plugin by Jesse Vincent. Original work is MIT-licensed; modifications carry the same license.
+
+## Upstream baseline
+
+Synced against upstream `obra/superpowers` v5.0.7 (commit: <fill in upstream commit SHA at first port>) on 2026-05-05.
+
+## Upstream changes ported since baseline
+
+(none yet — list each port as it lands, with link to upstream commit)
+
+## Modifications from upstream
+
+Each skill in this plugin adds a `## Research phase` section relative to the upstream version. See `specs/2026-05-05-superjawn-research-phases-design.md` for the design rationale.

--- a/superjawn/LICENSE
+++ b/superjawn/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 Jesse Vincent (original superpowers skills)
+Copyright (c) 2026 Joe Amditis (superjawn modifications)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/superjawn/README.md
+++ b/superjawn/README.md
@@ -1,0 +1,34 @@
+# superjawn
+
+Research-augmented Claude Code skills derived from [obra/superpowers](https://github.com/obra/superpowers) v5.0.7. Each skill grows a default-on research phase tailored to its stage of the workflow — gather trends, pitfalls, patterns, and discourse before building or proposing.
+
+## Skills
+
+| Skill | Status |
+|---|---|
+| `brainstorming` | Ported (Batch 1) |
+| `writing-plans` | Ported (Batch 1) |
+| `executing-plans` | Ported (Batch 1) |
+| `systematic-debugging` | Pending (Batch 2) |
+| `test-driven-development` | Pending (Batch 2) |
+| `verification-before-completion` | Pending (Batch 2) |
+| `receiving-code-review` | Pending (Batch 3) |
+| `requesting-code-review` | Pending (Batch 3) |
+| `subagent-driven-development` | Pending (Batch 4) |
+| `dispatching-parallel-agents` | Pending (Batch 4) |
+| `using-git-worktrees` | Pending (Batch 4) |
+| `finishing-a-development-branch` | Pending (Batch 5) |
+| `using-superjawn` | Pending (Batch 5) |
+| `writing-skills` | Pending (Batch 5) |
+
+## Coexistence with upstream
+
+During the rollout (v0.1.0 through v0.5.0), keep both `superpowers` and `superjawn` plugins installed. Skills not yet ported still resolve via `superpowers:<skill>`. At v1.0.0, after at least 2 weeks of real use of the full set, disable the upstream `superpowers` plugin in your Claude Code config.
+
+## Research phase
+
+Every ported skill includes a `## Research phase` section. By default, the research runs via subagent dispatch (`Explore` for codebase questions, `general-purpose` for web/discourse). Findings are written into the skill's existing artifact (spec, plan, debug log). Skipping research requires an explicit, justified line in the artifact — see each skill's Skip protocol.
+
+## Credits
+
+See `CREDITS.md`.

--- a/superjawn/skills/brainstorming/SKILL.md
+++ b/superjawn/skills/brainstorming/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: brainstorming
+description: "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation."
+---
+
+# Brainstorming Ideas Into Designs
+
+Help turn ideas into fully formed designs and specs through natural collaborative dialogue.
+
+Start by understanding the current project context, then ask questions one at a time to refine the idea. Once you understand what you're building, present the design and get user approval.
+
+<HARD-GATE>
+Do NOT invoke any implementation skill, write any code, scaffold any project, or take any implementation action until you have presented a design and the user has approved it. This applies to EVERY project regardless of perceived simplicity.
+</HARD-GATE>
+
+## Anti-Pattern: "This Is Too Simple To Need A Design"
+
+Every project goes through this process. A todo list, a single-function utility, a config change — all of them. "Simple" projects are where unexamined assumptions cause the most wasted work. The design can be short (a few sentences for truly simple projects), but you MUST present it and get approval.
+
+## Checklist
+
+You MUST create a task for each of these items and complete them in order:
+
+1. **Explore project context** — check files, docs, recent commits
+2. **Offer visual companion** (if topic will involve visual questions) — this is its own message, not combined with a clarifying question. See the Visual Companion section below.
+3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
+4. **Propose 2-3 approaches** — with trade-offs and your recommendation
+5. **Present design** — in sections scaled to their complexity, get user approval after each section
+6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
+7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
+8. **User reviews written spec** — ask user to review the spec file before proceeding
+9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
+
+## Process Flow
+
+```dot
+digraph brainstorming {
+    "Explore project context" [shape=box];
+    "Visual questions ahead?" [shape=diamond];
+    "Offer Visual Companion\n(own message, no other content)" [shape=box];
+    "Ask clarifying questions" [shape=box];
+    "Propose 2-3 approaches" [shape=box];
+    "Present design sections" [shape=box];
+    "User approves design?" [shape=diamond];
+    "Write design doc" [shape=box];
+    "Spec self-review\n(fix inline)" [shape=box];
+    "User reviews spec?" [shape=diamond];
+    "Invoke writing-plans skill" [shape=doublecircle];
+
+    "Explore project context" -> "Visual questions ahead?";
+    "Visual questions ahead?" -> "Offer Visual Companion\n(own message, no other content)" [label="yes"];
+    "Visual questions ahead?" -> "Ask clarifying questions" [label="no"];
+    "Offer Visual Companion\n(own message, no other content)" -> "Ask clarifying questions";
+    "Ask clarifying questions" -> "Propose 2-3 approaches";
+    "Propose 2-3 approaches" -> "Present design sections";
+    "Present design sections" -> "User approves design?";
+    "User approves design?" -> "Present design sections" [label="no, revise"];
+    "User approves design?" -> "Write design doc" [label="yes"];
+    "Write design doc" -> "Spec self-review\n(fix inline)";
+    "Spec self-review\n(fix inline)" -> "User reviews spec?";
+    "User reviews spec?" -> "Write design doc" [label="changes requested"];
+    "User reviews spec?" -> "Invoke writing-plans skill" [label="approved"];
+}
+```
+
+**The terminal state is invoking writing-plans.** Do NOT invoke frontend-design, mcp-builder, or any other implementation skill. The ONLY skill you invoke after brainstorming is writing-plans.
+
+## The Process
+
+**Understanding the idea:**
+
+- Check out the current project state first (files, docs, recent commits)
+- Before asking detailed questions, assess scope: if the request describes multiple independent subsystems (e.g., "build a platform with chat, file storage, billing, and analytics"), flag this immediately. Don't spend questions refining details of a project that needs to be decomposed first.
+- If the project is too large for a single spec, help the user decompose into sub-projects: what are the independent pieces, how do they relate, what order should they be built? Then brainstorm the first sub-project through the normal design flow. Each sub-project gets its own spec → plan → implementation cycle.
+- For appropriately-scoped projects, ask questions one at a time to refine the idea
+- Prefer multiple choice questions when possible, but open-ended is fine too
+- Only one question per message - if a topic needs more exploration, break it into multiple questions
+- Focus on understanding: purpose, constraints, success criteria
+
+**Exploring approaches:**
+
+- Propose 2-3 different approaches with trade-offs
+- Present options conversationally with your recommendation and reasoning
+- Lead with your recommended option and explain why
+
+**Presenting the design:**
+
+- Once you believe you understand what you're building, present the design
+- Scale each section to its complexity: a few sentences if straightforward, up to 200-300 words if nuanced
+- Ask after each section whether it looks right so far
+- Cover: architecture, components, data flow, error handling, testing
+- Be ready to go back and clarify if something doesn't make sense
+
+**Design for isolation and clarity:**
+
+- Break the system into smaller units that each have one clear purpose, communicate through well-defined interfaces, and can be understood and tested independently
+- For each unit, you should be able to answer: what does it do, how do you use it, and what does it depend on?
+- Can someone understand what a unit does without reading its internals? Can you change the internals without breaking consumers? If not, the boundaries need work.
+- Smaller, well-bounded units are also easier for you to work with - you reason better about code you can hold in context at once, and your edits are more reliable when files are focused. When a file grows large, that's often a signal that it's doing too much.
+
+**Working in existing codebases:**
+
+- Explore the current structure before proposing changes. Follow existing patterns.
+- Where existing code has problems that affect the work (e.g., a file that's grown too large, unclear boundaries, tangled responsibilities), include targeted improvements as part of the design - the way a good developer improves code they're working in.
+- Don't propose unrelated refactoring. Stay focused on what serves the current goal.
+
+## After the Design
+
+**Documentation:**
+
+- Write the validated design (spec) to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
+  - (User preferences for spec location override this default)
+- Use elements-of-style:writing-clearly-and-concisely skill if available
+- Commit the design document to git
+
+**Spec Self-Review:**
+After writing the spec document, look at it with fresh eyes:
+
+1. **Placeholder scan:** Any "TBD", "TODO", incomplete sections, or vague requirements? Fix them.
+2. **Internal consistency:** Do any sections contradict each other? Does the architecture match the feature descriptions?
+3. **Scope check:** Is this focused enough for a single implementation plan, or does it need decomposition?
+4. **Ambiguity check:** Could any requirement be interpreted two different ways? If so, pick one and make it explicit.
+
+Fix any issues inline. No need to re-review — just fix and move on.
+
+**User Review Gate:**
+After the spec review loop passes, ask the user to review the written spec before proceeding:
+
+> "Spec written and committed to `<path>`. Please review it and let me know if you want to make any changes before we start writing out the implementation plan."
+
+Wait for the user's response. If they request changes, make them and re-run the spec review loop. Only proceed once the user approves.
+
+**Implementation:**
+
+- Invoke the writing-plans skill to create a detailed implementation plan
+- Do NOT invoke any other skill. writing-plans is the next step.
+
+## Key Principles
+
+- **One question at a time** - Don't overwhelm with multiple questions
+- **Multiple choice preferred** - Easier to answer than open-ended when possible
+- **YAGNI ruthlessly** - Remove unnecessary features from all designs
+- **Explore alternatives** - Always propose 2-3 approaches before settling
+- **Incremental validation** - Present design, get approval before moving on
+- **Be flexible** - Go back and clarify when something doesn't make sense
+
+## Visual Companion
+
+A browser-based companion for showing mockups, diagrams, and visual options during brainstorming. Available as a tool — not a mode. Accepting the companion means it's available for questions that benefit from visual treatment; it does NOT mean every question goes through the browser.
+
+**Offering the companion:** When you anticipate that upcoming questions will involve visual content (mockups, layouts, diagrams), offer it once for consent:
+> "Some of what we're working on might be easier to explain if I can show it to you in a web browser. I can put together mockups, diagrams, comparisons, and other visuals as we go. This feature is still new and can be token-intensive. Want to try it? (Requires opening a local URL)"
+
+**This offer MUST be its own message.** Do not combine it with clarifying questions, context summaries, or any other content. The message should contain ONLY the offer above and nothing else. Wait for the user's response before continuing. If they decline, proceed with text-only brainstorming.
+
+**Per-question decision:** Even after the user accepts, decide FOR EACH QUESTION whether to use the browser or the terminal. The test: **would the user understand this better by seeing it than reading it?**
+
+- **Use the browser** for content that IS visual — mockups, wireframes, layout comparisons, architecture diagrams, side-by-side visual designs
+- **Use the terminal** for content that is text — requirements questions, conceptual choices, tradeoff lists, A/B/C/D text options, scope decisions
+
+A question about a UI topic is not automatically a visual question. "What does personality mean in this context?" is a conceptual question — use the terminal. "Which wizard layout works better?" is a visual question — use the browser.
+
+If they agree to the companion, read the detailed guide before proceeding:
+`skills/brainstorming/visual-companion.md`

--- a/superjawn/skills/brainstorming/SKILL.md
+++ b/superjawn/skills/brainstorming/SKILL.md
@@ -3,6 +3,14 @@ name: brainstorming
 description: "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation."
 ---
 
+<!--
+Adapted from obra/superpowers brainstorming skill (v5.0.7), MIT-licensed,
+copyright 2025 Jesse Vincent. Modifications copyright 2026 Joe Amditis.
+Modifications add a default-on research phase between clarifying questions
+and approach proposal, plus updates to cross-references and process flow.
+See CREDITS.md.
+-->
+
 # Brainstorming Ideas Into Designs
 
 Help turn ideas into fully formed designs and specs through natural collaborative dialogue.
@@ -24,12 +32,48 @@ You MUST create a task for each of these items and complete them in order:
 1. **Explore project context** — check files, docs, recent commits
 2. **Offer visual companion** (if topic will involve visual questions) — this is its own message, not combined with a clarifying question. See the Visual Companion section below.
 3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
-4. **Propose 2-3 approaches** — with trade-offs and your recommendation
-5. **Present design** — in sections scaled to their complexity, get user approval after each section
-6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
-7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
-8. **User reviews written spec** — ask user to review the spec file before proceeding
-9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
+4. **Research phase** — gather outside context (default-on; skip only with explicit justification). See "Research phase" section below.
+5. **Propose 2-3 approaches** — with trade-offs and your recommendation
+6. **Present design** — in sections scaled to their complexity, get user approval after each section
+7. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
+8. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
+9. **User reviews written spec** — ask user to review the spec file before proceeding
+10. **Transition to implementation** — invoke superjawn:writing-plans skill to create implementation plan
+
+## Research phase
+
+After clarifying questions, before proposing approaches, gather outside context. This is **default-on**: skip only with explicit, justified statement.
+
+### 1. Pick research kinds
+
+From the menu — trends + discourse, patterns, pitfalls, authoritative verification, user-context.
+
+For brainstorming, the **defaults are: web (trends + discourse) and codebase (prior art)**. Add others if the topic warrants — e.g. authoritative verification when an external API is in scope, or user-context when prior decisions in memory are relevant.
+
+### 2. Dispatch
+
+Subagent by default:
+- `Explore` for codebase / prior-art questions ("does this repo already have something like X?", "what's the convention for Y here?")
+- `general-purpose` for web / discourse / verification ("what's the current best practice for Z?", "what pitfalls do people hit with W?")
+- Run multiple in parallel when the kinds are independent
+
+Inline only for light-touch research (single grep, memory check).
+
+### 3. Record findings
+
+Write 3–5 tight bullets into the spec doc under a new `## Research notes` section. Include load-bearing links/refs and anything considered-but-ruled-out so future-you knows it was checked.
+
+### 4. Skip protocol
+
+If skipping, write one line into the spec doc: `Skipped research because <reason>. <Verifiable pointer if applicable>.`
+
+**Valid reasons:**
+- Trivial scope (typo, comment edit, single-line config)
+- Fresh prior research — same topic in current session OR within last 7 days with verifiable spec/plan pointer
+- User explicit (quote the phrase)
+- Repeat of identical task (with pointer to prior instance)
+
+**Invalid reasons:** "I think I know", "seems straightforward", "moving fast", "user wants this done quickly", "already familiar with this codebase". If those are tempting, do the research.
 
 ## Process Flow
 
@@ -39,6 +83,7 @@ digraph brainstorming {
     "Visual questions ahead?" [shape=diamond];
     "Offer Visual Companion\n(own message, no other content)" [shape=box];
     "Ask clarifying questions" [shape=box];
+    "Research phase" [shape=box];
     "Propose 2-3 approaches" [shape=box];
     "Present design sections" [shape=box];
     "User approves design?" [shape=diamond];
@@ -51,7 +96,8 @@ digraph brainstorming {
     "Visual questions ahead?" -> "Offer Visual Companion\n(own message, no other content)" [label="yes"];
     "Visual questions ahead?" -> "Ask clarifying questions" [label="no"];
     "Offer Visual Companion\n(own message, no other content)" -> "Ask clarifying questions";
-    "Ask clarifying questions" -> "Propose 2-3 approaches";
+    "Ask clarifying questions" -> "Research phase";
+    "Research phase" -> "Propose 2-3 approaches";
     "Propose 2-3 approaches" -> "Present design sections";
     "Present design sections" -> "User approves design?";
     "User approves design?" -> "Present design sections" [label="no, revise"];
@@ -120,6 +166,7 @@ After writing the spec document, look at it with fresh eyes:
 2. **Internal consistency:** Do any sections contradict each other? Does the architecture match the feature descriptions?
 3. **Scope check:** Is this focused enough for a single implementation plan, or does it need decomposition?
 4. **Ambiguity check:** Could any requirement be interpreted two different ways? If so, pick one and make it explicit.
+5. **Research phase check:** Does the spec contain either a `## Research notes` section with findings, or a one-line `Skipped research because <reason>` declaration? If neither, the brainstorming flow didn't run correctly — go back to the research phase before continuing.
 
 Fix any issues inline. No need to re-review — just fix and move on.
 

--- a/superjawn/skills/brainstorming/SKILL.md
+++ b/superjawn/skills/brainstorming/SKILL.md
@@ -69,9 +69,9 @@ If skipping, write one line into the spec doc: `Skipped research because <reason
 
 **Valid reasons:**
 - Trivial scope (typo, comment edit, single-line config)
-- Fresh prior research — same topic in current session OR within last 7 days with verifiable spec/plan pointer
-- User explicit (quote the phrase)
-- Repeat of identical task (with pointer to prior instance)
+- Fresh prior research — same topic in current session OR within last 7 days with verifiable spec/plan pointer. **If the pointer doesn't resolve, the skip is invalid.** (Beyond 7 days, repeat the research even if you remember the prior findings — the landscape drifts.)
+- User explicit — **must quote the phrase** that authorized the skip.
+- Repeat of identical task — **must include a pointer** to the prior successful run.
 
 **Invalid reasons:** "I think I know", "seems straightforward", "moving fast", "user wants this done quickly", "already familiar with this codebase". If those are tempting, do the research.
 

--- a/superjawn/skills/brainstorming/SKILL.md
+++ b/superjawn/skills/brainstorming/SKILL.md
@@ -109,7 +109,7 @@ digraph brainstorming {
 }
 ```
 
-**The terminal state is invoking superjawn:writing-plans.** Do NOT invoke superpowers:frontend-design, superpowers:mcp-builder, or any other implementation skill. The ONLY skill you invoke after brainstorming is superjawn:writing-plans.
+**The terminal state is invoking superjawn:writing-plans.** Do NOT invoke frontend-design, mcp-builder, or any other implementation skill. The ONLY skill you invoke after brainstorming is superjawn:writing-plans.
 
 ## The Process
 

--- a/superjawn/skills/brainstorming/SKILL.md
+++ b/superjawn/skills/brainstorming/SKILL.md
@@ -90,7 +90,7 @@ digraph brainstorming {
     "Write design doc" [shape=box];
     "Spec self-review\n(fix inline)" [shape=box];
     "User reviews spec?" [shape=diamond];
-    "Invoke writing-plans skill" [shape=doublecircle];
+    "Invoke superjawn:writing-plans skill" [shape=doublecircle];
 
     "Explore project context" -> "Visual questions ahead?";
     "Visual questions ahead?" -> "Offer Visual Companion\n(own message, no other content)" [label="yes"];
@@ -105,11 +105,11 @@ digraph brainstorming {
     "Write design doc" -> "Spec self-review\n(fix inline)";
     "Spec self-review\n(fix inline)" -> "User reviews spec?";
     "User reviews spec?" -> "Write design doc" [label="changes requested"];
-    "User reviews spec?" -> "Invoke writing-plans skill" [label="approved"];
+    "User reviews spec?" -> "Invoke superjawn:writing-plans skill" [label="approved"];
 }
 ```
 
-**The terminal state is invoking writing-plans.** Do NOT invoke frontend-design, mcp-builder, or any other implementation skill. The ONLY skill you invoke after brainstorming is writing-plans.
+**The terminal state is invoking superjawn:writing-plans.** Do NOT invoke superpowers:frontend-design, superpowers:mcp-builder, or any other implementation skill. The ONLY skill you invoke after brainstorming is superjawn:writing-plans.
 
 ## The Process
 
@@ -179,8 +179,8 @@ Wait for the user's response. If they request changes, make them and re-run the 
 
 **Implementation:**
 
-- Invoke the writing-plans skill to create a detailed implementation plan
-- Do NOT invoke any other skill. writing-plans is the next step.
+- Invoke the superjawn:writing-plans skill to create a detailed implementation plan
+- Do NOT invoke any other skill. superjawn:writing-plans is the next step.
 
 ## Key Principles
 

--- a/superjawn/skills/brainstorming/scripts/frame-template.html
+++ b/superjawn/skills/brainstorming/scripts/frame-template.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Superpowers Brainstorming</title>
+  <style>
+    /*
+     * BRAINSTORM COMPANION FRAME TEMPLATE
+     *
+     * This template provides a consistent frame with:
+     * - OS-aware light/dark theming
+     * - Fixed header and selection indicator bar
+     * - Scrollable main content area
+     * - CSS helpers for common UI patterns
+     *
+     * Content is injected via placeholder comment in #claude-content.
+     */
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; overflow: hidden; }
+
+    /* ===== THEME VARIABLES ===== */
+    :root {
+      --bg-primary: #f5f5f7;
+      --bg-secondary: #ffffff;
+      --bg-tertiary: #e5e5e7;
+      --border: #d1d1d6;
+      --text-primary: #1d1d1f;
+      --text-secondary: #86868b;
+      --text-tertiary: #aeaeb2;
+      --accent: #0071e3;
+      --accent-hover: #0077ed;
+      --success: #34c759;
+      --warning: #ff9f0a;
+      --error: #ff3b30;
+      --selected-bg: #e8f4fd;
+      --selected-border: #0071e3;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg-primary: #1d1d1f;
+        --bg-secondary: #2d2d2f;
+        --bg-tertiary: #3d3d3f;
+        --border: #424245;
+        --text-primary: #f5f5f7;
+        --text-secondary: #86868b;
+        --text-tertiary: #636366;
+        --accent: #0a84ff;
+        --accent-hover: #409cff;
+        --selected-bg: rgba(10, 132, 255, 0.15);
+        --selected-border: #0a84ff;
+      }
+    }
+
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+      background: var(--bg-primary);
+      color: var(--text-primary);
+      display: flex;
+      flex-direction: column;
+      line-height: 1.5;
+    }
+
+    /* ===== FRAME STRUCTURE ===== */
+    .header {
+      background: var(--bg-secondary);
+      padding: 0.5rem 1.5rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+    .header h1 { font-size: 0.85rem; font-weight: 500; color: var(--text-secondary); }
+    .header .status { font-size: 0.7rem; color: var(--success); display: flex; align-items: center; gap: 0.4rem; }
+    .header .status::before { content: ''; width: 6px; height: 6px; background: var(--success); border-radius: 50%; }
+
+    .main { flex: 1; overflow-y: auto; }
+    #claude-content { padding: 2rem; min-height: 100%; }
+
+    .indicator-bar {
+      background: var(--bg-secondary);
+      border-top: 1px solid var(--border);
+      padding: 0.5rem 1.5rem;
+      flex-shrink: 0;
+      text-align: center;
+    }
+    .indicator-bar span {
+      font-size: 0.75rem;
+      color: var(--text-secondary);
+    }
+    .indicator-bar .selected-text {
+      color: var(--accent);
+      font-weight: 500;
+    }
+
+    /* ===== TYPOGRAPHY ===== */
+    h2 { font-size: 1.5rem; font-weight: 600; margin-bottom: 0.5rem; }
+    h3 { font-size: 1.1rem; font-weight: 600; margin-bottom: 0.25rem; }
+    .subtitle { color: var(--text-secondary); margin-bottom: 1.5rem; }
+    .section { margin-bottom: 2rem; }
+    .label { font-size: 0.7rem; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.5rem; }
+
+    /* ===== OPTIONS (for A/B/C choices) ===== */
+    .options { display: flex; flex-direction: column; gap: 0.75rem; }
+    .option {
+      background: var(--bg-secondary);
+      border: 2px solid var(--border);
+      border-radius: 12px;
+      padding: 1rem 1.25rem;
+      cursor: pointer;
+      transition: all 0.15s ease;
+      display: flex;
+      align-items: flex-start;
+      gap: 1rem;
+    }
+    .option:hover { border-color: var(--accent); }
+    .option.selected { background: var(--selected-bg); border-color: var(--selected-border); }
+    .option .letter {
+      background: var(--bg-tertiary);
+      color: var(--text-secondary);
+      width: 1.75rem; height: 1.75rem;
+      border-radius: 6px;
+      display: flex; align-items: center; justify-content: center;
+      font-weight: 600; font-size: 0.85rem; flex-shrink: 0;
+    }
+    .option.selected .letter { background: var(--accent); color: white; }
+    .option .content { flex: 1; }
+    .option .content h3 { font-size: 0.95rem; margin-bottom: 0.15rem; }
+    .option .content p { color: var(--text-secondary); font-size: 0.85rem; margin: 0; }
+
+    /* ===== CARDS (for showing designs/mockups) ===== */
+    .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; }
+    .card {
+      background: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      overflow: hidden;
+      cursor: pointer;
+      transition: all 0.15s ease;
+    }
+    .card:hover { border-color: var(--accent); transform: translateY(-2px); box-shadow: 0 4px 12px rgba(0,0,0,0.1); }
+    .card.selected { border-color: var(--selected-border); border-width: 2px; }
+    .card-image { background: var(--bg-tertiary); aspect-ratio: 16/10; display: flex; align-items: center; justify-content: center; }
+    .card-body { padding: 1rem; }
+    .card-body h3 { margin-bottom: 0.25rem; }
+    .card-body p { color: var(--text-secondary); font-size: 0.85rem; }
+
+    /* ===== MOCKUP CONTAINER ===== */
+    .mockup {
+      background: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      overflow: hidden;
+      margin-bottom: 1.5rem;
+    }
+    .mockup-header {
+      background: var(--bg-tertiary);
+      padding: 0.5rem 1rem;
+      font-size: 0.75rem;
+      color: var(--text-secondary);
+      border-bottom: 1px solid var(--border);
+    }
+    .mockup-body { padding: 1.5rem; }
+
+    /* ===== SPLIT VIEW (side-by-side comparison) ===== */
+    .split { display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; }
+    @media (max-width: 700px) { .split { grid-template-columns: 1fr; } }
+
+    /* ===== PROS/CONS ===== */
+    .pros-cons { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin: 1rem 0; }
+    .pros, .cons { background: var(--bg-secondary); border-radius: 8px; padding: 1rem; }
+    .pros h4 { color: var(--success); font-size: 0.85rem; margin-bottom: 0.5rem; }
+    .cons h4 { color: var(--error); font-size: 0.85rem; margin-bottom: 0.5rem; }
+    .pros ul, .cons ul { margin-left: 1.25rem; font-size: 0.85rem; color: var(--text-secondary); }
+    .pros li, .cons li { margin-bottom: 0.25rem; }
+
+    /* ===== PLACEHOLDER (for mockup areas) ===== */
+    .placeholder {
+      background: var(--bg-tertiary);
+      border: 2px dashed var(--border);
+      border-radius: 8px;
+      padding: 2rem;
+      text-align: center;
+      color: var(--text-tertiary);
+    }
+
+    /* ===== INLINE MOCKUP ELEMENTS ===== */
+    .mock-nav { background: var(--accent); color: white; padding: 0.75rem 1rem; display: flex; gap: 1.5rem; font-size: 0.9rem; }
+    .mock-sidebar { background: var(--bg-tertiary); padding: 1rem; min-width: 180px; }
+    .mock-content { padding: 1.5rem; flex: 1; }
+    .mock-button { background: var(--accent); color: white; border: none; padding: 0.5rem 1rem; border-radius: 6px; font-size: 0.85rem; }
+    .mock-input { background: var(--bg-primary); border: 1px solid var(--border); border-radius: 6px; padding: 0.5rem; width: 100%; }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <h1><a href="https://github.com/obra/superpowers" style="color: inherit; text-decoration: none;">Superpowers Brainstorming</a></h1>
+    <div class="status">Connected</div>
+  </div>
+
+  <div class="main">
+    <div id="claude-content">
+      <!-- CONTENT -->
+    </div>
+  </div>
+
+  <div class="indicator-bar">
+    <span id="indicator-text">Click an option above, then return to the terminal</span>
+  </div>
+
+</body>
+</html>

--- a/superjawn/skills/brainstorming/scripts/frame-template.html
+++ b/superjawn/skills/brainstorming/scripts/frame-template.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Superpowers Brainstorming</title>
+  <title>superjawn Brainstorming</title>
   <style>
     /*
      * BRAINSTORM COMPANION FRAME TEMPLATE

--- a/superjawn/skills/brainstorming/scripts/frame-template.html
+++ b/superjawn/skills/brainstorming/scripts/frame-template.html
@@ -196,7 +196,7 @@
 </head>
 <body>
   <div class="header">
-    <h1><a href="https://github.com/obra/superpowers" style="color: inherit; text-decoration: none;">Superpowers Brainstorming</a></h1>
+    <h1><a href="https://github.com/jamditis/claude-skills-journalism/tree/master/superjawn" style="color: inherit; text-decoration: none;">superjawn Brainstorming</a> <span style="font-size: 0.7em; opacity: 0.7;">(forked from <a href="https://github.com/obra/superpowers" style="color: inherit; text-decoration: underline;">superpowers</a>)</span></h1>
     <div class="status">Connected</div>
   </div>
 

--- a/superjawn/skills/brainstorming/scripts/helper.js
+++ b/superjawn/skills/brainstorming/scripts/helper.js
@@ -1,0 +1,88 @@
+(function() {
+  const WS_URL = 'ws://' + window.location.host;
+  let ws = null;
+  let eventQueue = [];
+
+  function connect() {
+    ws = new WebSocket(WS_URL);
+
+    ws.onopen = () => {
+      eventQueue.forEach(e => ws.send(JSON.stringify(e)));
+      eventQueue = [];
+    };
+
+    ws.onmessage = (msg) => {
+      const data = JSON.parse(msg.data);
+      if (data.type === 'reload') {
+        window.location.reload();
+      }
+    };
+
+    ws.onclose = () => {
+      setTimeout(connect, 1000);
+    };
+  }
+
+  function sendEvent(event) {
+    event.timestamp = Date.now();
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(event));
+    } else {
+      eventQueue.push(event);
+    }
+  }
+
+  // Capture clicks on choice elements
+  document.addEventListener('click', (e) => {
+    const target = e.target.closest('[data-choice]');
+    if (!target) return;
+
+    sendEvent({
+      type: 'click',
+      text: target.textContent.trim(),
+      choice: target.dataset.choice,
+      id: target.id || null
+    });
+
+    // Update indicator bar (defer so toggleSelect runs first)
+    setTimeout(() => {
+      const indicator = document.getElementById('indicator-text');
+      if (!indicator) return;
+      const container = target.closest('.options') || target.closest('.cards');
+      const selected = container ? container.querySelectorAll('.selected') : [];
+      if (selected.length === 0) {
+        indicator.textContent = 'Click an option above, then return to the terminal';
+      } else if (selected.length === 1) {
+        const label = selected[0].querySelector('h3, .content h3, .card-body h3')?.textContent?.trim() || selected[0].dataset.choice;
+        indicator.innerHTML = '<span class="selected-text">' + label + ' selected</span> — return to terminal to continue';
+      } else {
+        indicator.innerHTML = '<span class="selected-text">' + selected.length + ' selected</span> — return to terminal to continue';
+      }
+    }, 0);
+  });
+
+  // Frame UI: selection tracking
+  window.selectedChoice = null;
+
+  window.toggleSelect = function(el) {
+    const container = el.closest('.options') || el.closest('.cards');
+    const multi = container && container.dataset.multiselect !== undefined;
+    if (container && !multi) {
+      container.querySelectorAll('.option, .card').forEach(o => o.classList.remove('selected'));
+    }
+    if (multi) {
+      el.classList.toggle('selected');
+    } else {
+      el.classList.add('selected');
+    }
+    window.selectedChoice = el.dataset.choice;
+  };
+
+  // Expose API for explicit use
+  window.brainstorm = {
+    send: sendEvent,
+    choice: (value, metadata = {}) => sendEvent({ type: 'choice', value, ...metadata })
+  };
+
+  connect();
+})();

--- a/superjawn/skills/brainstorming/scripts/helper.js
+++ b/superjawn/skills/brainstorming/scripts/helper.js
@@ -52,11 +52,14 @@
       const selected = container ? container.querySelectorAll('.selected') : [];
       if (selected.length === 0) {
         indicator.textContent = 'Click an option above, then return to the terminal';
-      } else if (selected.length === 1) {
-        const label = selected[0].querySelector('h3, .content h3, .card-body h3')?.textContent?.trim() || selected[0].dataset.choice;
-        indicator.innerHTML = '<span class="selected-text">' + label + ' selected</span> — return to terminal to continue';
       } else {
-        indicator.innerHTML = '<span class="selected-text">' + selected.length + ' selected</span> — return to terminal to continue';
+        const labelText = selected.length === 1
+          ? (selected[0].querySelector('h3, .content h3, .card-body h3')?.textContent?.trim() || selected[0].dataset.choice)
+          : String(selected.length);
+        const span = document.createElement('span');
+        span.className = 'selected-text';
+        span.textContent = labelText + ' selected';
+        indicator.replaceChildren(span, ' — return to terminal to continue');
       }
     }, 0);
   });

--- a/superjawn/skills/brainstorming/scripts/server.cjs
+++ b/superjawn/skills/brainstorming/scripts/server.cjs
@@ -1,0 +1,354 @@
+const crypto = require('crypto');
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+// ========== WebSocket Protocol (RFC 6455) ==========
+
+const OPCODES = { TEXT: 0x01, CLOSE: 0x08, PING: 0x09, PONG: 0x0A };
+const WS_MAGIC = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+
+function computeAcceptKey(clientKey) {
+  return crypto.createHash('sha1').update(clientKey + WS_MAGIC).digest('base64');
+}
+
+function encodeFrame(opcode, payload) {
+  const fin = 0x80;
+  const len = payload.length;
+  let header;
+
+  if (len < 126) {
+    header = Buffer.alloc(2);
+    header[0] = fin | opcode;
+    header[1] = len;
+  } else if (len < 65536) {
+    header = Buffer.alloc(4);
+    header[0] = fin | opcode;
+    header[1] = 126;
+    header.writeUInt16BE(len, 2);
+  } else {
+    header = Buffer.alloc(10);
+    header[0] = fin | opcode;
+    header[1] = 127;
+    header.writeBigUInt64BE(BigInt(len), 2);
+  }
+
+  return Buffer.concat([header, payload]);
+}
+
+function decodeFrame(buffer) {
+  if (buffer.length < 2) return null;
+
+  const secondByte = buffer[1];
+  const opcode = buffer[0] & 0x0F;
+  const masked = (secondByte & 0x80) !== 0;
+  let payloadLen = secondByte & 0x7F;
+  let offset = 2;
+
+  if (!masked) throw new Error('Client frames must be masked');
+
+  if (payloadLen === 126) {
+    if (buffer.length < 4) return null;
+    payloadLen = buffer.readUInt16BE(2);
+    offset = 4;
+  } else if (payloadLen === 127) {
+    if (buffer.length < 10) return null;
+    payloadLen = Number(buffer.readBigUInt64BE(2));
+    offset = 10;
+  }
+
+  const maskOffset = offset;
+  const dataOffset = offset + 4;
+  const totalLen = dataOffset + payloadLen;
+  if (buffer.length < totalLen) return null;
+
+  const mask = buffer.slice(maskOffset, dataOffset);
+  const data = Buffer.alloc(payloadLen);
+  for (let i = 0; i < payloadLen; i++) {
+    data[i] = buffer[dataOffset + i] ^ mask[i % 4];
+  }
+
+  return { opcode, payload: data, bytesConsumed: totalLen };
+}
+
+// ========== Configuration ==========
+
+const PORT = process.env.BRAINSTORM_PORT || (49152 + Math.floor(Math.random() * 16383));
+const HOST = process.env.BRAINSTORM_HOST || '127.0.0.1';
+const URL_HOST = process.env.BRAINSTORM_URL_HOST || (HOST === '127.0.0.1' ? 'localhost' : HOST);
+const SESSION_DIR = process.env.BRAINSTORM_DIR || '/tmp/brainstorm';
+const CONTENT_DIR = path.join(SESSION_DIR, 'content');
+const STATE_DIR = path.join(SESSION_DIR, 'state');
+let ownerPid = process.env.BRAINSTORM_OWNER_PID ? Number(process.env.BRAINSTORM_OWNER_PID) : null;
+
+const MIME_TYPES = {
+  '.html': 'text/html', '.css': 'text/css', '.js': 'application/javascript',
+  '.json': 'application/json', '.png': 'image/png', '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg', '.gif': 'image/gif', '.svg': 'image/svg+xml'
+};
+
+// ========== Templates and Constants ==========
+
+const WAITING_PAGE = `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>Brainstorm Companion</title>
+<style>body { font-family: system-ui, sans-serif; padding: 2rem; max-width: 800px; margin: 0 auto; }
+h1 { color: #333; } p { color: #666; }</style>
+</head>
+<body><h1>Brainstorm Companion</h1>
+<p>Waiting for the agent to push a screen...</p></body></html>`;
+
+const frameTemplate = fs.readFileSync(path.join(__dirname, 'frame-template.html'), 'utf-8');
+const helperScript = fs.readFileSync(path.join(__dirname, 'helper.js'), 'utf-8');
+const helperInjection = '<script>\n' + helperScript + '\n</script>';
+
+// ========== Helper Functions ==========
+
+function isFullDocument(html) {
+  const trimmed = html.trimStart().toLowerCase();
+  return trimmed.startsWith('<!doctype') || trimmed.startsWith('<html');
+}
+
+function wrapInFrame(content) {
+  return frameTemplate.replace('<!-- CONTENT -->', content);
+}
+
+function getNewestScreen() {
+  const files = fs.readdirSync(CONTENT_DIR)
+    .filter(f => f.endsWith('.html'))
+    .map(f => {
+      const fp = path.join(CONTENT_DIR, f);
+      return { path: fp, mtime: fs.statSync(fp).mtime.getTime() };
+    })
+    .sort((a, b) => b.mtime - a.mtime);
+  return files.length > 0 ? files[0].path : null;
+}
+
+// ========== HTTP Request Handler ==========
+
+function handleRequest(req, res) {
+  touchActivity();
+  if (req.method === 'GET' && req.url === '/') {
+    const screenFile = getNewestScreen();
+    let html = screenFile
+      ? (raw => isFullDocument(raw) ? raw : wrapInFrame(raw))(fs.readFileSync(screenFile, 'utf-8'))
+      : WAITING_PAGE;
+
+    if (html.includes('</body>')) {
+      html = html.replace('</body>', helperInjection + '\n</body>');
+    } else {
+      html += helperInjection;
+    }
+
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(html);
+  } else if (req.method === 'GET' && req.url.startsWith('/files/')) {
+    const fileName = req.url.slice(7);
+    const filePath = path.join(CONTENT_DIR, path.basename(fileName));
+    if (!fs.existsSync(filePath)) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    const ext = path.extname(filePath).toLowerCase();
+    const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(fs.readFileSync(filePath));
+  } else {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+}
+
+// ========== WebSocket Connection Handling ==========
+
+const clients = new Set();
+
+function handleUpgrade(req, socket) {
+  const key = req.headers['sec-websocket-key'];
+  if (!key) { socket.destroy(); return; }
+
+  const accept = computeAcceptKey(key);
+  socket.write(
+    'HTTP/1.1 101 Switching Protocols\r\n' +
+    'Upgrade: websocket\r\n' +
+    'Connection: Upgrade\r\n' +
+    'Sec-WebSocket-Accept: ' + accept + '\r\n\r\n'
+  );
+
+  let buffer = Buffer.alloc(0);
+  clients.add(socket);
+
+  socket.on('data', (chunk) => {
+    buffer = Buffer.concat([buffer, chunk]);
+    while (buffer.length > 0) {
+      let result;
+      try {
+        result = decodeFrame(buffer);
+      } catch (e) {
+        socket.end(encodeFrame(OPCODES.CLOSE, Buffer.alloc(0)));
+        clients.delete(socket);
+        return;
+      }
+      if (!result) break;
+      buffer = buffer.slice(result.bytesConsumed);
+
+      switch (result.opcode) {
+        case OPCODES.TEXT:
+          handleMessage(result.payload.toString());
+          break;
+        case OPCODES.CLOSE:
+          socket.end(encodeFrame(OPCODES.CLOSE, Buffer.alloc(0)));
+          clients.delete(socket);
+          return;
+        case OPCODES.PING:
+          socket.write(encodeFrame(OPCODES.PONG, result.payload));
+          break;
+        case OPCODES.PONG:
+          break;
+        default: {
+          const closeBuf = Buffer.alloc(2);
+          closeBuf.writeUInt16BE(1003);
+          socket.end(encodeFrame(OPCODES.CLOSE, closeBuf));
+          clients.delete(socket);
+          return;
+        }
+      }
+    }
+  });
+
+  socket.on('close', () => clients.delete(socket));
+  socket.on('error', () => clients.delete(socket));
+}
+
+function handleMessage(text) {
+  let event;
+  try {
+    event = JSON.parse(text);
+  } catch (e) {
+    console.error('Failed to parse WebSocket message:', e.message);
+    return;
+  }
+  touchActivity();
+  console.log(JSON.stringify({ source: 'user-event', ...event }));
+  if (event.choice) {
+    const eventsFile = path.join(STATE_DIR, 'events');
+    fs.appendFileSync(eventsFile, JSON.stringify(event) + '\n');
+  }
+}
+
+function broadcast(msg) {
+  const frame = encodeFrame(OPCODES.TEXT, Buffer.from(JSON.stringify(msg)));
+  for (const socket of clients) {
+    try { socket.write(frame); } catch (e) { clients.delete(socket); }
+  }
+}
+
+// ========== Activity Tracking ==========
+
+const IDLE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+let lastActivity = Date.now();
+
+function touchActivity() {
+  lastActivity = Date.now();
+}
+
+// ========== File Watching ==========
+
+const debounceTimers = new Map();
+
+// ========== Server Startup ==========
+
+function startServer() {
+  if (!fs.existsSync(CONTENT_DIR)) fs.mkdirSync(CONTENT_DIR, { recursive: true });
+  if (!fs.existsSync(STATE_DIR)) fs.mkdirSync(STATE_DIR, { recursive: true });
+
+  // Track known files to distinguish new screens from updates.
+  // macOS fs.watch reports 'rename' for both new files and overwrites,
+  // so we can't rely on eventType alone.
+  const knownFiles = new Set(
+    fs.readdirSync(CONTENT_DIR).filter(f => f.endsWith('.html'))
+  );
+
+  const server = http.createServer(handleRequest);
+  server.on('upgrade', handleUpgrade);
+
+  const watcher = fs.watch(CONTENT_DIR, (eventType, filename) => {
+    if (!filename || !filename.endsWith('.html')) return;
+
+    if (debounceTimers.has(filename)) clearTimeout(debounceTimers.get(filename));
+    debounceTimers.set(filename, setTimeout(() => {
+      debounceTimers.delete(filename);
+      const filePath = path.join(CONTENT_DIR, filename);
+
+      if (!fs.existsSync(filePath)) return; // file was deleted
+      touchActivity();
+
+      if (!knownFiles.has(filename)) {
+        knownFiles.add(filename);
+        const eventsFile = path.join(STATE_DIR, 'events');
+        if (fs.existsSync(eventsFile)) fs.unlinkSync(eventsFile);
+        console.log(JSON.stringify({ type: 'screen-added', file: filePath }));
+      } else {
+        console.log(JSON.stringify({ type: 'screen-updated', file: filePath }));
+      }
+
+      broadcast({ type: 'reload' });
+    }, 100));
+  });
+  watcher.on('error', (err) => console.error('fs.watch error:', err.message));
+
+  function shutdown(reason) {
+    console.log(JSON.stringify({ type: 'server-stopped', reason }));
+    const infoFile = path.join(STATE_DIR, 'server-info');
+    if (fs.existsSync(infoFile)) fs.unlinkSync(infoFile);
+    fs.writeFileSync(
+      path.join(STATE_DIR, 'server-stopped'),
+      JSON.stringify({ reason, timestamp: Date.now() }) + '\n'
+    );
+    watcher.close();
+    clearInterval(lifecycleCheck);
+    server.close(() => process.exit(0));
+  }
+
+  function ownerAlive() {
+    if (!ownerPid) return true;
+    try { process.kill(ownerPid, 0); return true; } catch (e) { return e.code === 'EPERM'; }
+  }
+
+  // Check every 60s: exit if owner process died or idle for 30 minutes
+  const lifecycleCheck = setInterval(() => {
+    if (!ownerAlive()) shutdown('owner process exited');
+    else if (Date.now() - lastActivity > IDLE_TIMEOUT_MS) shutdown('idle timeout');
+  }, 60 * 1000);
+  lifecycleCheck.unref();
+
+  // Validate owner PID at startup. If it's already dead, the PID resolution
+  // was wrong (common on WSL, Tailscale SSH, and cross-user scenarios).
+  // Disable monitoring and rely on the idle timeout instead.
+  if (ownerPid) {
+    try { process.kill(ownerPid, 0); }
+    catch (e) {
+      if (e.code !== 'EPERM') {
+        console.log(JSON.stringify({ type: 'owner-pid-invalid', pid: ownerPid, reason: 'dead at startup' }));
+        ownerPid = null;
+      }
+    }
+  }
+
+  server.listen(PORT, HOST, () => {
+    const info = JSON.stringify({
+      type: 'server-started', port: Number(PORT), host: HOST,
+      url_host: URL_HOST, url: 'http://' + URL_HOST + ':' + PORT,
+      screen_dir: CONTENT_DIR, state_dir: STATE_DIR
+    });
+    console.log(info);
+    fs.writeFileSync(path.join(STATE_DIR, 'server-info'), info + '\n');
+  });
+}
+
+if (require.main === module) {
+  startServer();
+}
+
+module.exports = { computeAcceptKey, encodeFrame, decodeFrame, OPCODES };

--- a/superjawn/skills/brainstorming/scripts/server.cjs
+++ b/superjawn/skills/brainstorming/scripts/server.cjs
@@ -6,6 +6,7 @@ const path = require('path');
 // ========== WebSocket Protocol (RFC 6455) ==========
 
 const OPCODES = { TEXT: 0x01, CLOSE: 0x08, PING: 0x09, PONG: 0x0A };
+const MAX_FRAME_BYTES = 1 << 20;
 const WS_MAGIC = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
 
 function computeAcceptKey(clientKey) {
@@ -55,6 +56,10 @@ function decodeFrame(buffer) {
     if (buffer.length < 10) return null;
     payloadLen = Number(buffer.readBigUInt64BE(2));
     offset = 10;
+  }
+
+  if (payloadLen > MAX_FRAME_BYTES) {
+    throw new Error('Frame payload exceeds maximum (' + payloadLen + ' > ' + MAX_FRAME_BYTES + ')');
   }
 
   const maskOffset = offset;

--- a/superjawn/skills/brainstorming/scripts/start-server.sh
+++ b/superjawn/skills/brainstorming/scripts/start-server.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Start the brainstorm server and output connection info
+# Usage: start-server.sh [--project-dir <path>] [--host <bind-host>] [--url-host <display-host>] [--foreground] [--background]
+#
+# Starts server on a random high port, outputs JSON with URL.
+# Each session gets its own directory to avoid conflicts.
+#
+# Options:
+#   --project-dir <path>  Store session files under <path>/.superpowers/brainstorm/
+#                         instead of /tmp. Files persist after server stops.
+#   --host <bind-host>    Host/interface to bind (default: 127.0.0.1).
+#                         Use 0.0.0.0 in remote/containerized environments.
+#   --url-host <host>     Hostname shown in returned URL JSON.
+#   --foreground          Run server in the current terminal (no backgrounding).
+#   --background          Force background mode (overrides Codex auto-foreground).
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Parse arguments
+PROJECT_DIR=""
+FOREGROUND="false"
+FORCE_BACKGROUND="false"
+BIND_HOST="127.0.0.1"
+URL_HOST=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project-dir)
+      PROJECT_DIR="$2"
+      shift 2
+      ;;
+    --host)
+      BIND_HOST="$2"
+      shift 2
+      ;;
+    --url-host)
+      URL_HOST="$2"
+      shift 2
+      ;;
+    --foreground|--no-daemon)
+      FOREGROUND="true"
+      shift
+      ;;
+    --background|--daemon)
+      FORCE_BACKGROUND="true"
+      shift
+      ;;
+    *)
+      echo "{\"error\": \"Unknown argument: $1\"}"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$URL_HOST" ]]; then
+  if [[ "$BIND_HOST" == "127.0.0.1" || "$BIND_HOST" == "localhost" ]]; then
+    URL_HOST="localhost"
+  else
+    URL_HOST="$BIND_HOST"
+  fi
+fi
+
+# Some environments reap detached/background processes. Auto-foreground when detected.
+if [[ -n "${CODEX_CI:-}" && "$FOREGROUND" != "true" && "$FORCE_BACKGROUND" != "true" ]]; then
+  FOREGROUND="true"
+fi
+
+# Windows/Git Bash reaps nohup background processes. Auto-foreground when detected.
+if [[ "$FOREGROUND" != "true" && "$FORCE_BACKGROUND" != "true" ]]; then
+  case "${OSTYPE:-}" in
+    msys*|cygwin*|mingw*) FOREGROUND="true" ;;
+  esac
+  if [[ -n "${MSYSTEM:-}" ]]; then
+    FOREGROUND="true"
+  fi
+fi
+
+# Generate unique session directory
+SESSION_ID="$$-$(date +%s)"
+
+if [[ -n "$PROJECT_DIR" ]]; then
+  SESSION_DIR="${PROJECT_DIR}/.superpowers/brainstorm/${SESSION_ID}"
+else
+  SESSION_DIR="/tmp/brainstorm-${SESSION_ID}"
+fi
+
+STATE_DIR="${SESSION_DIR}/state"
+PID_FILE="${STATE_DIR}/server.pid"
+LOG_FILE="${STATE_DIR}/server.log"
+
+# Create fresh session directory with content and state peers
+mkdir -p "${SESSION_DIR}/content" "$STATE_DIR"
+
+# Kill any existing server
+if [[ -f "$PID_FILE" ]]; then
+  old_pid=$(cat "$PID_FILE")
+  kill "$old_pid" 2>/dev/null
+  rm -f "$PID_FILE"
+fi
+
+cd "$SCRIPT_DIR"
+
+# Resolve the harness PID (grandparent of this script).
+# $PPID is the ephemeral shell the harness spawned to run us — it dies
+# when this script exits. The harness itself is $PPID's parent.
+OWNER_PID="$(ps -o ppid= -p "$PPID" 2>/dev/null | tr -d ' ')"
+if [[ -z "$OWNER_PID" || "$OWNER_PID" == "1" ]]; then
+  OWNER_PID="$PPID"
+fi
+
+# Foreground mode for environments that reap detached/background processes.
+if [[ "$FOREGROUND" == "true" ]]; then
+  echo "$$" > "$PID_FILE"
+  env BRAINSTORM_DIR="$SESSION_DIR" BRAINSTORM_HOST="$BIND_HOST" BRAINSTORM_URL_HOST="$URL_HOST" BRAINSTORM_OWNER_PID="$OWNER_PID" node server.cjs
+  exit $?
+fi
+
+# Start server, capturing output to log file
+# Use nohup to survive shell exit; disown to remove from job table
+nohup env BRAINSTORM_DIR="$SESSION_DIR" BRAINSTORM_HOST="$BIND_HOST" BRAINSTORM_URL_HOST="$URL_HOST" BRAINSTORM_OWNER_PID="$OWNER_PID" node server.cjs > "$LOG_FILE" 2>&1 &
+SERVER_PID=$!
+disown "$SERVER_PID" 2>/dev/null
+echo "$SERVER_PID" > "$PID_FILE"
+
+# Wait for server-started message (check log file)
+for i in {1..50}; do
+  if grep -q "server-started" "$LOG_FILE" 2>/dev/null; then
+    # Verify server is still alive after a short window (catches process reapers)
+    alive="true"
+    for _ in {1..20}; do
+      if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        alive="false"
+        break
+      fi
+      sleep 0.1
+    done
+    if [[ "$alive" != "true" ]]; then
+      echo "{\"error\": \"Server started but was killed. Retry in a persistent terminal with: $SCRIPT_DIR/start-server.sh${PROJECT_DIR:+ --project-dir $PROJECT_DIR} --host $BIND_HOST --url-host $URL_HOST --foreground\"}"
+      exit 1
+    fi
+    grep "server-started" "$LOG_FILE" | head -1
+    exit 0
+  fi
+  sleep 0.1
+done
+
+# Timeout - server didn't start
+echo '{"error": "Server failed to start within 5 seconds"}'
+exit 1

--- a/superjawn/skills/brainstorming/scripts/start-server.sh
+++ b/superjawn/skills/brainstorming/scripts/start-server.sh
@@ -108,10 +108,11 @@ if [[ -z "$OWNER_PID" || "$OWNER_PID" == "1" ]]; then
 fi
 
 # Foreground mode for environments that reap detached/background processes.
+# `exec` replaces this bash process with node, preserving PID so the value
+# already written to PID_FILE refers to the actual server process.
 if [[ "$FOREGROUND" == "true" ]]; then
   echo "$$" > "$PID_FILE"
-  env BRAINSTORM_DIR="$SESSION_DIR" BRAINSTORM_HOST="$BIND_HOST" BRAINSTORM_URL_HOST="$URL_HOST" BRAINSTORM_OWNER_PID="$OWNER_PID" node server.cjs
-  exit $?
+  exec env BRAINSTORM_DIR="$SESSION_DIR" BRAINSTORM_HOST="$BIND_HOST" BRAINSTORM_URL_HOST="$URL_HOST" BRAINSTORM_OWNER_PID="$OWNER_PID" node server.cjs
 fi
 
 # Start server, capturing output to log file

--- a/superjawn/skills/brainstorming/scripts/stop-server.sh
+++ b/superjawn/skills/brainstorming/scripts/stop-server.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Stop the brainstorm server and clean up
+# Usage: stop-server.sh <session_dir>
+#
+# Kills the server process. Only deletes session directory if it's
+# under /tmp (ephemeral). Persistent directories (.superpowers/) are
+# kept so mockups can be reviewed later.
+
+SESSION_DIR="$1"
+
+if [[ -z "$SESSION_DIR" ]]; then
+  echo '{"error": "Usage: stop-server.sh <session_dir>"}'
+  exit 1
+fi
+
+STATE_DIR="${SESSION_DIR}/state"
+PID_FILE="${STATE_DIR}/server.pid"
+
+if [[ -f "$PID_FILE" ]]; then
+  pid=$(cat "$PID_FILE")
+
+  # Try to stop gracefully, fallback to force if still alive
+  kill "$pid" 2>/dev/null || true
+
+  # Wait for graceful shutdown (up to ~2s)
+  for i in {1..20}; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.1
+  done
+
+  # If still running, escalate to SIGKILL
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -9 "$pid" 2>/dev/null || true
+
+    # Give SIGKILL a moment to take effect
+    sleep 0.1
+  fi
+
+  if kill -0 "$pid" 2>/dev/null; then
+    echo '{"status": "failed", "error": "process still running"}'
+    exit 1
+  fi
+
+  rm -f "$PID_FILE" "${STATE_DIR}/server.log"
+
+  # Only delete ephemeral /tmp directories
+  if [[ "$SESSION_DIR" == /tmp/* ]]; then
+    rm -rf "$SESSION_DIR"
+  fi
+
+  echo '{"status": "stopped"}'
+else
+  echo '{"status": "not_running"}'
+fi

--- a/superjawn/skills/brainstorming/scripts/stop-server.sh
+++ b/superjawn/skills/brainstorming/scripts/stop-server.sh
@@ -13,6 +13,16 @@ if [[ -z "$SESSION_DIR" ]]; then
   exit 1
 fi
 
+# Refuse to act on paths outside known brainstorm session locations.
+case "$SESSION_DIR" in
+  /tmp/brainstorm-*) ;;
+  */.superpowers/brainstorm/*) ;;
+  *)
+    echo '{"error": "session_dir must be /tmp/brainstorm-* or .../.superpowers/brainstorm/*"}'
+    exit 1
+    ;;
+esac
+
 STATE_DIR="${SESSION_DIR}/state"
 PID_FILE="${STATE_DIR}/server.pid"
 

--- a/superjawn/skills/brainstorming/spec-document-reviewer-prompt.md
+++ b/superjawn/skills/brainstorming/spec-document-reviewer-prompt.md
@@ -1,0 +1,49 @@
+# Spec Document Reviewer Prompt Template
+
+Use this template when dispatching a spec document reviewer subagent.
+
+**Purpose:** Verify the spec is complete, consistent, and ready for implementation planning.
+
+**Dispatch after:** Spec document is written to docs/superpowers/specs/
+
+```
+Task tool (general-purpose):
+  description: "Review spec document"
+  prompt: |
+    You are a spec document reviewer. Verify this spec is complete and ready for planning.
+
+    **Spec to review:** [SPEC_FILE_PATH]
+
+    ## What to Check
+
+    | Category | What to Look For |
+    |----------|------------------|
+    | Completeness | TODOs, placeholders, "TBD", incomplete sections |
+    | Consistency | Internal contradictions, conflicting requirements |
+    | Clarity | Requirements ambiguous enough to cause someone to build the wrong thing |
+    | Scope | Focused enough for a single plan — not covering multiple independent subsystems |
+    | YAGNI | Unrequested features, over-engineering |
+
+    ## Calibration
+
+    **Only flag issues that would cause real problems during implementation planning.**
+    A missing section, a contradiction, or a requirement so ambiguous it could be
+    interpreted two different ways — those are issues. Minor wording improvements,
+    stylistic preferences, and "sections less detailed than others" are not.
+
+    Approve unless there are serious gaps that would lead to a flawed plan.
+
+    ## Output Format
+
+    ## Spec Review
+
+    **Status:** Approved | Issues Found
+
+    **Issues (if any):**
+    - [Section X]: [specific issue] - [why it matters for planning]
+
+    **Recommendations (advisory, do not block approval):**
+    - [suggestions for improvement]
+```
+
+**Reviewer returns:** Status, Issues (if any), Recommendations

--- a/superjawn/skills/brainstorming/visual-companion.md
+++ b/superjawn/skills/brainstorming/visual-companion.md
@@ -1,0 +1,287 @@
+# Visual Companion Guide
+
+Browser-based visual brainstorming companion for showing mockups, diagrams, and options.
+
+## When to Use
+
+Decide per-question, not per-session. The test: **would the user understand this better by seeing it than reading it?**
+
+**Use the browser** when the content itself is visual:
+
+- **UI mockups** — wireframes, layouts, navigation structures, component designs
+- **Architecture diagrams** — system components, data flow, relationship maps
+- **Side-by-side visual comparisons** — comparing two layouts, two color schemes, two design directions
+- **Design polish** — when the question is about look and feel, spacing, visual hierarchy
+- **Spatial relationships** — state machines, flowcharts, entity relationships rendered as diagrams
+
+**Use the terminal** when the content is text or tabular:
+
+- **Requirements and scope questions** — "what does X mean?", "which features are in scope?"
+- **Conceptual A/B/C choices** — picking between approaches described in words
+- **Tradeoff lists** — pros/cons, comparison tables
+- **Technical decisions** — API design, data modeling, architectural approach selection
+- **Clarifying questions** — anything where the answer is words, not a visual preference
+
+A question *about* a UI topic is not automatically a visual question. "What kind of wizard do you want?" is conceptual — use the terminal. "Which of these wizard layouts feels right?" is visual — use the browser.
+
+## How It Works
+
+The server watches a directory for HTML files and serves the newest one to the browser. You write HTML content to `screen_dir`, the user sees it in their browser and can click to select options. Selections are recorded to `state_dir/events` that you read on your next turn.
+
+**Content fragments vs full documents:** If your HTML file starts with `<!DOCTYPE` or `<html`, the server serves it as-is (just injects the helper script). Otherwise, the server automatically wraps your content in the frame template — adding the header, CSS theme, selection indicator, and all interactive infrastructure. **Write content fragments by default.** Only write full documents when you need complete control over the page.
+
+## Starting a Session
+
+```bash
+# Start server with persistence (mockups saved to project)
+scripts/start-server.sh --project-dir /path/to/project
+
+# Returns: {"type":"server-started","port":52341,"url":"http://localhost:52341",
+#           "screen_dir":"/path/to/project/.superpowers/brainstorm/12345-1706000000/content",
+#           "state_dir":"/path/to/project/.superpowers/brainstorm/12345-1706000000/state"}
+```
+
+Save `screen_dir` and `state_dir` from the response. Tell user to open the URL.
+
+**Finding connection info:** The server writes its startup JSON to `$STATE_DIR/server-info`. If you launched the server in the background and didn't capture stdout, read that file to get the URL and port. When using `--project-dir`, check `<project>/.superpowers/brainstorm/` for the session directory.
+
+**Note:** Pass the project root as `--project-dir` so mockups persist in `.superpowers/brainstorm/` and survive server restarts. Without it, files go to `/tmp` and get cleaned up. Remind the user to add `.superpowers/` to `.gitignore` if it's not already there.
+
+**Launching the server by platform:**
+
+**Claude Code (macOS / Linux):**
+```bash
+# Default mode works — the script backgrounds the server itself
+scripts/start-server.sh --project-dir /path/to/project
+```
+
+**Claude Code (Windows):**
+```bash
+# Windows auto-detects and uses foreground mode, which blocks the tool call.
+# Use run_in_background: true on the Bash tool call so the server survives
+# across conversation turns.
+scripts/start-server.sh --project-dir /path/to/project
+```
+When calling this via the Bash tool, set `run_in_background: true`. Then read `$STATE_DIR/server-info` on the next turn to get the URL and port.
+
+**Codex:**
+```bash
+# Codex reaps background processes. The script auto-detects CODEX_CI and
+# switches to foreground mode. Run it normally — no extra flags needed.
+scripts/start-server.sh --project-dir /path/to/project
+```
+
+**Gemini CLI:**
+```bash
+# Use --foreground and set is_background: true on your shell tool call
+# so the process survives across turns
+scripts/start-server.sh --project-dir /path/to/project --foreground
+```
+
+**Other environments:** The server must keep running in the background across conversation turns. If your environment reaps detached processes, use `--foreground` and launch the command with your platform's background execution mechanism.
+
+If the URL is unreachable from your browser (common in remote/containerized setups), bind a non-loopback host:
+
+```bash
+scripts/start-server.sh \
+  --project-dir /path/to/project \
+  --host 0.0.0.0 \
+  --url-host localhost
+```
+
+Use `--url-host` to control what hostname is printed in the returned URL JSON.
+
+## The Loop
+
+1. **Check server is alive**, then **write HTML** to a new file in `screen_dir`:
+   - Before each write, check that `$STATE_DIR/server-info` exists. If it doesn't (or `$STATE_DIR/server-stopped` exists), the server has shut down — restart it with `start-server.sh` before continuing. The server auto-exits after 30 minutes of inactivity.
+   - Use semantic filenames: `platform.html`, `visual-style.html`, `layout.html`
+   - **Never reuse filenames** — each screen gets a fresh file
+   - Use Write tool — **never use cat/heredoc** (dumps noise into terminal)
+   - Server automatically serves the newest file
+
+2. **Tell user what to expect and end your turn:**
+   - Remind them of the URL (every step, not just first)
+   - Give a brief text summary of what's on screen (e.g., "Showing 3 layout options for the homepage")
+   - Ask them to respond in the terminal: "Take a look and let me know what you think. Click to select an option if you'd like."
+
+3. **On your next turn** — after the user responds in the terminal:
+   - Read `$STATE_DIR/events` if it exists — this contains the user's browser interactions (clicks, selections) as JSON lines
+   - Merge with the user's terminal text to get the full picture
+   - The terminal message is the primary feedback; `state_dir/events` provides structured interaction data
+
+4. **Iterate or advance** — if feedback changes current screen, write a new file (e.g., `layout-v2.html`). Only move to the next question when the current step is validated.
+
+5. **Unload when returning to terminal** — when the next step doesn't need the browser (e.g., a clarifying question, a tradeoff discussion), push a waiting screen to clear the stale content:
+
+   ```html
+   <!-- filename: waiting.html (or waiting-2.html, etc.) -->
+   <div style="display:flex;align-items:center;justify-content:center;min-height:60vh">
+     <p class="subtitle">Continuing in terminal...</p>
+   </div>
+   ```
+
+   This prevents the user from staring at a resolved choice while the conversation has moved on. When the next visual question comes up, push a new content file as usual.
+
+6. Repeat until done.
+
+## Writing Content Fragments
+
+Write just the content that goes inside the page. The server wraps it in the frame template automatically (header, theme CSS, selection indicator, and all interactive infrastructure).
+
+**Minimal example:**
+
+```html
+<h2>Which layout works better?</h2>
+<p class="subtitle">Consider readability and visual hierarchy</p>
+
+<div class="options">
+  <div class="option" data-choice="a" onclick="toggleSelect(this)">
+    <div class="letter">A</div>
+    <div class="content">
+      <h3>Single Column</h3>
+      <p>Clean, focused reading experience</p>
+    </div>
+  </div>
+  <div class="option" data-choice="b" onclick="toggleSelect(this)">
+    <div class="letter">B</div>
+    <div class="content">
+      <h3>Two Column</h3>
+      <p>Sidebar navigation with main content</p>
+    </div>
+  </div>
+</div>
+```
+
+That's it. No `<html>`, no CSS, no `<script>` tags needed. The server provides all of that.
+
+## CSS Classes Available
+
+The frame template provides these CSS classes for your content:
+
+### Options (A/B/C choices)
+
+```html
+<div class="options">
+  <div class="option" data-choice="a" onclick="toggleSelect(this)">
+    <div class="letter">A</div>
+    <div class="content">
+      <h3>Title</h3>
+      <p>Description</p>
+    </div>
+  </div>
+</div>
+```
+
+**Multi-select:** Add `data-multiselect` to the container to let users select multiple options. Each click toggles the item. The indicator bar shows the count.
+
+```html
+<div class="options" data-multiselect>
+  <!-- same option markup — users can select/deselect multiple -->
+</div>
+```
+
+### Cards (visual designs)
+
+```html
+<div class="cards">
+  <div class="card" data-choice="design1" onclick="toggleSelect(this)">
+    <div class="card-image"><!-- mockup content --></div>
+    <div class="card-body">
+      <h3>Name</h3>
+      <p>Description</p>
+    </div>
+  </div>
+</div>
+```
+
+### Mockup container
+
+```html
+<div class="mockup">
+  <div class="mockup-header">Preview: Dashboard Layout</div>
+  <div class="mockup-body"><!-- your mockup HTML --></div>
+</div>
+```
+
+### Split view (side-by-side)
+
+```html
+<div class="split">
+  <div class="mockup"><!-- left --></div>
+  <div class="mockup"><!-- right --></div>
+</div>
+```
+
+### Pros/Cons
+
+```html
+<div class="pros-cons">
+  <div class="pros"><h4>Pros</h4><ul><li>Benefit</li></ul></div>
+  <div class="cons"><h4>Cons</h4><ul><li>Drawback</li></ul></div>
+</div>
+```
+
+### Mock elements (wireframe building blocks)
+
+```html
+<div class="mock-nav">Logo | Home | About | Contact</div>
+<div style="display: flex;">
+  <div class="mock-sidebar">Navigation</div>
+  <div class="mock-content">Main content area</div>
+</div>
+<button class="mock-button">Action Button</button>
+<input class="mock-input" placeholder="Input field">
+<div class="placeholder">Placeholder area</div>
+```
+
+### Typography and sections
+
+- `h2` — page title
+- `h3` — section heading
+- `.subtitle` — secondary text below title
+- `.section` — content block with bottom margin
+- `.label` — small uppercase label text
+
+## Browser Events Format
+
+When the user clicks options in the browser, their interactions are recorded to `$STATE_DIR/events` (one JSON object per line). The file is cleared automatically when you push a new screen.
+
+```jsonl
+{"type":"click","choice":"a","text":"Option A - Simple Layout","timestamp":1706000101}
+{"type":"click","choice":"c","text":"Option C - Complex Grid","timestamp":1706000108}
+{"type":"click","choice":"b","text":"Option B - Hybrid","timestamp":1706000115}
+```
+
+The full event stream shows the user's exploration path — they may click multiple options before settling. The last `choice` event is typically the final selection, but the pattern of clicks can reveal hesitation or preferences worth asking about.
+
+If `$STATE_DIR/events` doesn't exist, the user didn't interact with the browser — use only their terminal text.
+
+## Design Tips
+
+- **Scale fidelity to the question** — wireframes for layout, polish for polish questions
+- **Explain the question on each page** — "Which layout feels more professional?" not just "Pick one"
+- **Iterate before advancing** — if feedback changes current screen, write a new version
+- **2-4 options max** per screen
+- **Use real content when it matters** — for a photography portfolio, use actual images (Unsplash). Placeholder content obscures design issues.
+- **Keep mockups simple** — focus on layout and structure, not pixel-perfect design
+
+## File Naming
+
+- Use semantic names: `platform.html`, `visual-style.html`, `layout.html`
+- Never reuse filenames — each screen must be a new file
+- For iterations: append version suffix like `layout-v2.html`, `layout-v3.html`
+- Server serves newest file by modification time
+
+## Cleaning Up
+
+```bash
+scripts/stop-server.sh $SESSION_DIR
+```
+
+If the session used `--project-dir`, mockup files persist in `.superpowers/brainstorm/` for later reference. Only `/tmp` sessions get deleted on stop.
+
+## Reference
+
+- Frame template (CSS reference): `scripts/frame-template.html`
+- Helper script (client-side): `scripts/helper.js`

--- a/superjawn/skills/executing-plans/SKILL.md
+++ b/superjawn/skills/executing-plans/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: executing-plans
+description: Use when you have a written implementation plan to execute in a separate session with review checkpoints
+---
+
+# Executing Plans
+
+## Overview
+
+Load plan, review critically, execute all tasks, report when complete.
+
+**Announce at start:** "I'm using the executing-plans skill to implement this plan."
+
+**Note:** Tell your human partner that Superpowers works much better with access to subagents. The quality of its work will be significantly higher if run on a platform with subagent support (such as Claude Code or Codex). If subagents are available, use superpowers:subagent-driven-development instead of this skill.
+
+## The Process
+
+### Step 1: Load and Review Plan
+1. Read plan file
+2. Review critically - identify any questions or concerns about the plan
+3. If concerns: Raise them with your human partner before starting
+4. If no concerns: Create TodoWrite and proceed
+
+### Step 2: Execute Tasks
+
+For each task:
+1. Mark as in_progress
+2. Follow each step exactly (plan has bite-sized steps)
+3. Run verifications as specified
+4. Mark as completed
+
+### Step 3: Complete Development
+
+After all tasks complete and verified:
+- Announce: "I'm using the finishing-a-development-branch skill to complete this work."
+- **REQUIRED SUB-SKILL:** Use superpowers:finishing-a-development-branch
+- Follow that skill to verify tests, present options, execute choice
+
+## When to Stop and Ask for Help
+
+**STOP executing immediately when:**
+- Hit a blocker (missing dependency, test fails, instruction unclear)
+- Plan has critical gaps preventing starting
+- You don't understand an instruction
+- Verification fails repeatedly
+
+**Ask for clarification rather than guessing.**
+
+## When to Revisit Earlier Steps
+
+**Return to Review (Step 1) when:**
+- Partner updates the plan based on your feedback
+- Fundamental approach needs rethinking
+
+**Don't force through blockers** - stop and ask.
+
+## Remember
+- Review plan critically first
+- Follow plan steps exactly
+- Don't skip verifications
+- Reference skills when plan says to
+- Stop when blocked, don't guess
+- Never start implementation on main/master branch without explicit user consent
+
+## Integration
+
+**Required workflow skills:**
+- **superpowers:using-git-worktrees** - REQUIRED: Set up isolated workspace before starting
+- **superpowers:writing-plans** - Creates the plan this skill executes
+- **superpowers:finishing-a-development-branch** - Complete development after all tasks

--- a/superjawn/skills/executing-plans/SKILL.md
+++ b/superjawn/skills/executing-plans/SKILL.md
@@ -17,7 +17,7 @@ See CREDITS.md.
 
 Load plan, review critically, execute all tasks, report when complete.
 
-**Announce at start:** "I'm using the executing-plans skill to implement this plan."
+**Announce at start:** "I'm using the superjawn:executing-plans skill to implement this plan."
 
 **Note:** Tell your human partner that superjawn works much better with access to subagents. The quality of its work will be significantly higher if run on a platform with subagent support (such as Claude Code or Codex). If subagents are available, use superpowers:subagent-driven-development instead of this skill.
 
@@ -79,7 +79,7 @@ For each task:
 ### Step 3: Complete Development
 
 After all tasks complete and verified:
-- Announce: "I'm using the finishing-a-development-branch skill to complete this work."
+- Announce: "I'm using the superpowers:finishing-a-development-branch skill to complete this work."
 - **REQUIRED SUB-SKILL:** Use superpowers:finishing-a-development-branch
 - Follow that skill to verify tests, present options, execute choice
 

--- a/superjawn/skills/executing-plans/SKILL.md
+++ b/superjawn/skills/executing-plans/SKILL.md
@@ -3,6 +3,14 @@ name: executing-plans
 description: Use when you have a written implementation plan to execute in a separate session with review checkpoints
 ---
 
+<!--
+Adapted from obra/superpowers executing-plans skill (v5.0.7), MIT-licensed,
+copyright 2025 Jesse Vincent. Modifications copyright 2026 Joe Amditis.
+Modifications add a per-task research phase (drift check before
+implementation), plus updates to cross-references.
+See CREDITS.md.
+-->
+
 # Executing Plans
 
 ## Overview
@@ -12,6 +20,42 @@ Load plan, review critically, execute all tasks, report when complete.
 **Announce at start:** "I'm using the executing-plans skill to implement this plan."
 
 **Note:** Tell your human partner that Superpowers works much better with access to subagents. The quality of its work will be significantly higher if run on a platform with subagent support (such as Claude Code or Codex). If subagents are available, use superpowers:subagent-driven-development instead of this skill.
+
+## Research phase (per task)
+
+Before implementing each task in the plan, run a quick drift check. **Default-on**: skip only with explicit, justified statement per task.
+
+### 1. What to verify
+
+The plan was written at a point in time. Before each task, verify:
+- **Authoritative state:** If the task touches an external API or file the plan references, confirm the API contract or file content hasn't changed. Live curl, file read, version check.
+- **Codebase drift:** If the task assumes a function/module exists at a specific path, grep to confirm it still does.
+- **Repo state:** Has anyone landed conflicting work on the branch since the plan was drafted?
+
+### 2. Dispatch
+
+Inline for single-file or single-API checks. `general-purpose` subagent only when the verification spans multiple sources.
+
+### 3. Record findings
+
+Append a short note to the execution journal (or PR description) for each task:
+
+```
+Task N drift check: <PASS / FAIL> — <one-line summary>
+```
+
+If FAIL, escalate before implementing — the plan may need revision.
+
+### 4. Skip protocol
+
+If skipping per-task research, write one line in the journal: `Task N research skipped because <reason>.`
+
+**Valid reasons:**
+- Task is purely additive within a file the previous task just created (no external state to verify)
+- Plan was drafted within the current session and nothing has changed
+- Task is a pure mechanical commit / rebase / push step
+
+**Invalid reasons:** "I think I know", "seems straightforward", "moving fast", "user wants this done quickly", "already familiar with this codebase". If those are tempting, do the check.
 
 ## The Process
 
@@ -25,9 +69,10 @@ Load plan, review critically, execute all tasks, report when complete.
 
 For each task:
 1. Mark as in_progress
-2. Follow each step exactly (plan has bite-sized steps)
-3. Run verifications as specified
-4. Mark as completed
+2. Run the per-task research / drift check (see "Research phase (per task)" section above)
+3. Follow each step exactly (plan has bite-sized steps)
+4. Run verifications as specified
+5. Mark as completed
 
 ### Step 3: Complete Development
 
@@ -57,6 +102,7 @@ After all tasks complete and verified:
 ## Remember
 - Review plan critically first
 - Follow plan steps exactly
+- Drift-check each task against current codebase reality before implementing (see Research phase)
 - Don't skip verifications
 - Reference skills when plan says to
 - Stop when blocked, don't guess

--- a/superjawn/skills/executing-plans/SKILL.md
+++ b/superjawn/skills/executing-plans/SKILL.md
@@ -38,7 +38,6 @@ The plan was written at a point in time. Before each task, verify:
 - `Explore` subagent for codebase-drift questions spanning multiple files
 - `general-purpose` subagent for verification that spans external sources
 
-
 ### 3. Record findings
 
 Append a short note to the execution journal (or PR description) for each task:

--- a/superjawn/skills/executing-plans/SKILL.md
+++ b/superjawn/skills/executing-plans/SKILL.md
@@ -19,7 +19,7 @@ Load plan, review critically, execute all tasks, report when complete.
 
 **Announce at start:** "I'm using the executing-plans skill to implement this plan."
 
-**Note:** Tell your human partner that Superpowers works much better with access to subagents. The quality of its work will be significantly higher if run on a platform with subagent support (such as Claude Code or Codex). If subagents are available, use superpowers:subagent-driven-development instead of this skill.
+**Note:** Tell your human partner that superjawn works much better with access to subagents. The quality of its work will be significantly higher if run on a platform with subagent support (such as Claude Code or Codex). If subagents are available, use superpowers:subagent-driven-development instead of this skill.
 
 ## Research phase (per task)
 
@@ -34,7 +34,10 @@ The plan was written at a point in time. Before each task, verify:
 
 ### 2. Dispatch
 
-Inline for single-file or single-API checks. `general-purpose` subagent only when the verification spans multiple sources.
+- Inline for single-file or single-API checks
+- `Explore` subagent for codebase-drift questions spanning multiple files
+- `general-purpose` subagent for verification that spans external sources
+
 
 ### 3. Record findings
 
@@ -48,7 +51,7 @@ If FAIL, escalate before implementing — the plan may need revision.
 
 ### 4. Skip protocol
 
-If skipping per-task research, write one line in the journal: `Task N research skipped because <reason>.`
+If skipping the per-task drift check, write one line in the journal: `Task N drift check skipped because <reason>.`
 
 **Valid reasons:**
 - Task is purely additive within a file the previous task just created (no external state to verify)
@@ -69,7 +72,7 @@ If skipping per-task research, write one line in the journal: `Task N research s
 
 For each task:
 1. Mark as in_progress
-2. Run the per-task research / drift check (see "Research phase (per task)" section above)
+2. Run the drift check (see "Research phase (per task)" above)
 3. Follow each step exactly (plan has bite-sized steps)
 4. Run verifications as specified
 5. Mark as completed
@@ -112,5 +115,5 @@ After all tasks complete and verified:
 
 **Required workflow skills:**
 - **superpowers:using-git-worktrees** - REQUIRED: Set up isolated workspace before starting
-- **superpowers:writing-plans** - Creates the plan this skill executes
+- **superjawn:writing-plans** - Creates the plan this skill executes
 - **superpowers:finishing-a-development-branch** - Complete development after all tasks

--- a/superjawn/skills/writing-plans/SKILL.md
+++ b/superjawn/skills/writing-plans/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: writing-plans
+description: Use when you have a spec or requirements for a multi-step task, before touching code
+---
+
+# Writing Plans
+
+## Overview
+
+Write comprehensive implementation plans assuming the engineer has zero context for our codebase and questionable taste. Document everything they need to know: which files to touch for each task, code, testing, docs they might need to check, how to test it. Give them the whole plan as bite-sized tasks. DRY. YAGNI. TDD. Frequent commits.
+
+Assume they are a skilled developer, but know almost nothing about our toolset or problem domain. Assume they don't know good test design very well.
+
+**Announce at start:** "I'm using the writing-plans skill to create the implementation plan."
+
+**Context:** This should be run in a dedicated worktree (created by brainstorming skill).
+
+**Save plans to:** `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md`
+- (User preferences for plan location override this default)
+
+## Scope Check
+
+If the spec covers multiple independent subsystems, it should have been broken into sub-project specs during brainstorming. If it wasn't, suggest breaking this into separate plans — one per subsystem. Each plan should produce working, testable software on its own.
+
+## File Structure
+
+Before defining tasks, map out which files will be created or modified and what each one is responsible for. This is where decomposition decisions get locked in.
+
+- Design units with clear boundaries and well-defined interfaces. Each file should have one clear responsibility.
+- You reason best about code you can hold in context at once, and your edits are more reliable when files are focused. Prefer smaller, focused files over large ones that do too much.
+- Files that change together should live together. Split by responsibility, not by technical layer.
+- In existing codebases, follow established patterns. If the codebase uses large files, don't unilaterally restructure - but if a file you're modifying has grown unwieldy, including a split in the plan is reasonable.
+
+This structure informs the task decomposition. Each task should produce self-contained changes that make sense independently.
+
+## Bite-Sized Task Granularity
+
+**Each step is one action (2-5 minutes):**
+- "Write the failing test" - step
+- "Run it to make sure it fails" - step
+- "Implement the minimal code to make the test pass" - step
+- "Run the tests and make sure they pass" - step
+- "Commit" - step
+
+## Plan Document Header
+
+**Every plan MUST start with this header:**
+
+```markdown
+# [Feature Name] Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** [One sentence describing what this builds]
+
+**Architecture:** [2-3 sentences about approach]
+
+**Tech Stack:** [Key technologies/libraries]
+
+---
+```
+
+## Task Structure
+
+````markdown
+### Task N: [Component Name]
+
+**Files:**
+- Create: `exact/path/to/file.py`
+- Modify: `exact/path/to/existing.py:123-145`
+- Test: `tests/exact/path/to/test.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_specific_behavior():
+    result = function(input)
+    assert result == expected
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/path/test.py::test_name -v`
+Expected: FAIL with "function not defined"
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+def function(input):
+    return expected
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/path/test.py::test_name -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/path/test.py src/path/file.py
+git commit -m "feat: add specific feature"
+```
+````
+
+## No Placeholders
+
+Every step must contain the actual content an engineer needs. These are **plan failures** — never write them:
+- "TBD", "TODO", "implement later", "fill in details"
+- "Add appropriate error handling" / "add validation" / "handle edge cases"
+- "Write tests for the above" (without actual test code)
+- "Similar to Task N" (repeat the code — the engineer may be reading tasks out of order)
+- Steps that describe what to do without showing how (code blocks required for code steps)
+- References to types, functions, or methods not defined in any task
+
+## Remember
+- Exact file paths always
+- Complete code in every step — if a step changes code, show the code
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+
+## Self-Review
+
+After writing the complete plan, look at the spec with fresh eyes and check the plan against it. This is a checklist you run yourself — not a subagent dispatch.
+
+**1. Spec coverage:** Skim each section/requirement in the spec. Can you point to a task that implements it? List any gaps.
+
+**2. Placeholder scan:** Search your plan for red flags — any of the patterns from the "No Placeholders" section above. Fix them.
+
+**3. Type consistency:** Do the types, method signatures, and property names you used in later tasks match what you defined in earlier tasks? A function called `clearLayers()` in Task 3 but `clearFullLayers()` in Task 7 is a bug.
+
+If you find issues, fix them inline. No need to re-review — just fix and move on. If you find a spec requirement with no task, add the task.
+
+## Execution Handoff
+
+After saving the plan, offer execution choice:
+
+**"Plan complete and saved to `docs/superpowers/plans/<filename>.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+**Which approach?"**
+
+**If Subagent-Driven chosen:**
+- **REQUIRED SUB-SKILL:** Use superpowers:subagent-driven-development
+- Fresh subagent per task + two-stage review
+
+**If Inline Execution chosen:**
+- **REQUIRED SUB-SKILL:** Use superpowers:executing-plans
+- Batch execution with checkpoints for review

--- a/superjawn/skills/writing-plans/SKILL.md
+++ b/superjawn/skills/writing-plans/SKILL.md
@@ -19,9 +19,9 @@ Write comprehensive implementation plans assuming the engineer has zero context 
 
 Assume they are a skilled developer, but know almost nothing about our toolset or problem domain. Assume they don't know good test design very well.
 
-**Announce at start:** "I'm using the writing-plans skill to create the implementation plan."
+**Announce at start:** "I'm using the superjawn:writing-plans skill to create the implementation plan."
 
-**Context:** This should be run in a dedicated worktree (created by brainstorming skill).
+**Context:** This should be run in a dedicated worktree (created by superjawn:brainstorming skill).
 
 **Save plans to:** `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md`
 - (User preferences for plan location override this default)
@@ -95,7 +95,7 @@ This structure informs the task decomposition. Each task should produce self-con
 ```markdown
 # [Feature Name] Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superjawn:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** [One sentence describing what this builds]
 
@@ -187,7 +187,7 @@ After saving the plan, offer execution choice:
 
 **1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
 
-**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+**2. Inline Execution** - Execute tasks in this session using superjawn:executing-plans, batch execution with checkpoints
 
 **Which approach?"**
 
@@ -196,5 +196,5 @@ After saving the plan, offer execution choice:
 - Fresh subagent per task + two-stage review
 
 **If Inline Execution chosen:**
-- **REQUIRED SUB-SKILL:** Use superpowers:executing-plans
+- **REQUIRED SUB-SKILL:** Use superjawn:executing-plans
 - Batch execution with checkpoints for review

--- a/superjawn/skills/writing-plans/SKILL.md
+++ b/superjawn/skills/writing-plans/SKILL.md
@@ -3,6 +3,14 @@ name: writing-plans
 description: Use when you have a spec or requirements for a multi-step task, before touching code
 ---
 
+<!--
+Adapted from obra/superpowers writing-plans skill (v5.0.7), MIT-licensed,
+copyright 2025 Jesse Vincent. Modifications copyright 2026 Joe Amditis.
+Modifications add a default-on research phase before plan drafting, plus
+updates to cross-references and self-review.
+See CREDITS.md.
+-->
+
 # Writing Plans
 
 ## Overview
@@ -21,6 +29,44 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 ## Scope Check
 
 If the spec covers multiple independent subsystems, it should have been broken into sub-project specs during brainstorming. If it wasn't, suggest breaking this into separate plans — one per subsystem. Each plan should produce working, testable software on its own.
+
+## Research phase
+
+Before drafting plan steps, gather outside context. **Default-on**: skip only with explicit justification.
+
+### 1. Pick research kinds
+
+For writing-plans, the **defaults are:**
+- **Web (pitfalls in chosen approach):** What's gone wrong for others doing this kind of plan? Recent post-mortems, GitHub issues, conference talks?
+- **Codebase (similar features):** Has this codebase done something similar before? What patterns can be reused?
+- **Authoritative verification:** If the plan involves external APIs/services/standards, hit the real source — current docs, live curl, current spec — to confirm the plan's assumptions.
+
+Add user-context if a prior plan or session is relevant.
+
+### 2. Dispatch
+
+Subagent by default:
+- `Explore` for codebase / similar-feature search
+- `general-purpose` for web research and live API verification
+- Run in parallel when independent
+
+Inline for trivial plans (single-file edits, mechanical changes).
+
+### 3. Record findings
+
+Write 3–5 tight bullets into a new `## Research notes` section AT THE TOP of the plan doc, immediately after the plan header. Include load-bearing references and anything considered-but-ruled-out.
+
+### 4. Skip protocol
+
+If skipping, write one line into the plan doc: `Skipped research because <reason>. <Verifiable pointer if applicable>.`
+
+**Valid reasons:**
+- Trivial scope (typo, comment edit, single-line config)
+- Fresh prior research — same topic in current session OR within last 7 days with verifiable spec/plan pointer. **If the pointer doesn't resolve, the skip is invalid.** (Beyond 7 days, repeat the research even if you remember the prior findings — the landscape drifts.)
+- User explicit — **must quote the phrase** that authorized the skip.
+- Repeat of identical task — **must include a pointer** to the prior successful run.
+
+**Invalid reasons:** "I think I know", "seems straightforward", "moving fast", "user wants this done quickly", "already familiar with this codebase". If those are tempting, do the research.
 
 ## File Structure
 
@@ -128,6 +174,8 @@ After writing the complete plan, look at the spec with fresh eyes and check the 
 **2. Placeholder scan:** Search your plan for red flags — any of the patterns from the "No Placeholders" section above. Fix them.
 
 **3. Type consistency:** Do the types, method signatures, and property names you used in later tasks match what you defined in earlier tasks? A function called `clearLayers()` in Task 3 but `clearFullLayers()` in Task 7 is a bug.
+
+**4. Research phase check:** Does the plan contain either a `## Research notes` section with findings, or a `Skipped research because <reason>` declaration? If neither, the plan was drafted without the research step — return to the research phase.
 
 If you find issues, fix them inline. No need to re-review — just fix and move on. If you find a spec requirement with no task, add the task.
 

--- a/superjawn/skills/writing-plans/SKILL.md
+++ b/superjawn/skills/writing-plans/SKILL.md
@@ -54,7 +54,7 @@ Inline for trivial plans (single-file edits, mechanical changes).
 
 ### 3. Record findings
 
-Write 3–5 tight bullets into a new `## Research notes` section AT THE TOP of the plan doc, immediately after the plan header. Include load-bearing references and anything considered-but-ruled-out.
+Write 3–5 tight bullets into a new `## Research notes` section placed immediately after the plan header's `---` separator and before Task 1. Include load-bearing references and anything considered-but-ruled-out.
 
 ### 4. Skip protocol
 

--- a/superjawn/skills/writing-plans/SKILL.md
+++ b/superjawn/skills/writing-plans/SKILL.md
@@ -21,7 +21,7 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 **Announce at start:** "I'm using the superjawn:writing-plans skill to create the implementation plan."
 
-**Context:** This should be run in a dedicated worktree (created by superjawn:brainstorming skill).
+**Context:** This should be run in a dedicated worktree (set up via superpowers:using-git-worktrees).
 
 **Save plans to:** `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md`
 - (User preferences for plan location override this default)

--- a/superjawn/skills/writing-plans/plan-document-reviewer-prompt.md
+++ b/superjawn/skills/writing-plans/plan-document-reviewer-prompt.md
@@ -1,0 +1,49 @@
+# Plan Document Reviewer Prompt Template
+
+Use this template when dispatching a plan document reviewer subagent.
+
+**Purpose:** Verify the plan is complete, matches the spec, and has proper task decomposition.
+
+**Dispatch after:** The complete plan is written.
+
+```
+Task tool (general-purpose):
+  description: "Review plan document"
+  prompt: |
+    You are a plan document reviewer. Verify this plan is complete and ready for implementation.
+
+    **Plan to review:** [PLAN_FILE_PATH]
+    **Spec for reference:** [SPEC_FILE_PATH]
+
+    ## What to Check
+
+    | Category | What to Look For |
+    |----------|------------------|
+    | Completeness | TODOs, placeholders, incomplete tasks, missing steps |
+    | Spec Alignment | Plan covers spec requirements, no major scope creep |
+    | Task Decomposition | Tasks have clear boundaries, steps are actionable |
+    | Buildability | Could an engineer follow this plan without getting stuck? |
+
+    ## Calibration
+
+    **Only flag issues that would cause real problems during implementation.**
+    An implementer building the wrong thing or getting stuck is an issue.
+    Minor wording, stylistic preferences, and "nice to have" suggestions are not.
+
+    Approve unless there are serious gaps — missing requirements from the spec,
+    contradictory steps, placeholder content, or tasks so vague they can't be acted on.
+
+    ## Output Format
+
+    ## Plan Review
+
+    **Status:** Approved | Issues Found
+
+    **Issues (if any):**
+    - [Task X, Step Y]: [specific issue] - [why it matters for implementation]
+
+    **Recommendations (advisory, do not block approval):**
+    - [suggestions for improvement]
+```
+
+**Reviewer returns:** Status, Issues (if any), Recommendations


### PR DESCRIPTION
## Summary

Bootstraps `superjawn`, a new plugin in this marketplace, as a research-augmented variant of the upstream MIT-licensed [obra/superpowers](https://github.com/obra/superpowers) plugin (v5.0.7). Each ported skill grows a default-on research phase tailored to its stage of the workflow — gather trends, pitfalls, patterns, and discourse before building or proposing.

This is **Batch 1 of 5**. It scaffolds the plugin and ports the foundation triad: `brainstorming`, `writing-plans`, `executing-plans`. Batches 2-5 will get their own implementation plans after this lands.

Closes nothing yet — this PR opens superjawn for use.

## What's in this PR

**Design + plan artifacts:**
- `specs/2026-05-05-superjawn-research-phases-design.md` — 6-section design (architecture, per-skill research taxonomy, common research-step shape, skip-justification protocol, rollout sequence, drift-management strategy)
- `plans/2026-05-05-superjawn-batch-1.md` — 18-task implementation plan

**Plugin scaffold:**
- `superjawn/.claude-plugin/plugin.json` — manifest (v0.1.0)
- `superjawn/LICENSE` — MIT, dual-copyright (Jesse Vincent 2025 / Joe Amditis 2026)
- `superjawn/CREDITS.md` — upstream attribution and baseline tracking
- `superjawn/README.md` — skill status table, coexistence notes, research-phase summary
- `.claude-plugin/marketplace.json` — superjawn registered alongside autocontext, pdf-design, pdf-playground

**Three ported skills** (each follows a 3-commit shape: verbatim copy → research phase + attribution → cross-ref rewrites):
- `superjawn/skills/brainstorming/` — research between clarifying questions and approach proposal; visual-companion header rebranded to dual-link form
- `superjawn/skills/writing-plans/` — research between Scope Check and File Structure; findings written to `## Research notes` after the plan header's `---`
- `superjawn/skills/executing-plans/` — per-task drift check inside the Step 2 loop; findings written to the execution journal as `Task N drift check: PASS|FAIL`

**Cross-cutting design:**
- All three skills use the same skip-justification whitelist (trivial scope / fresh prior research within 7 days / user explicit / repeat of identical task), with bolded enforcement clauses ("If the pointer doesn't resolve, the skip is invalid", "must quote the phrase", "must include a pointer", and the 7-day "the landscape drifts" rationale).
- Cross-references use dual-namespace mode: in-batch ports (`brainstorming`, `writing-plans`, `executing-plans`) point at `superjawn:`; not-yet-ported skills (`subagent-driven-development`, `using-git-worktrees`, `finishing-a-development-branch`) stay on `superpowers:`.
- Explicit non-renames preserved: `.superpowers/` runtime directory (user data), `docs/superpowers/specs/` and `docs/superpowers/plans/` (project conventions), `https://github.com/obra/superpowers` attribution links.

## Test plan

- [x] `claude plugin validate ./superjawn` passes
- [x] `claude plugin tag --dry-run ./superjawn` confirms manifest agrees with marketplace entry
- [x] All 3 skills load when superjawn is installed via local-path marketplace
- [x] `superjawn:brainstorming` smoke-tested live: research phase fires correctly, dispatches Explore + general-purpose subagents in parallel, references user-context (memory), records findings to `## Research notes` block
- [x] Two-stage review (spec compliance + code quality) passed for every task
- [ ] Once merged: `claude plugin marketplace update claude-skills-journalism && claude plugin install superjawn@claude-skills-journalism` works for downstream users

## Out of scope

- Batches 2-5 (debugging + testing, code review, parallelism + isolation, meta + integration) each get their own implementation plan after this validates the pattern in the wild
- Disabling upstream `superpowers` plugin (deferred to v1.0.0 after at least 2 weeks of real use of the full set)
- Filing follow-ups on stale marketplace versions for autocontext/pdf-design/pdf-playground (already filed as #33)

## Related

- Issue #33 (pre-existing marketplace version drift in 3 sibling plugins)
- Upstream: [obra/superpowers v5.0.7](https://github.com/obra/superpowers)