### PR TITLE
fix(docs): plugin grid 3-col → 4-col (no orphan card)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -339,7 +339,7 @@
                     <span class="section-label">4 Plugins</span>
                 </div>
 
-                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
                     <a href="autocontext/" class="skill-card skill-card-featured p-6 transition-all duration-300 block group" style="background: linear-gradient(135deg, rgba(26, 107, 90, 0.08) 0%, rgba(255, 255, 255, 0.5) 100%); border: 2px solid rgba(26, 107, 90, 0.3);">
                         <div class="flex items-start justify-between mb-3">
                             <i data-lucide="brain" class="w-5 h-5 text-[#1a6b5a]"></i>


### PR DESCRIPTION
## Summary

After v1.7.0 added superjawn as the fourth featured plugin, the marketplace index grid renders 3 + 1-orphan at the \`lg\` breakpoint (1024px+). Switching the plugin section's grid from \`lg:grid-cols-3\` to \`lg:grid-cols-4\` puts all four cards in a single row at desktop width.

## Test plan

- [ ] Live page at https://skills.amditis.tech/ shows 4 plugin cards in one row at desktop widths
- [ ] At \`md\` (768px+) cards still render 2×2 (existing \`md:grid-cols-2\` unchanged)
- [ ] At mobile widths cards stack 1-up (existing \`grid-cols-1\` unchanged)
- [ ] Other section grids (core journalism, communications) untouched