### PR TITLE
Sync marketplace.json versions with plugin.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "autocontext",
       "description": "Accumulates project knowledge across sessions and developers through structured lessons and hooks",
-      "version": "0.2.0",
+      "version": "1.1.0",
       "author": {
         "name": "Joe Amditis",
         "email": "jamditis@gmail.com"
@@ -21,7 +21,7 @@
     {
       "name": "pdf-design",
       "description": "PDF report and proposal design system with interactive editing",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "Joe Amditis",
         "email": "jamditis@gmail.com"
@@ -32,7 +32,7 @@
     {
       "name": "pdf-playground",
       "description": "Interactive playground for creating and testing PDF reports and proposals",
-      "version": "1.1.1",
+      "version": "1.3.1",
       "author": {
         "name": "Joe Amditis",
         "email": "jamditis@gmail.com"


### PR DESCRIPTION
Closes #33.

## Summary
- Updated `marketplace.json` entries to match each plugin's own `plugin.json`:
  - autocontext: `0.2.0` → `1.1.0`
  - pdf-design: `1.0.0` → `1.1.0`
  - pdf-playground: `1.1.1` → `1.3.1`
- superjawn deliberately untouched (its entry already agrees with `plugin.json` at `0.1.0`, per the issue scope).

## Why
`plugin.json` wins at install time, so installs were unaffected — but anyone reading the marketplace listing saw stale versions. Confusing for browsers and a recurring trap when contributors bump one file and miss the other.

## Verification
Before:
```
$ claude plugin tag --dry-run ./autocontext
✘ Version mismatch: plugin.json says "1.1.0" but ... marketplace.json plugins[0].version says "0.2.0".
```
(same for pdf-design and pdf-playground)

After:
```
$ claude plugin validate .
✔ Validation passed
```
The version-mismatch errors are gone for all three plugins. The dry-run still warns about uncommitted changes (expected — that clears once the PR merges).

## Test plan
- [ ] CI passes
- [ ] Reviewer confirms diff touches only the three intended `version` fields (no incidental changes)
- [ ] After merge, `claude plugin tag --dry-run ./<plugin-dir>` reports no version drift for autocontext, pdf-design, and pdf-playground