### PR TITLE
deps: remove unused single-file-cli (#51)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "playwright": "^1.57.0",
-        "single-file-cli": "^2.0.83"
+        "playwright": "^1.57.0"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.11.3"
@@ -82,54 +81,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/simple-cdp": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/simple-cdp/-/simple-cdp-1.8.6.tgz",
-      "integrity": "sha512-c33zKvBOOIBfdfDCr++N8Dv6kY03wD+cGuu3MEiBJHC4LtHE5aSwjw5E+dOSeuXolS+8MoDzYuWrJdT+IFp8bw==",
-      "license": "MIT",
-      "engines": {
-        "bun": ">=1.0",
-        "deno": ">=1.4"
-      }
-    },
-    "node_modules/single-file-cli": {
-      "version": "2.0.83",
-      "resolved": "https://registry.npmjs.org/single-file-cli/-/single-file-cli-2.0.83.tgz",
-      "integrity": "sha512-MGKOyvuOgdw5HT1Z5lpzgr30O0uq34Tb6+kPRAbUp2rBMvpxdr0oxn0SqVV0x1oM0g5T8JzvQpUdloOVJkZZrA==",
-      "dependencies": {
-        "simple-cdp": "^1.8.6",
-        "ws": "^8.18.3"
-      },
-      "bin": {
-        "single-file": "single-file-node.js"
-      },
-      "engines": {
-        "bun": ">=1.0",
-        "deno": ">=1.4",
-        "node": ">=20"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "playwright": "^1.57.0",
-    "single-file-cli": "^2.0.83"
+    "playwright": "^1.57.0"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3"


### PR DESCRIPTION
Closes #51.

## What

Drops \`single-file-cli\` from \`dependencies\`. Regenerates \`package-lock.json\` accordingly.

## Why

Same shape as #41 / PR #50 (puppeteer-core). The package was declared in \`dependencies\` but had no actual consumer.

| Check | Result |
|---|---|
| Direct \`require\`/\`import\`/binary call (\`single-file\`) in source | None |
| Reference in \`.github/workflows/skill-lint.yml\` | None — workflow is bash-only |
| Reference in \`web-archiving/SKILL.md\`, \`content-access/SKILL.md\`, \`digital-archive/SKILL.md\` | None |
| \`SingleFile\` matches in \`research/web-*.md\` | Refer to the browser extension ([gildas-lormeau/SingleFile](https://github.com/gildas-lormeau/SingleFile)), not the npm CLI |

## Effect on the install

| Before | After |
|---|---|
| 8 audited packages | 5 audited packages |
| chromium auto-download triggered on \`npm install\` | None |
| 0 vulnerabilities | 0 vulnerabilities (still clean) |

## Risk

Same as PR #50 — removing a dep that nothing imports cannot break anything that currently works. \`playwright\` (still in \`dependencies\`) covers any future browser automation need, and \`@axe-core/playwright\` (devDep) consumes it for the accessibility audit pass.