### PR TITLE
ci: bump actions/checkout from v4 to v6 (#27)

### DIFF
--- a/.github/workflows/skill-lint.yml
+++ b/.github/workflows/skill-lint.yml
@@ -12,7 +12,7 @@ jobs:
   lint-skills:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Validate skill frontmatter
         run: |
@@ -84,7 +84,7 @@ jobs:
   check-readme:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check new skills are listed in README
         run: |


### PR DESCRIPTION
Closes #27.

## What

Bumps \`actions/checkout\` from \`v4\` to \`v6\` in \`.github/workflows/skill-lint.yml\`. Two occurrences in two jobs (\`lint-skills\` + \`check-readme\`) — both updated.

## Why

[GitHub deprecates Node.js 20 in Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/):
- **2026-06-02** — Node 20 actions auto-upgraded to Node 24 default at runtime.
- **2026-09-16** — Node 20 removed from the runner entirely.

\`actions/checkout@v6\` ships with Node 24 support; \`v4\` does not.

## Verification strategy

The workflow's path filter on master is:

\`\`\`yaml
paths:
  - '*/SKILL.md'
  - 'hooks/*.md'
  - '.github/workflows/skill-lint.yml'
\`\`\`

This PR edits the workflow file itself, so the path filter matches and the workflow runs under the new \`v6\` pin on this PR. If both jobs pass on the PR's check-rollup, the bump is confirmed working before merge.

## Behavioral change in v6

Per the [v6.0.0 release notes](https://github.com/actions/checkout/releases/tag/v6.0.0), the only non-version change is [actions/checkout#2286](https://github.com/actions/checkout/pull/2286) — \"Persist creds to a separate file.\" Our jobs do no git operations after checkout (pure bash + sed + grep on local files), so the credential change does not affect us.

## Note on issue scope

Issue #27's plan listed one \`actions/checkout@v4\` occurrence; the workflow actually has two (the \`check-readme\` job, added later, also pins v4). Both bumped here.