### PR TITLE
chore(docs): superjawn card on landing page → v0.4.0 (8 of 14)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -410,7 +410,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                             <span class="featured-badge" style="background: linear-gradient(135deg, #1e3a8a 0%, #1e40af 100%);">Research-augmented</span>
                         </div>
                         <h3 class="font-display text-lg font-bold mb-2 group-hover:text-[#1e3a8a] transition-colors">superjawn</h3>
-                        <p class="text-sm text-mist leading-relaxed">Research-augmented fork of obra/superpowers. Default-on research phase fires before brainstorming and debugging today; writing-skills lands in a future batch. v0.3.0 ships 6 of 14 ported skills.</p>
+                        <p class="text-sm text-mist leading-relaxed">Research-augmented fork of obra/superpowers. Default-on research phase fires before brainstorming and debugging today; writing-skills lands in a future batch. v0.4.0 ships 8 of 14 ported skills.</p>
                         <div class="flex flex-wrap gap-2 mt-3">
                             <span class="text-[8px] bg-[#1e3a8a]/10 text-[#1e3a8a] px-2 py-1 rounded font-semibold">Research phase</span>
                             <span class="text-[8px] bg-[#1e3a8a]/10 text-[#1e3a8a] px-2 py-1 rounded font-semibold">Subagents</span>


### PR DESCRIPTION
## Summary

Stale plugin card on the main landing page (`docs/index.html`) — was advertising v0.3.0 / 6 of 14 ported skills. Bring it in line with the v0.4.0 marketplace + superjawn landing page (which already say 8 of 14).

One-line change.

## Test plan

- [x] Visual check at `https://skills.amditis.tech/`: superjawn card reads "v0.4.0 ships 8 of 14 ported skills."
- [x] No other versioned references on `docs/index.html` need touching.
- [x] No mobile-width regression (line wraps inside the card unchanged in length).