### PR TITLE
superjawn v0.2.0: rearchitect for entry-point-only research

### DIFF
--- a/specs/2026-05-05-superjawn-research-phases-design.md
+++ b/specs/2026-05-05-superjawn-research-phases-design.md
@@ -157,7 +157,7 @@ Verify, in order:
 Write to the execution journal at `.superpowers/exec-journal-<plan-slug>.md` (created on first run if it doesn't exist). One line per check:
 
 ```
-[YYYY-MM-DD HH:MM] Task N freshness check: <PASS / FAIL> — <one-line summary>
+[YYYY-MM-DD HH:MM] Freshness check: <PASS / FAIL> — <one-line summary>
 ```
 
 If FAIL on any check, escalate before implementing — the plan needs revision.

--- a/specs/2026-05-05-superjawn-research-phases-design.md
+++ b/specs/2026-05-05-superjawn-research-phases-design.md
@@ -1,30 +1,49 @@
-# superjawn — research-phase additions to superpowers skills
+# superjawn — research and freshness phases on superpowers skills
 
-**Status:** design approved, awaiting implementation plan
-**Date:** 2026-05-05
+**Status:** v0.1.0 shipped (foundation triad), v0.2.0 in flight (architecture rework)
+**Date:** 2026-05-05 (v0.1.0 design), revised 2026-05-05 (v0.2.0 architecture)
 **Author:** Joe Amditis (with brainstorming session)
 **Repo:** `claude-skills-journalism`
-**New plugin:** `superjawn/`
+**Plugin:** `superjawn/`
 
 ## Goal
 
-Add a default-on research phase to all 14 skills currently shipped by the upstream `superpowers` plugin (obra/superpowers, MIT, currently v5.0.7), recreated as a new plugin `superjawn` inside the existing `claude-skills-journalism` marketplace.
+Recreate the 14 skills shipped by upstream `superpowers` (obra/superpowers, MIT, currently v5.0.7) as `superjawn` inside the existing `claude-skills-journalism` marketplace, with research phases added only at entry-point stages and a narrow freshness check on stale-artifact-consumer skills.
 
-The research phase realizes the "research-first approach" already documented in `~/.claude/CLAUDE.md` — "let me check the latest trends, possible pitfalls, patterns, and discourse surrounding this topic before we start actually building or proposing solutions." Each skill gets a tailored research step at the right stage of its existing flow, dispatched via subagent by default, with findings written into the skill's existing artifact.
+The research phase realizes the "research-first approach" already documented in `~/.claude/CLAUDE.md` — "let me check the latest trends, possible pitfalls, patterns, and discourse surrounding this topic before we start actually building or proposing solutions." But research belongs only where work originates without an upstream artifact. Skills that consume an artifact from a research-baked-in upstream stage trust the handoff and don't re-research.
+
+## Architecture revision (v0.2.0)
+
+v0.1.0 shipped with research phases on all three foundation skills (`brainstorming`, `writing-plans`, `executing-plans`). Real-use feedback identified the issue: when these skills run in succession (the canonical flow), the research duplicates conclusions already encoded in the upstream artifact. Research at every stage:
+- Costs time (especially with subagent dispatch)
+- Risks conflicting findings (brainstorming concluded X, writing-plans research finds Y, plan is now ambiguous)
+- Bloats skill text and skip-protocol overhead
+- Creates a discipline-skip excuse in rigid skills like `test-driven-development`
+
+The v0.2.0 architecture concentrates research at entry-point stages, adds a narrow freshness check on stale-artifact-consumer skills, and ports the remaining skills as pure consumers (no research insertion).
 
 ## Decision log
 
-Locked during brainstorming on 2026-05-05:
+Locked during brainstorming on 2026-05-05 (v0.1.0):
 
 | Question | Decision |
 |---|---|
 | Kind of research | All four — web/best-practices, codebase/prior-art, authoritative verification, user-context — situational and skill-dependent |
-| Scope | All 14 superpowers skills |
+| Scope | All 14 superpowers skills (revised in v0.2.0 — see below) |
 | Rigidity | Default-on with explicit skip (justified, surfaced) |
 | Mechanism | Subagent dispatch by default; inline only for light-touch |
 | Output destination | Findings written into the skill's existing artifact (spec, plan, debug log) |
 | Delivery approach | Approach D — new plugin `superjawn/` inside `claude-skills-journalism`; copy upstream MIT-licensed skills with attribution; rewrite cross-references; disable upstream `superpowers` once migration complete |
 | Plugin name | `superjawn` |
+
+Revised 2026-05-05 (v0.2.0):
+
+| Question | Decision |
+|---|---|
+| Where does research belong | Only at entry-point stages where work originates without an upstream artifact (3 skills) |
+| Stale-artifact consumers | Get a narrow freshness check (default-skip with explicit triggers) instead of research (2 skills) |
+| Pure consumers | Port without any research/freshness insertion — trust the upstream-artifact handoff (9 skills) |
+| Trigger for the architecture revision | Real-use feedback that research in writing-plans/executing-plans duplicated brainstorming conclusions when the three skills ran in succession |
 
 ## Section 1 — Plugin architecture
 
@@ -38,42 +57,62 @@ Locked during brainstorming on 2026-05-05:
 
 **Versioning:** Track upstream-source version in `CREDITS.md` (currently 5.0.7). Manual diff-and-port pass when upstream ships changes worth pulling in. No automatic rebase.
 
-## Section 2 — Per-skill research taxonomy
+## Section 2 — Per-skill categorization (14 skills, three categories)
+
+The categorization rule: research belongs at **entry-point stages where work originates without an upstream artifact**. Skills that consume an artifact from a research-baked-in upstream stage are consumers and trust the handoff. The narrow exception is **stale-artifact consumers** — skills that consume an artifact that may have aged across a session boundary or external API drift, which get a default-skip freshness check.
+
+### Research (entry points) — 3 skills
+
+These skills begin work from scratch (an idea, a bug report, a behavior to teach). The research phase fires by default with the locked skip protocol from Section 4.
 
 | Skill | Research stage | Default kinds | Subagent | Findings land in |
 |---|---|---|---|---|
 | `brainstorming` | After clarifying questions, before approaches | Web (trends + discourse), codebase (prior art) | general-purpose + Explore (parallel) | Spec doc, new `## Research notes` section |
-| `writing-plans` | Before drafting plan steps | Web (pitfalls in chosen approach), codebase (similar features), authoritative (live API smoke) | general-purpose + Explore | Plan doc, top section |
-| `executing-plans` | Before each step's implementation | Authoritative re-verification (drift check) | general-purpose, scoped to current step | Execution journal entry |
-| `subagent-driven-development` | Per-subagent, before each task starts | Codebase (independence verification), authoritative (per-task) | Each subagent does its own | Subagent's report |
-| `systematic-debugging` | At hypothesis formation | Web (error-string search, GitHub issues), codebase (prior bugs in this area) | general-purpose + Explore | Debug log, hypothesis section |
-| `test-driven-development` | Before writing the red test | Web (testing patterns for this code shape), codebase (existing test conventions) | general-purpose + Explore | Test file header comment + draft notes |
-| `using-git-worktrees` | Before creating worktree | User-context (existing worktrees? unfinished branches?) | Inline | Inline log line |
-| `dispatching-parallel-agents` | Before fan-out | Codebase (verify task independence — no hidden shared state) | Explore | Dispatch plan |
-| `finishing-a-development-branch` | Before integration choice | Codebase (competing PRs on adjacent code), user-context (recent decisions) | Inline | Inline summary |
-| `receiving-code-review` | Per comment, before responding | Authoritative (verify reviewer's claim), codebase (current behavior) | general-purpose | Comment-response draft |
-| `requesting-code-review` | Before requesting | User-context (review-scope conventions, reviewer preferences) | Inline | Inline |
-| `using-superjawn` | Before invoking another skill | User-context (recent feedback memory about this skill) | Inline (memory check) | Inline |
-| `verification-before-completion` | At verification step | Authoritative (what command actually proves this?) | general-purpose | Verification evidence block |
-| `writing-skills` | Before drafting skill | Codebase (overlapping skills in plugin), user-context (description conventions) | Explore | Skill draft metadata |
+| `systematic-debugging` | At hypothesis formation (Phase 1 → Phase 2 boundary) | Web (error-string search, GitHub issues), codebase (prior bugs in this area), user-context (recent regressions in memory) | general-purpose + Explore | Debug log, hypothesis section |
+| `writing-skills` | Before drafting the skill's first version | Codebase (overlapping skills in plugin), user-context (description conventions, naming patterns), web (recent skill-format changes upstream) | Explore | Skill draft notes / RED-phase scenarios |
 
-**Light-touch flags:** `using-superjawn`, `finishing-a-development-branch`, `requesting-code-review`, `using-git-worktrees`, `dispatching-parallel-agents` have thin research fits — research is a brief inline check, not a subagent dispatch. Skill text says so explicitly rather than padding cargo-cult research into the flow.
+### Freshness check (stale-artifact consumers) — 2 skills
+
+These skills consume a plan that may have aged. Default-skip with explicit triggers.
+
+| Skill | Trigger conditions | Verification kinds | Findings land in |
+|---|---|---|---|
+| `executing-plans` | (a) plan drafted in a prior session, OR (b) any task touches an external API/service/file outside the repo, OR (c) current branch is `main`/`master` | Authoritative state (live curl / file read / version check), codebase drift (grep that referenced functions/modules still exist), repo state (no conflicting commits since plan written) | Execution journal at `.superpowers/exec-journal-<plan-name>.md` (defined; see Section 3) |
+| `subagent-driven-development` | Same triggers as executing-plans | Same as executing-plans, but each subagent's dispatched prompt includes the relevant freshness pointer | Subagent dispatch prompt + journal note |
+
+### Consumer (pure port, no research/freshness insertion) — 9 skills
+
+These skills port from upstream with attribution comment + dual-namespace cross-reference rewrites only. No research or freshness phase. The artifact handoff carries the conclusions.
+
+| Skill | Why no research | Notes |
+|---|---|---|
+| `writing-plans` | Consumes spec from brainstorming. Spec encodes research conclusions. | v0.2.0 strips the research phase that v0.1.0 added |
+| `test-driven-development` | Sub-skill called within other workflows. Pure red-green-refactor discipline. Adding research creates a discipline-skip excuse. | |
+| `verification-before-completion` | Gate function. Verification command is determined by what was just built; no external research adds value. | |
+| `receiving-code-review` | "Verify against codebase reality" is already step 3 of the existing skill. No separate research duplicates internal work. | |
+| `requesting-code-review` | Pure dispatch mechanic. Reviewer preferences live in CLAUDE.md/memory. | |
+| `dispatching-parallel-agents` | "Identify independent domains" is step 1 of the existing skill — already inline. | |
+| `using-git-worktrees` | Pure mechanical (directory pick + gitignore + baseline tests). | |
+| `finishing-a-development-branch` | Mechanical 4-option choice (merge/PR/keep/discard). | |
+| `using-superjawn` | Meta-skill about skill discovery itself. | |
 
 **Cross-cutting principles:**
-- All research is default-on with explicit skip
-- Research output is always written into the skill's existing artifact, never to a separate file
-- Subagent-by-default uses existing `Explore` / `general-purpose` agent types only
+- Research findings always land in the skill's existing artifact, never a separate file
+- Subagent dispatch uses existing `Explore` / `general-purpose` agent types only
+- Freshness check defaults to skip with explicit triggers (inverse of research's default-on)
 
-## Section 3 — Common research-step shape
+## Section 3 — Phase shapes
 
-Reusable template inserted into each skill's `## Research phase` section, with skill-specific substitutions (stage trigger, default kinds, subagent recommendation, artifact name).
+Two shapes, one per phase type.
+
+### 3a. Research phase (used by entry-point skills only)
 
 ```
 ## Research phase
 
 [Skill-specific stage: e.g. "After clarifying questions, before proposing approaches"]
 
-This is default-on. Skip only with explicit justification.
+**Default-on.** Skip only with explicit justification per the locked skip protocol (Section 4).
 
 ### 1. Pick research kinds
 From the menu — trends + discourse, patterns, pitfalls, authoritative verification, user-context.
@@ -84,22 +123,53 @@ Subagent by default:
   - Explore for codebase / prior-art
   - general-purpose for web / discourse / verification
   - Parallel when kinds are independent
-Inline only for light-touch research (memory check, single grep).
 
 ### 3. Record findings
 Write 3-5 tight bullets into <skill-specific artifact>. Include load-bearing
 links/refs and anything considered-but-ruled-out so future-you knows it was checked.
 
 ### 4. Skip protocol
-If skipping, write one line: "Skipped research because <reason>."
-Valid reasons: trivial scope, fresh prior research in memory, user said skip.
-Invalid reasons: "I think I know", "seems straightforward", "moving fast" —
-if those are tempting, do the research.
+[Insert the locked Section 4 skip protocol verbatim — bolded enforcement clauses preserved]
 ```
 
-**Integration with existing skill flow:** The `## Research phase` section gets inserted into each skill's existing `## Checklist` or `## Process` block as a new numbered step at the right stage. Existing process flow diagrams (the dot graphs in brainstorming, debugging, etc.) get one new node added — `"Research phase"` — with edges into and out of the right neighbors.
+### 3b. Freshness check (used by stale-artifact consumer skills only)
 
-## Section 4 — Skip-justification protocol
+```
+## Freshness check (when artifact is stale)
+
+**Default-skip.** Run only when one of these triggers fires:
+
+- **Cross-session execution.** The plan was drafted in a prior session (different cwd, different transcript), not the current one.
+- **External API/service touched.** Any task in the plan calls an API, service, or file outside the repo (e.g., live HTTP, third-party SDK call, OS-managed config).
+- **Working on main/master.** Current branch is `main` or `master` — heightened drift risk because integration work assumes the branch is in sync.
+
+If none of the triggers fire, write one line in the journal: "Freshness check skipped — none of the triggers fired (current session, no external APIs, on feature branch <name>)."
+
+### When the check fires
+
+Verify, in order:
+1. **Authoritative state.** For each external API/file the plan references, hit the real source (live curl / file read / version check). Confirm the contract still matches what the plan assumed.
+2. **Codebase drift.** Grep that any function/module/path the plan names still exists at the same path with the same shape.
+3. **Repo state.** `git log <plan-write-sha>..HEAD` — has anyone landed conflicting work?
+
+### Findings location
+
+Write to the execution journal at `.superpowers/exec-journal-<plan-slug>.md` (created on first run if it doesn't exist). One line per check:
+
+```
+[YYYY-MM-DD HH:MM] Task N freshness check: <PASS / FAIL> — <one-line summary>
+```
+
+If FAIL on any check, escalate before implementing — the plan needs revision.
+```
+
+**Integration with existing skill flow:** The `## Research phase` section gets inserted into entry-point skills at the stage from Section 2 (after clarifying questions in brainstorming, between Phase 1 and Phase 2 in systematic-debugging, before drafting in writing-skills). Existing process flow diagrams (the dot graphs) get one new node added with edges into and out of the right neighbors.
+
+The `## Freshness check (when artifact is stale)` section goes into executing-plans and subagent-driven-development between the plan-load step and the per-task implementation step. Default-skip means the check itself is one decision and one line in the journal — not a forcing function.
+
+## Section 4 — Skip-justification protocol (research skills only)
+
+This protocol applies to the three research-phase skills (`brainstorming`, `systematic-debugging`, `writing-skills`). Freshness-check skills (Section 3b) have their own inverse pattern (default-skip with explicit triggers); the protocol below does not apply there.
 
 **Skip line format:**
 
@@ -132,37 +202,38 @@ One line, written into the same artifact where findings would have gone. Audit-t
 
 ## Section 5 — Rollout sequence
 
-**Build batches (5 batches, ~3 skills each, one PR per batch):**
+**Build batches (5 batches, one PR per batch):**
 
-1. **Foundation:** `brainstorming`, `writing-plans`, `executing-plans`
-2. **Debugging + testing:** `systematic-debugging`, `test-driven-development`, `verification-before-completion`
-3. **Code review:** `receiving-code-review`, `requesting-code-review`
-4. **Parallelism + isolation:** `subagent-driven-development`, `dispatching-parallel-agents`, `using-git-worktrees`
-5. **Meta + integration:** `finishing-a-development-branch`, `using-superjawn`, `writing-skills`
+1. **Foundation (shipped v0.1.0; rearchitected v0.2.0):** `brainstorming` (research), `writing-plans` (consumer — strip research), `executing-plans` (freshness check — replace research)
+2. **Debugging + testing:** `systematic-debugging` (research), `test-driven-development` (consumer), `verification-before-completion` (consumer)
+3. **Code review:** `receiving-code-review` (consumer), `requesting-code-review` (consumer)
+4. **Parallelism + isolation:** `subagent-driven-development` (freshness check), `dispatching-parallel-agents` (consumer), `using-git-worktrees` (consumer)
+5. **Meta + integration:** `finishing-a-development-branch` (consumer), `using-superjawn` (consumer), `writing-skills` (research)
 
-**Per-skill build steps:**
+**Per-skill build steps depend on the category:**
 
-1. Copy upstream `SKILL.md` into `superjawn/skills/<name>/SKILL.md`
-2. Add MIT attribution comment at top with original source URL
-3. Insert `## Research phase` section at the stage from Section 2
-4. Rewrite cross-references (`superpowers:` → `superjawn:`)
-5. Update process flow diagram (dot graph) to include the new node
-6. Self-test on a small real task; confirm research phase fires and findings record correctly
+**Research skill:** Copy upstream `SKILL.md` → add MIT attribution comment → insert `## Research phase` section per Section 3a at the stage from Section 2 → rewrite `superpowers:` cross-references → update process flow diagram to include the research node → self-test that research phase fires and skip protocol works.
 
-**Plugin install during build:** Local plugin path for fast iteration. Both upstream and superjawn installed; manually invoke `superjawn:<skill>` to test. After batch 5, disable upstream `superpowers`.
+**Freshness-check skill:** Copy upstream `SKILL.md` → add MIT attribution comment → insert `## Freshness check (when artifact is stale)` section per Section 3b → rewrite `superpowers:` cross-references → ensure execution journal path is defined and reachable → self-test the trigger conditions (cross-session, external API, main/master) and the default-skip path.
+
+**Consumer skill:** Copy upstream `SKILL.md` → add MIT attribution comment → rewrite `superpowers:` cross-references → done. No research/freshness phase, no flow-diagram edits beyond cross-ref text.
+
+**Plugin install during build:** Marketplace cleanup completed 2026-05-05 post-merge of v0.1.0 — local-path registration removed, GitHub-sourced marketplace re-registered. For feature-branch live testing, register the local path under a parallel marketplace name (e.g., `claude-skills-journalism-local`) instead of replacing the canonical GitHub-sourced one.
 
 **Versioning:**
 
-- `v0.1.0` — batch 1 shipped
-- `v0.2.0`–`v0.4.0` — batches 2–4
-- `v0.5.0` — batch 5 (all 14 in place, upstream still enabled)
+- `v0.1.0` — batch 1 shipped (foundation triad with research on all three; rearchitected in v0.2.0)
+- `v0.2.0` — batch 1 architecture rework: strip research from writing-plans, replace executing-plans research with freshness check, fold in smoke-test bug fixes
+- `v0.3.0`–`v0.5.0` — batches 2-4 per the new categorization
+- `v0.6.0` — batch 5 (all 14 in place, upstream still enabled)
 - `v1.0.0` — upstream disabled, 2+ weeks of real use, no critical issues
 
 **Per-batch testing:**
 
-- Cross-ref resolution: every `superjawn:` reference must resolve
-- Research phase fires: pick one small real task per skill, verify findings or skip line appear in the artifact
-- Skip protocol works: deliberately invoke on a trivial task, verify skip line is correct and audit-visible
+- Cross-ref resolution: every `superjawn:` reference must resolve to a real upstream or already-ported skill
+- Research phase fires (entry-point skills only): pick one small real task per skill, verify findings or skip line appear in the artifact
+- Freshness check (executing-plans, subagent-driven-development): deliberately exercise the trigger conditions (cross-session plan, external-API task, main-branch invocation) and the default-skip path on a feature-branch run
+- Pure-port consumers: cross-ref resolution + announce-string namespace correctness only (no phase to test)
 
 ## Section 6 — Upstream drift management
 

--- a/superjawn/.claude-plugin/plugin.json
+++ b/superjawn/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superjawn",
   "version": "0.2.0",
-  "description": "Skills derived from obra/superpowers — research at entry-point stages (brainstorming, debugging, skill-writing) and a narrow freshness check on stale-artifact-consumer skills (executing plans). Pure consumer ports for the rest.",
+  "description": "Skills derived from obra/superpowers — research at entry-point stages (brainstorming, debugging, skill-writing), a narrow freshness check on stale-artifact-consumer skills (executing-plans, subagent-driven-development), and pure consumer ports for the rest.",
   "author": {
     "name": "Joe Amditis",
     "email": "jamditis@gmail.com"

--- a/superjawn/.claude-plugin/plugin.json
+++ b/superjawn/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superjawn",
-  "version": "0.1.0",
-  "description": "Research-augmented skills derived from obra/superpowers — adds default-on research phases to each skill in the workflow",
+  "version": "0.2.0",
+  "description": "Skills derived from obra/superpowers — research at entry-point stages (brainstorming, debugging, skill-writing) and a narrow freshness check on stale-artifact-consumer skills (executing plans). Pure consumer ports for the rest.",
   "author": {
     "name": "Joe Amditis",
     "email": "jamditis@gmail.com"

--- a/superjawn/CREDITS.md
+++ b/superjawn/CREDITS.md
@@ -17,7 +17,7 @@ Synced against upstream `obra/superpowers` v5.0.7 (release tag) on 2026-05-05. T
 - `writing-plans` — research phase stripped (consumer of brainstorming spec; trusts the handoff)
 - `executing-plans` — per-task drift check replaced with a one-time default-skip freshness check at execution start, gated on three triggers (cross-session plan, external API/service, main/master branch). Two smoke-test bugs from PR #34 review folded in: the execution-journal location is now defined (`.superpowers/exec-journal-<plan-slug>.md`), and the master-branch guardrail is wired into the freshness check itself (was previously only in Remember).
 
-See `specs/2026-05-05-superjawn-research-phases-design.md` (in the parent `claude-skills-journalism` repo) for the full architecture and the categorization across all 14 skills.
+See [`../specs/2026-05-05-superjawn-research-phases-design.md`](../specs/2026-05-05-superjawn-research-phases-design.md) for the full architecture and the categorization across all 14 skills.
 
 **v0.1.0 (foundation triad).** Each ported skill added a `## Research phase` section. Reverted/replaced in v0.2.0 for `writing-plans` and `executing-plans`.
 

--- a/superjawn/CREDITS.md
+++ b/superjawn/CREDITS.md
@@ -12,6 +12,13 @@ Synced against upstream `obra/superpowers` v5.0.7 (release tag) on 2026-05-05. T
 
 ## Modifications from upstream
 
-Each skill in this plugin adds a `## Research phase` section relative to the upstream version. See `specs/2026-05-05-superjawn-research-phases-design.md` for the design rationale.
+**v0.2.0 architecture revision (current).** Research belongs only at entry-point stages where work originates without an upstream artifact. The three foundation skills shipped in v0.1.0 are now categorized:
+- `brainstorming` — research phase preserved (entry-point skill)
+- `writing-plans` — research phase stripped (consumer of brainstorming spec; trusts the handoff)
+- `executing-plans` — per-task drift check replaced with a one-time default-skip freshness check at execution start, gated on three triggers (cross-session plan, external API/service, main/master branch). Two smoke-test bugs from PR #34 review folded in: the execution-journal location is now defined (`.superpowers/exec-journal-<plan-slug>.md`), and the master-branch guardrail is wired into the freshness check itself (was previously only in Remember).
 
-Visual companion scripts (`skills/brainstorming/scripts/{helper.js,server.cjs,start-server.sh,stop-server.sh}`) diverge from upstream v5.0.7 with security and correctness fixes flagged during PR #34 review: XSS-safe DOM construction in `helper.js` (replaces `innerHTML` with `createElement`+`textContent`+`replaceChildren`), an inbound WebSocket frame size cap in `server.cjs` (rejects payloads above 1 MiB before allocating), `exec`-based PID preservation in `start-server.sh` foreground mode (so `server.pid` matches the node process), and SESSION_DIR validation in `stop-server.sh` (rejects paths outside `/tmp/brainstorm-*` or `*/.superpowers/brainstorm/*`). Carry these forward when syncing future upstream releases.
+See `specs/2026-05-05-superjawn-research-phases-design.md` (in the parent `claude-skills-journalism` repo) for the full architecture and the categorization across all 14 skills.
+
+**v0.1.0 (foundation triad).** Each ported skill added a `## Research phase` section. Reverted/replaced in v0.2.0 for `writing-plans` and `executing-plans`.
+
+**Visual companion scripts.** `skills/brainstorming/scripts/{helper.js,server.cjs,start-server.sh,stop-server.sh}` diverge from upstream v5.0.7 with security and correctness fixes flagged during PR #34 review: XSS-safe DOM construction in `helper.js` (replaces `innerHTML` with `createElement`+`textContent`+`replaceChildren`), an inbound WebSocket frame size cap in `server.cjs` (rejects payloads above 1 MiB before allocating), `exec`-based PID preservation in `start-server.sh` foreground mode (so `server.pid` matches the node process), and SESSION_DIR validation in `stop-server.sh` (rejects paths outside `/tmp/brainstorm-*` or `*/.superpowers/brainstorm/*`). Carry these forward when syncing future upstream releases.

--- a/superjawn/README.md
+++ b/superjawn/README.md
@@ -1,33 +1,37 @@
 # superjawn
 
-Research-augmented Claude Code skills derived from [obra/superpowers](https://github.com/obra/superpowers) v5.0.7. Each skill grows a default-on research phase tailored to its stage of the workflow — gather trends, pitfalls, patterns, and discourse before building or proposing.
+Claude Code skills derived from [obra/superpowers](https://github.com/obra/superpowers) v5.0.7. Research belongs at entry-point stages where work originates without an upstream artifact (`brainstorming`, `systematic-debugging`, `writing-skills`); stale-artifact-consumer skills get a narrow default-skip freshness check (`executing-plans`, `subagent-driven-development`); the rest port as pure consumers that trust the artifact handoff. See `specs/2026-05-05-superjawn-research-phases-design.md` (in the parent `claude-skills-journalism` repo) for the full architecture.
 
 ## Skills
 
-| Skill | Status |
-|---|---|
-| `brainstorming` | Ported (Batch 1) |
-| `writing-plans` | Ported (Batch 1) |
-| `executing-plans` | Ported (Batch 1) |
-| `systematic-debugging` | Pending (Batch 2) |
-| `test-driven-development` | Pending (Batch 2) |
-| `verification-before-completion` | Pending (Batch 2) |
-| `receiving-code-review` | Pending (Batch 3) |
-| `requesting-code-review` | Pending (Batch 3) |
-| `subagent-driven-development` | Pending (Batch 4) |
-| `dispatching-parallel-agents` | Pending (Batch 4) |
-| `using-git-worktrees` | Pending (Batch 4) |
-| `finishing-a-development-branch` | Pending (Batch 5) |
-| `using-superjawn` | Pending (Batch 5) |
-| `writing-skills` | Pending (Batch 5) |
+| Skill | Category | Status |
+|---|---|---|
+| `brainstorming` | Research | Ported (Batch 1) |
+| `writing-plans` | Consumer | Ported (Batch 1, research stripped in v0.2.0) |
+| `executing-plans` | Freshness check | Ported (Batch 1, freshness check in v0.2.0) |
+| `systematic-debugging` | Research | Pending (Batch 2) |
+| `test-driven-development` | Consumer | Pending (Batch 2) |
+| `verification-before-completion` | Consumer | Pending (Batch 2) |
+| `receiving-code-review` | Consumer | Pending (Batch 3) |
+| `requesting-code-review` | Consumer | Pending (Batch 3) |
+| `subagent-driven-development` | Freshness check | Pending (Batch 4) |
+| `dispatching-parallel-agents` | Consumer | Pending (Batch 4) |
+| `using-git-worktrees` | Consumer | Pending (Batch 4) |
+| `finishing-a-development-branch` | Consumer | Pending (Batch 5) |
+| `using-superjawn` | Consumer | Pending (Batch 5) |
+| `writing-skills` | Research | Pending (Batch 5) |
 
 ## Coexistence with upstream
 
-During the rollout (v0.1.0 through v0.5.0), keep both `superpowers` and `superjawn` plugins installed. Skills not yet ported still resolve via `superpowers:<skill>`. At v1.0.0, after at least 2 weeks of real use of the full set, disable the upstream `superpowers` plugin in your Claude Code config.
+During the rollout (v0.1.0 through v0.6.0), keep both `superpowers` and `superjawn` plugins installed. Skills not yet ported still resolve via `superpowers:<skill>`. At v1.0.0, after at least 2 weeks of real use of the full set, disable the upstream `superpowers` plugin in your Claude Code config.
 
-## Research phase
+## Phase shapes
 
-Every ported skill includes a `## Research phase` section. By default, the research runs via subagent dispatch (`Explore` for codebase questions, `general-purpose` for web/discourse). Findings are written into the skill's existing artifact (spec, plan, debug log). Skipping research requires an explicit, justified line in the artifact — see each skill's Skip protocol.
+**Research phase (3 entry-point skills).** Default-on. Subagent dispatch by default (`Explore` for codebase, `general-purpose` for web/discourse). Findings land in the skill's existing artifact. Skip requires an explicit, justified line per the locked skip protocol.
+
+**Freshness check (2 stale-artifact consumer skills).** Default-skip. Fires only when a trigger indicates real drift risk: cross-session execution, external API/service touched, or working on `main`/`master`. Findings land in `.superpowers/exec-journal-<plan-slug>.md`.
+
+**Consumer (9 skills).** No phase. Pure port from upstream with attribution comment + dual-namespace cross-reference rewrites. Trusts the upstream-artifact handoff.
 
 ## Credits
 

--- a/superjawn/README.md
+++ b/superjawn/README.md
@@ -1,6 +1,6 @@
 # superjawn
 
-Claude Code skills derived from [obra/superpowers](https://github.com/obra/superpowers) v5.0.7. Research belongs at entry-point stages where work originates without an upstream artifact (`brainstorming`, `systematic-debugging`, `writing-skills`); stale-artifact-consumer skills get a narrow default-skip freshness check (`executing-plans`, `subagent-driven-development`); the rest port as pure consumers that trust the artifact handoff. See `specs/2026-05-05-superjawn-research-phases-design.md` (in the parent `claude-skills-journalism` repo) for the full architecture.
+Claude Code skills derived from [obra/superpowers](https://github.com/obra/superpowers) v5.0.7. Research belongs at entry-point stages where work originates without an upstream artifact (`brainstorming`, `systematic-debugging`, `writing-skills`); stale-artifact-consumer skills get a narrow default-skip freshness check (`executing-plans`, `subagent-driven-development`); the rest port as pure consumers that trust the artifact handoff. See [`../specs/2026-05-05-superjawn-research-phases-design.md`](../specs/2026-05-05-superjawn-research-phases-design.md) for the full architecture.
 
 ## Skills
 

--- a/superjawn/skills/executing-plans/SKILL.md
+++ b/superjawn/skills/executing-plans/SKILL.md
@@ -6,9 +6,12 @@ description: Use when you have a written implementation plan to execute in a sep
 <!--
 Adapted from obra/superpowers executing-plans skill (v5.0.7), MIT-licensed,
 copyright 2025 Jesse Vincent. Modifications copyright 2026 Joe Amditis.
-Modifications add a per-task research phase (drift check before
-implementation), plus updates to cross-references.
-See CREDITS.md.
+v0.1.0 added a per-task drift check (default-on research). v0.2.0
+replaced that with a one-time freshness check at execution start,
+default-skip with explicit triggers (cross-session plan, external API,
+main/master branch), fixing the "execution journal undefined" and
+"master-branch guardrail not in drift check" bugs surfaced by smoke
+testing. See CREDITS.md.
 -->
 
 # Executing Plans
@@ -21,60 +24,66 @@ Load plan, review critically, execute all tasks, report when complete.
 
 **Note:** Tell your human partner that superjawn works much better with access to subagents. The quality of its work will be significantly higher if run on a platform with subagent support (such as Claude Code or Codex). If subagents are available, use superpowers:subagent-driven-development instead of this skill.
 
-## Research phase (per task)
+## Freshness check (when artifact is stale)
 
-Before implementing each task in the plan, run a quick drift check. **Default-on**: skip only with explicit, justified statement per task.
+The plan was written at a point in time. **Default-skip.** Run only when one of these triggers fires:
 
-### 1. What to verify
+- **Cross-session execution.** The plan was drafted in a prior session — different cwd, different transcript, or different day. If you wrote the plan yourself in this session, the freshness check is not needed.
+- **External API/service touched.** Any task in the plan calls an external API, service, or file outside the repo (e.g., live HTTP, third-party SDK call, OS-managed config). Internal state can be assumed stable; external contracts cannot.
+- **Working on main/master.** Current branch is `main` or `master`. Heightened drift risk because integration work assumes the branch is in sync, and other people landing commits can invalidate the plan's assumptions silently.
 
-The plan was written at a point in time. Before each task, verify:
-- **Authoritative state:** If the task touches an external API or file the plan references, confirm the API contract or file content hasn't changed. Live curl, file read, version check.
-- **Codebase drift:** If the task assumes a function/module exists at a specific path, grep to confirm it still does.
-- **Repo state:** Has anyone landed conflicting work on the branch since the plan was drafted?
-
-### 2. Dispatch
-
-- Inline for single-file or single-API checks
-- `Explore` subagent for codebase-drift questions spanning multiple files
-- `general-purpose` subagent for verification that spans external sources
-
-### 3. Record findings
-
-Append a short note to the execution journal (or PR description) for each task:
+If none of the triggers fire, write one line into the execution journal and proceed:
 
 ```
-Task N drift check: <PASS / FAIL> — <one-line summary>
+[YYYY-MM-DD HH:MM] Freshness check skipped — none of the triggers fired (current session, no external APIs, on feature branch <name>).
 ```
 
-If FAIL, escalate before implementing — the plan may need revision.
+### When the check fires
 
-### 4. Skip protocol
+Verify, in order, BEFORE running any tasks:
 
-If skipping the per-task drift check, write one line in the journal: `Task N drift check skipped because <reason>.`
+1. **Authoritative state.** For each external API/file the plan references, hit the real source — live curl, file read, version check. Confirm the contract still matches what the plan assumed.
+2. **Codebase drift.** Grep that any function/module/path the plan names still exists at the expected location with the expected shape.
+3. **Repo state.** `git log <plan-write-sha>..HEAD` if you can identify when the plan was written; otherwise `git log --since='1 week ago' --oneline`. Has anyone landed conflicting work since the plan was drafted?
 
-**Valid reasons:**
-- Task is purely additive within a file the previous task just created (no external state to verify)
-- Plan was drafted within the current session and nothing has changed
-- Task is a pure mechanical commit / rebase / push step
+### Findings location: the execution journal
 
-**Invalid reasons:** "I think I know", "seems straightforward", "moving fast", "user wants this done quickly", "already familiar with this codebase". If those are tempting, do the check.
+Findings land in a per-plan execution journal at:
+
+```
+.superpowers/exec-journal-<plan-slug>.md
+```
+
+Where `<plan-slug>` is the kebab-case basename of the plan file (e.g., `2026-05-05-superjawn-batch-1.md` → `exec-journal-2026-05-05-superjawn-batch-1.md`). The journal is created on first run if it doesn't exist; entries are appended in chronological order. The directory `.superpowers/` is git-ignored by upstream convention.
+
+One line per check:
+
+```
+[YYYY-MM-DD HH:MM] Freshness check: <PASS / FAIL> — <one-line summary>
+```
+
+If FAIL on any check, **stop and escalate to your human partner before implementing** — the plan may need revision.
+
+### Master-branch guardrail
+
+If the trigger fired because you're on `main` or `master`, the freshness check ALSO requires explicit user consent before any implementation begins. Per the upstream rule "never start implementation on main/master without explicit user consent," ask first, then proceed. Document the consent in the journal as part of the freshness check entry.
 
 ## The Process
 
 ### Step 1: Load and Review Plan
 1. Read plan file
 2. Review critically - identify any questions or concerns about the plan
-3. If concerns: Raise them with your human partner before starting
-4. If no concerns: Create TodoWrite and proceed
+3. Run the freshness check (see "Freshness check (when artifact is stale)" above) — single decision, write the result line to the execution journal
+4. If concerns or freshness FAIL: Raise them with your human partner before starting
+5. If no concerns and freshness PASS or skipped: Create TodoWrite and proceed
 
 ### Step 2: Execute Tasks
 
 For each task:
 1. Mark as in_progress
-2. Run the drift check (see "Research phase (per task)" above)
-3. Follow each step exactly (plan has bite-sized steps)
-4. Run verifications as specified
-5. Mark as completed
+2. Follow each step exactly (plan has bite-sized steps)
+3. Run verifications as specified
+4. Mark as completed
 
 ### Step 3: Complete Development
 
@@ -104,11 +113,11 @@ After all tasks complete and verified:
 ## Remember
 - Review plan critically first
 - Follow plan steps exactly
-- Drift-check each task against current codebase reality before implementing (see Research phase)
+- Run the freshness check at Step 1 — default-skip, but fires for cross-session plans, external APIs, or main/master branch work
 - Don't skip verifications
 - Reference skills when plan says to
 - Stop when blocked, don't guess
-- Never start implementation on main/master branch without explicit user consent
+- Never start implementation on main/master branch without explicit user consent (the freshness check enforces this when triggered)
 
 ## Integration
 

--- a/superjawn/skills/executing-plans/SKILL.md
+++ b/superjawn/skills/executing-plans/SKILL.md
@@ -54,7 +54,7 @@ Findings land in a per-plan execution journal at:
 .superpowers/exec-journal-<plan-slug>.md
 ```
 
-Where `<plan-slug>` is the kebab-case basename of the plan file (e.g., `2026-05-05-superjawn-batch-1.md` → `exec-journal-2026-05-05-superjawn-batch-1.md`). The journal is created on first run if it doesn't exist; entries are appended in chronological order. The directory `.superpowers/` is git-ignored by upstream convention.
+Where `<plan-slug>` is the kebab-case basename of the plan file with the `.md` extension stripped (e.g., the plan file `2026-05-05-superjawn-batch-1.md` produces the slug `2026-05-05-superjawn-batch-1`, and the journal lands at `.superpowers/exec-journal-2026-05-05-superjawn-batch-1.md`). The journal is created on first run if it doesn't exist; entries are appended in chronological order. The directory `.superpowers/` is git-ignored by upstream convention.
 
 One line per check:
 

--- a/superjawn/skills/writing-plans/SKILL.md
+++ b/superjawn/skills/writing-plans/SKILL.md
@@ -6,8 +6,9 @@ description: Use when you have a spec or requirements for a multi-step task, bef
 <!--
 Adapted from obra/superpowers writing-plans skill (v5.0.7), MIT-licensed,
 copyright 2025 Jesse Vincent. Modifications copyright 2026 Joe Amditis.
-Modifications add a default-on research phase before plan drafting, plus
-updates to cross-references and self-review.
+v0.1.0 added a default-on research phase; v0.2.0 reverted that change
+and made writing-plans a pure consumer of the brainstorming spec
+(research belongs at the entry-point stage where work originates).
 See CREDITS.md.
 -->
 
@@ -29,44 +30,6 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 ## Scope Check
 
 If the spec covers multiple independent subsystems, it should have been broken into sub-project specs during brainstorming. If it wasn't, suggest breaking this into separate plans — one per subsystem. Each plan should produce working, testable software on its own.
-
-## Research phase
-
-Before drafting plan steps, gather outside context. **Default-on**: skip only with explicit justification.
-
-### 1. Pick research kinds
-
-For writing-plans, the **defaults are:**
-- **Web (pitfalls in chosen approach):** What's gone wrong for others doing this kind of plan? Recent post-mortems, GitHub issues, conference talks?
-- **Codebase (similar features):** Has this codebase done something similar before? What patterns can be reused?
-- **Authoritative verification:** If the plan involves external APIs/services/standards, hit the real source — current docs, live curl, current spec — to confirm the plan's assumptions.
-
-Add user-context if a prior plan or session is relevant.
-
-### 2. Dispatch
-
-Subagent by default:
-- `Explore` for codebase / similar-feature search
-- `general-purpose` for web research and live API verification
-- Run in parallel when independent
-
-Inline for trivial plans (single-file edits, mechanical changes).
-
-### 3. Record findings
-
-Write 3–5 tight bullets into a new `## Research notes` section placed immediately after the plan header's `---` separator and before Task 1. Include load-bearing references and anything considered-but-ruled-out.
-
-### 4. Skip protocol
-
-If skipping, write one line into the plan doc: `Skipped research because <reason>. <Verifiable pointer if applicable>.`
-
-**Valid reasons:**
-- Trivial scope (typo, comment edit, single-line config)
-- Fresh prior research — same topic in current session OR within last 7 days with verifiable spec/plan pointer. **If the pointer doesn't resolve, the skip is invalid.** (Beyond 7 days, repeat the research even if you remember the prior findings — the landscape drifts.)
-- User explicit — **must quote the phrase** that authorized the skip.
-- Repeat of identical task — **must include a pointer** to the prior successful run.
-
-**Invalid reasons:** "I think I know", "seems straightforward", "moving fast", "user wants this done quickly", "already familiar with this codebase". If those are tempting, do the research.
 
 ## File Structure
 
@@ -174,8 +137,6 @@ After writing the complete plan, look at the spec with fresh eyes and check the 
 **2. Placeholder scan:** Search your plan for red flags — any of the patterns from the "No Placeholders" section above. Fix them.
 
 **3. Type consistency:** Do the types, method signatures, and property names you used in later tasks match what you defined in earlier tasks? A function called `clearLayers()` in Task 3 but `clearFullLayers()` in Task 7 is a bug.
-
-**4. Research phase check:** Does the plan contain either a `## Research notes` section with findings, or a `Skipped research because <reason>` declaration? If neither, the plan was drafted without the research step — return to the research phase.
 
 If you find issues, fix them inline. No need to re-review — just fix and move on. If you find a spec requirement with no task, add the task.
 


### PR DESCRIPTION
## Summary

Reverts the v0.1.0 "research phase on every skill" design in favor of a tighter architecture: research at entry-point stages only (3 skills), freshness check on stale-artifact-consumer skills (2 skills), pure ports for the rest (9 skills).

The trigger was real-use feedback that research in `writing-plans`/`executing-plans` duplicated conclusions from `brainstorming` when the three skills ran in succession (the canonical flow). The duplicate research cost time without information gain and risked conflicting findings.

Two smoke-test bugs from PR #34 review folded in along the way:
- "Execution journal" was previously undefined; now defined as `.superpowers/exec-journal-<plan-slug>.md`
- Master-branch guardrail was in Remember but not in the per-task drift check; now wired into the freshness check itself

## Architecture

Categorization across the 14 superpowers skills:

- **Research (3 entry-point skills):** `brainstorming`, `systematic-debugging`, `writing-skills`
- **Freshness check (2 stale-artifact consumers):** `executing-plans`, `subagent-driven-development`
- **Consumer (9 pure-port skills):** `writing-plans`, `test-driven-development`, `verification-before-completion`, `receiving-code-review`, `requesting-code-review`, `dispatching-parallel-agents`, `using-git-worktrees`, `finishing-a-development-branch`, `using-superjawn`

Implementation impact for batches 2-5: 9 of the remaining 11 ports become pure copy + cross-ref rewrites. Only 4 skills across batches 2-5 need real customization work.

## Commits

1. `docs(superjawn): rearchitect spec for v0.2.0` — rewrites Sections 2-5 of the design spec
2. `refactor(superjawn): strip research phase from writing-plans` — reverts the v0.1.0 insertion; restores upstream Self-Review structure
3. `refactor(superjawn): replace per-task drift check with freshness check` — one-time-at-start, default-skip with three triggers; folds in the two smoke-test bugs
4. `chore(superjawn): bump 0.1.0 → 0.2.0, update README and CREDITS` — version + metadata

## Test plan

- [ ] Spec reads coherently end-to-end; the categorization rule is stated clearly enough that a reader can apply it to any new skill
- [ ] `superjawn:writing-plans` SKILL.md has no `## Research phase` section and no Self-Review item 4
- [ ] `superjawn:executing-plans` SKILL.md has `## Freshness check (when artifact is stale)` with three triggers, defined journal location, and master-branch guardrail
- [ ] `superjawn:executing-plans` Step 1 task loop runs the freshness check; Step 2 task loop is back to upstream's 4-item shape (no per-task drift check)
- [ ] `superjawn` plugin version is `0.2.0` in `.claude-plugin/plugin.json`
- [ ] README skill status table has a Category column with the new categorization
- [ ] CREDITS.md "Modifications from upstream" records the v0.2.0 changes alongside the visual-companion script divergences from PR #34