### PR TITLE
docs: feature superjawn instead of autocontext on landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -353,10 +353,10 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 </div>
             </header>
 
-            <!-- Skill evolution announcement -->
+            <!-- Featured plugin announcement -->
             <section class="reveal-section mb-32">
-                <a href="autocontext/" class="block group">
-                    <div class="relative overflow-hidden rounded-2xl" style="background: linear-gradient(135deg, #1a6b5a 0%, #135346 50%, #0e3f35 100%);">
+                <a href="superjawn/" class="block group">
+                    <div class="relative overflow-hidden rounded-2xl" style="background: linear-gradient(135deg, #1e3a8a 0%, #172554 50%, #0c1738 100%);">
                         <div class="absolute inset-0 opacity-10">
                             <svg aria-hidden="true" focusable="false" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
                                 <circle cx="15%" cy="30%" r="4" fill="white" opacity="0.6"/>
@@ -370,12 +370,12 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         </div>
                         <div class="relative z-10 p-8 md:p-12 flex flex-col md:flex-row items-start md:items-center gap-6 md:gap-12">
                             <div class="flex-1">
-                                <div class="inline-block px-3 py-1 bg-white/15 rounded-full text-[10px] font-bold tracking-[0.3em] uppercase text-white/90 mb-4">New in v1.1</div>
-                                <h2 class="font-display text-3xl md:text-4xl font-black text-white leading-tight mb-3">Skills that improve themselves.</h2>
-                                <p class="text-white/75 text-base md:text-lg max-w-xl">AutoContext now tracks which skills are active when you correct Claude. Lessons accumulate per-skill, and <code class="bg-white/10 px-2 py-0.5 rounded text-white/90 text-sm">/autocontext:evolve</code> folds them back into the skill files. Your skills get better every time you use them.</p>
+                                <div class="inline-block px-3 py-1 bg-white/15 rounded-full text-[10px] font-bold tracking-[0.3em] uppercase text-white/90 mb-4">New in v0.6.0</div>
+                                <h2 class="font-display text-3xl md:text-4xl font-black text-white leading-tight mb-3">Skills that do their homework first.</h2>
+                                <p class="text-white/75 text-base md:text-lg max-w-xl">Superjawn is a research-augmented fork of <code class="bg-white/10 px-2 py-0.5 rounded text-white/90 text-sm">obra/superpowers</code>. A default-on research phase fires before brainstorming, debugging, and writing skills &mdash; pulling from the web, your codebase, and authoritative docs before any plan gets drafted. Skip it when you already know the answer; otherwise the homework happens automatically. All 14 skills ported.</p>
                             </div>
                             <div class="flex-shrink-0">
-                                <span class="inline-flex items-center gap-2 bg-white text-[#1a6b5a] font-bold text-sm px-6 py-3 rounded-lg group-hover:bg-white/90 transition-colors">Learn more <span class="group-hover:translate-x-1 transition-transform">&rarr;</span></span>
+                                <span class="inline-flex items-center gap-2 bg-white text-[#1e3a8a] font-bold text-sm px-6 py-3 rounded-lg group-hover:bg-white/90 transition-colors">Learn more <span class="group-hover:translate-x-1 transition-transform">&rarr;</span></span>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Swaps the lead hero banner on the marketplace landing page (\`docs/index.html\`). autocontext held the slot since v1.1; with superjawn v0.6.0 shipping all 14 ports yesterday, the freshly-feature-complete plugin earns the lead promo. autocontext stays in the plugins grid below — only the hero changes.

## Visual

| Element | Before | After |
|---|---|---|
| Hero href | \`autocontext/\` | \`superjawn/\` |
| Pill | \`New in v1.1\` | \`New in v0.6.0\` |
| Headline | \"Skills that improve themselves.\" | \"Skills that do their homework first.\" |
| Background gradient | Teal (\`#1a6b5a → #135346 → #0e3f35\`) | Dark blue (\`#1e3a8a → #172554 → #0c1738\`) |
| CTA text color | \`#1a6b5a\` | \`#1e3a8a\` (matches new background) |
| Body | autocontext skill-evolution pitch | superjawn research-phase pitch + 14-of-14 ported note |
| Decorative SVG | Constellation (kept — reads as research network) | Same |

## Verification

Verified locally with Playwright via \`python3 -m http.server\` in \`docs/\`. Both viewports rendered cleanly:

- Desktop (1280×900): hero spans full content width, headline reads in the serif display, body copy + CTA aligned right.
- Mobile (375×812): pill, headline, body, and CTA stack vertically without horizontal overflow. \`obra/superpowers\` code chip and \`Learn more\` button both readable at phone width.

## Why no scope creep

autocontext is still the better plugin for daily-driver use; this swap reflects what's *new*, not what's *best*. Once the 2-week superjawn soak ends and v1.0.0 ships (~2026-05-21), the hero might naturally rotate again. Treating the hero as a rotating "what just landed" slot rather than a permanent showcase.