### PR TITLE
Expand persistent sessions guide with installation and client setup

### DIFF
--- a/docs/persistent-sessions/index.html
+++ b/docs/persistent-sessions/index.html
@@ -309,6 +309,8 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-6">Setup</h2>
 
+            <p class="text-clay/80 mb-6">tmux runs on the <strong>server</strong> — the always-on machine where Claude Code lives. Your laptop, phone, or tablet is just the client connecting to it. Everything below is configured on the server. See <a href="#install-tmux" class="text-accentDark underline underline-offset-2">Installing tmux</a> if you don't have it yet, and <a href="#clients" class="text-accentDark underline underline-offset-2">Connecting from different devices</a> for the client side.</p>
+
             <!-- Step 1 -->
             <div class="flex gap-4 mb-8">
                 <div class="step-number mt-1">1</div>
@@ -356,34 +358,38 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <div class="step-number mt-1">2</div>
                 <div class="flex-1">
                     <h3 class="font-semibold text-lg mb-3">Auto-attach on terminal open</h3>
-                    <p class="text-clay/80 mb-3">Add this to <code>~/.bashrc</code>. It detects when you're in a Cockpit terminal (<code>XDG_SESSION_TYPE=web</code>) and immediately attaches to (or creates) a tmux session named <code>main</code>.</p>
+                    <p class="text-clay/80 mb-3">Add this to <code>~/.bashrc</code> (or <code>~/.zshrc</code> on macOS, where zsh is the default). It attaches to (or creates) a tmux session named <code>main</code> whenever you open a new terminal on the server. Use whichever condition matches how you connect:</p>
+
                     <div class="terminal-bar">
                         <div class="terminal-titlebar">
                             <div class="terminal-dot bg-red-400"></div>
                             <div class="terminal-dot bg-yellow-400"></div>
                             <div class="terminal-dot bg-green-400"></div>
-                            <span class="text-white/70 text-xs ml-2">~/.bashrc</span>
+                            <span class="text-white/70 text-xs ml-2">~/.bashrc  /  ~/.zshrc</span>
                         </div>
                         <div class="terminal-body text-xs leading-relaxed">
-                            <span class="terminal-dim"># Auto-attach to persistent tmux session in cockpit terminals.</span><br>
-                            <span class="terminal-dim"># XDG_SESSION_TYPE=web is set by cockpit (not SSH, not console).</span><br>
+                            <span class="terminal-dim"># SSH (most common — Termius, Blink, Termux, OpenSSH, PuTTY, etc.)</span><br>
+                            <span class="terminal-dim"># SSH_TTY is set on interactive SSH logins only, not on `ssh host "cmd"`.</span><br>
+                            if [ -z "$TMUX" ] &amp;&amp; [ -n "$SSH_TTY" ]; then<br>
+                            &nbsp;&nbsp;&nbsp;&nbsp;exec tmux new-session -A -s main<br>
+                            fi<br><br>
+                            <span class="terminal-dim"># Cockpit (browser-based terminal at https://yourserver:9090)</span><br>
+                            <span class="terminal-dim"># Use this instead if you connect through Cockpit's web UI.</span><br>
                             if [ -z "$TMUX" ] &amp;&amp; [ "$XDG_SESSION_TYPE" = "web" ]; then<br>
                             &nbsp;&nbsp;&nbsp;&nbsp;exec tmux new-session -A -s main<br>
                             fi
                         </div>
                     </div>
-                    <div class="bg-amber-50 border border-amber-200 rounded-xl p-4 mt-3">
-                        <p class="text-sm text-amber-800"><strong>SSH instead of Cockpit?</strong> Use <code>SSH_TTY</code> instead of <code>XDG_SESSION_TYPE</code>. Replace the condition with <code>[ -n "$SSH_TTY" ]</code> — this fires only on interactive SSH logins, not on automated <code>ssh host "command"</code> calls.</p>
-                    </div>
+                    <p class="text-clay/80 text-sm mt-3">Pick one — or keep both, since the conditions don't overlap. The <code>-z "$TMUX"</code> guard prevents nested tmux sessions when you re-attach.</p>
                 </div>
             </div>
 
             <!-- Step 3 -->
-            <div class="flex gap-4 mb-8">
+            <div id="cockpit-timeout" class="flex gap-4 mb-8">
                 <div class="step-number mt-1">3</div>
                 <div class="flex-1">
-                    <h3 class="font-semibold text-lg mb-3">Fix the Cockpit idle timeout</h3>
-                    <p class="text-clay/80 mb-3">By default, Cockpit terminates idle web sessions after 15 minutes — exactly long enough to time out while Claude is working quietly. Disable it:</p>
+                    <h3 class="font-semibold text-lg mb-3">Fix the Cockpit idle timeout <span class="text-clay/50 font-normal text-sm">(Cockpit only)</span></h3>
+                    <p class="text-clay/80 mb-3">Skip this step if you connect over SSH. By default, Cockpit terminates idle web sessions after 15 minutes — exactly long enough to time out while Claude is working quietly. Disable it:</p>
                     <div class="terminal-bar">
                         <div class="terminal-titlebar">
                             <div class="terminal-dot bg-red-400"></div>
@@ -400,6 +406,118 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 </div>
             </div>
 
+        </section>
+
+        <!-- Installing tmux -->
+        <section id="install-tmux" class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Installing tmux on the server</h2>
+            <p class="text-clay/80 mb-4">Check whether it's already there with <code>tmux -V</code>. You want 3.2 or newer for the <code>display-popup</code> help binding; older versions still work if you remove that one block from <code>.tmux.conf</code>.</p>
+
+            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+                <table class="w-full text-sm">
+                    <thead>
+                        <tr class="bg-mist/10 border-b border-mist/30">
+                            <th class="px-5 py-3 text-left font-semibold">Server OS</th>
+                            <th class="px-5 py-3 text-left font-semibold">Install command</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-mist/20">
+                        <tr>
+                            <td class="px-5 py-3">Debian / Ubuntu / Raspberry Pi OS</td>
+                            <td class="px-5 py-3"><code>sudo apt update &amp;&amp; sudo apt install tmux</code></td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3">Fedora / RHEL / CentOS / Rocky / AlmaLinux</td>
+                            <td class="px-5 py-3"><code>sudo dnf install tmux</code></td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3">Arch / Manjaro</td>
+                            <td class="px-5 py-3"><code>sudo pacman -S tmux</code></td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3">openSUSE</td>
+                            <td class="px-5 py-3"><code>sudo zypper install tmux</code></td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3">Alpine</td>
+                            <td class="px-5 py-3"><code>sudo apk add tmux</code></td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3">macOS (as the server)</td>
+                            <td class="px-5 py-3"><code>brew install tmux</code> (needs <a href="https://brew.sh" class="text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">Homebrew</a>)</td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3">FreeBSD</td>
+                            <td class="px-5 py-3"><code>sudo pkg install tmux</code></td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3">Windows (WSL2 Ubuntu/Debian)</td>
+                            <td class="px-5 py-3"><code>sudo apt install tmux</code> inside the WSL shell</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="bg-amber-50 border border-amber-200 rounded-xl p-4 mt-4">
+                <p class="text-sm text-amber-800"><strong>Native Windows has no tmux.</strong> tmux is POSIX-only. On a Windows server, run Claude Code and tmux inside <a href="https://learn.microsoft.com/windows/wsl/install" class="underline underline-offset-2" target="_blank" rel="noopener noreferrer">WSL2</a>, or use a separate Linux/macOS box as your always-on host. PowerShell and CMD can be SSH <em>clients</em>, but they can't host the tmux session.</p>
+            </div>
+
+            <div class="bg-amber-50 border border-amber-200 rounded-xl p-4 mt-3">
+                <p class="text-sm text-amber-800"><strong>macOS as a server:</strong> works fine, but enable Remote Login in <em>System Settings → General → Sharing</em> so you can SSH in, and disable App Nap on Terminal so the box doesn't throttle background work. A Mac mini or always-plugged-in laptop with "prevent sleep when display is off" is a reasonable host.</p>
+            </div>
+        </section>
+
+        <!-- Connecting from different devices -->
+        <section id="clients" class="mb-12">
+            <h2 class="font-display text-2xl font-semibold mb-4">Connecting from different devices</h2>
+            <p class="text-clay/80 mb-6">Once tmux is set up on the server, anything that can open an SSH session works as a client. The auto-attach snippet drops you straight into the running session, so the client doesn't need to know anything about tmux.</p>
+
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">macOS</h3>
+                    <p class="text-sm text-clay/70 mb-2">Built-in Terminal.app or <a href="https://iterm2.com" class="text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">iTerm2</a> + <code>ssh user@server</code>. OpenSSH ships with macOS — no install needed.</p>
+                    <p class="text-xs text-clay/60">Tip: set up <code>~/.ssh/config</code> with a <code>Host</code> alias so you can run <code>ssh box</code> from any folder.</p>
+                </div>
+
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Windows</h3>
+                    <p class="text-sm text-clay/70 mb-2"><a href="https://aka.ms/terminal" class="text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">Windows Terminal</a> with the built-in OpenSSH client (<code>ssh user@server</code>) is the modern path. <a href="https://www.putty.org" class="text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">PuTTY</a> works too. WSL gives you a Linux shell that can both SSH out and host tmux.</p>
+                </div>
+
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Linux desktop</h3>
+                    <p class="text-sm text-clay/70">Any terminal emulator + <code>ssh</code>. Same pattern as macOS. GNOME Terminal, Konsole, Alacritty, Kitty, Wezterm — all fine.</p>
+                </div>
+
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">iOS / iPadOS</h3>
+                    <p class="text-sm text-clay/70 mb-2"><a href="https://blink.sh" class="text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">Blink Shell</a> (paid, polished, mosh support) and <a href="https://termius.com" class="text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">Termius</a> (free tier) are the two solid choices. Both handle the on-screen <span class="kbd">Ctrl</span> key needed for tmux's <span class="kbd">Ctrl+B</span> prefix.</p>
+                </div>
+
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Android</h3>
+                    <p class="text-sm text-clay/70 mb-2"><a href="https://termux.dev" class="text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">Termux</a> (free, install from F-Droid — the Play Store version is unmaintained) gives you a real shell with <code>pkg install openssh</code>. <a href="https://termius.com" class="text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">Termius</a> is the easiest GUI option.</p>
+                </div>
+
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">ChromeOS</h3>
+                    <p class="text-sm text-clay/70">Enable the Linux container (<em>Settings → Developers → Linux development environment</em>), then <code>sudo apt install openssh-client</code> and use <code>ssh</code> like any Linux desktop. The Secure Shell extension also works without enabling Linux.</p>
+                </div>
+
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Browser (Cockpit)</h3>
+                    <p class="text-sm text-clay/70">Open <code>https://yourserver:9090</code> and use the Terminal app. Works from any device with a browser, including phones, but apply <a href="#cockpit-timeout" class="text-accentDark underline underline-offset-2">the Cockpit timeout fix</a> above.</p>
+                </div>
+
+                <div class="bg-white rounded-xl p-5 border border-mist/30">
+                    <h3 class="font-semibold mb-2">Flaky networks (any device)</h3>
+                    <p class="text-sm text-clay/70">Install <a href="https://mosh.org" class="text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">mosh</a> on the server (<code>apt/dnf/brew install mosh</code>) and use <code>mosh user@server</code> instead of <code>ssh</code>. Mosh survives network changes and sleep — a good companion to tmux on cellular or while moving between Wi-Fi networks.</p>
+                </div>
+            </div>
+
+            <div class="bg-amber-50 border border-amber-200 rounded-xl p-4 mt-4">
+                <p class="text-sm text-amber-800"><strong>Phone keyboards and the <span class="kbd">Ctrl</span> key:</strong> tmux's prefix is <span class="kbd">Ctrl+B</span>, which most mobile SSH apps expose via a software toolbar above the keyboard. If you'd rather use a different prefix, add <code>set -g prefix C-a</code> (and <code>unbind C-b</code> / <code>bind C-a send-prefix</code>) to <code>~/.tmux.conf</code> — <span class="kbd">Ctrl+A</span> is a common alternative that's easier on some layouts.</p>
+            </div>
         </section>
 
         <!-- Key bindings -->
@@ -641,7 +759,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
                 <h2 class="font-display text-xl font-bold mb-3">Claude that keeps working after you close the tab</h2>
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
-                    Three config changes. Runs on any headless Linux server with tmux and Cockpit.
+                    A few config changes. Runs on any headless Linux, macOS, or BSD server with tmux. Connect from a Mac, Windows, Linux, ChromeOS, iOS, or Android client.
                 </p>
                 <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/persistent-sessions" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub

--- a/docs/persistent-sessions/index.html
+++ b/docs/persistent-sessions/index.html
@@ -309,7 +309,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-6">Setup</h2>
 
-            <p class="text-clay/80 mb-6">tmux runs on the <strong>server</strong> — the always-on machine where Claude Code lives. Your laptop, phone, or tablet is just the client connecting to it. Everything below is configured on the server. See <a href="#install-tmux" class="text-accentDark underline underline-offset-2">Installing tmux</a> if you don't have it yet, and <a href="#clients" class="text-accentDark underline underline-offset-2">Connecting from different devices</a> for the client side.</p>
+            <p class="text-clay/80 mb-6">tmux runs on the <strong>server</strong> — the always-on machine where Claude Code lives. Your laptop, phone, or tablet is just the client connecting to it. Everything in this Setup section is configured on the server. See <a href="#install-tmux" class="text-accentDark underline underline-offset-2">Installing tmux</a> if you don't have it yet, and <a href="#clients" class="text-accentDark underline underline-offset-2">Connecting from different devices</a> for the client side.</p>
 
             <!-- Step 1 -->
             <div class="flex gap-4 mb-8">
@@ -415,10 +415,11 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
             <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
                 <table class="w-full text-sm">
+                    <caption class="sr-only">tmux install commands by server operating system</caption>
                     <thead>
                         <tr class="bg-mist/10 border-b border-mist/30">
-                            <th class="px-5 py-3 text-left font-semibold">Server OS</th>
-                            <th class="px-5 py-3 text-left font-semibold">Install command</th>
+                            <th scope="col" class="px-5 py-3 text-left font-semibold">Server OS</th>
+                            <th scope="col" class="px-5 py-3 text-left font-semibold">Install command</th>
                         </tr>
                     </thead>
                     <tbody class="divide-y divide-mist/20">
@@ -427,8 +428,12 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                             <td class="px-5 py-3"><code>sudo apt update &amp;&amp; sudo apt install tmux</code></td>
                         </tr>
                         <tr>
-                            <td class="px-5 py-3">Fedora / RHEL / CentOS / Rocky / AlmaLinux</td>
+                            <td class="px-5 py-3">Fedora / RHEL 8+ / Rocky / AlmaLinux</td>
                             <td class="px-5 py-3"><code>sudo dnf install tmux</code></td>
+                        </tr>
+                        <tr>
+                            <td class="px-5 py-3">CentOS 7 / older RHEL</td>
+                            <td class="px-5 py-3"><code>sudo yum install tmux</code></td>
                         </tr>
                         <tr>
                             <td class="px-5 py-3">Arch / Manjaro</td>
@@ -440,7 +445,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         </tr>
                         <tr>
                             <td class="px-5 py-3">Alpine</td>
-                            <td class="px-5 py-3"><code>sudo apk add tmux</code></td>
+                            <td class="px-5 py-3"><code>apk add tmux</code> as root (Alpine has no <code>sudo</code> by default — use <code>doas</code> if configured)</td>
                         </tr>
                         <tr>
                             <td class="px-5 py-3">macOS (as the server)</td>
@@ -470,7 +475,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <!-- Connecting from different devices -->
         <section id="clients" class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Connecting from different devices</h2>
-            <p class="text-clay/80 mb-6">Once tmux is set up on the server, anything that can open an SSH session works as a client. The auto-attach snippet drops you straight into the running session, so the client doesn't need to know anything about tmux.</p>
+            <p class="text-clay/80 mb-6">Once tmux is set up on the server, anything that can open a shell on it — SSH, mosh, or Cockpit's web terminal — works as a client. The auto-attach snippet drops you straight into the running session, so the client doesn't need to know anything about tmux.</p>
 
             <div class="grid md:grid-cols-2 gap-4">
                 <div class="bg-white rounded-xl p-5 border border-mist/30">
@@ -511,7 +516,8 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
                 <div class="bg-white rounded-xl p-5 border border-mist/30">
                     <h3 class="font-semibold mb-2">Flaky networks (any device)</h3>
-                    <p class="text-sm text-clay/70">Install <a href="https://mosh.org" class="text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">mosh</a> on the server (<code>apt/dnf/brew install mosh</code>) and use <code>mosh user@server</code> instead of <code>ssh</code>. Mosh survives network changes and sleep — a good companion to tmux on cellular or while moving between Wi-Fi networks.</p>
+                    <p class="text-sm text-clay/70 mb-2">Install <a href="https://mosh.org" class="text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">mosh</a> on <em>both</em> the server and the client (<code>apt/dnf/brew install mosh</code>; Blink Shell has it built in), then use <code>mosh user@server</code> instead of <code>ssh</code>. Mosh survives network changes and sleep — a good companion to tmux on cellular or while moving between Wi-Fi networks.</p>
+                    <p class="text-xs text-clay/60">Mosh also needs UDP ports <code>60000–61000</code> open inbound to the server — open them in your firewall (and any cloud security group) or you'll see "mosh: connect failed".</p>
                 </div>
             </div>
 


### PR DESCRIPTION
## What does this PR do?

Significantly expands the persistent sessions documentation with two new comprehensive sections:

1. **Installing tmux on the server** — A new section with a table covering installation commands for all major Linux distributions (Debian/Ubuntu, Fedora/RHEL, Arch, openSUSE, Alpine), macOS, FreeBSD, and WSL2, plus warnings about Windows limitations and macOS-specific setup.

2. **Connecting from different devices** — A new section documenting how to connect to the tmux session from various client platforms: macOS, Windows, Linux desktop, iOS/iPadOS, Android, ChromeOS, Cockpit browser, and notes on mosh for flaky networks.

Also improves the core setup instructions by:
- Clarifying that tmux runs on the server while clients connect to it
- Expanding the auto-attach snippet to cover both SSH and Cockpit connection methods with clear comments
- Marking the Cockpit timeout fix as Cockpit-specific with a skip instruction for SSH users
- Adding an anchor link (`#cockpit-timeout`) for cross-referencing
- Updating the summary description to reflect broader OS and client support

## Type of change

- [x] Documentation

## Checklist

- [x] Documentation is clear and well-organized
- [x] Links are properly formatted with target="_blank" and rel="noopener noreferrer" where appropriate
- [x] Code examples are properly escaped (e.g., `&amp;` for `&`)
- [x] Anchor IDs added for internal linking (`#install-tmux`, `#clients`, `#cockpit-timeout`)
- [x] Responsive grid layout used for client device cards (md:grid-cols-2)

## Notes

The changes make the persistent sessions guide much more complete and practical by:
- Removing the assumption that users already have tmux installed
- Providing clear guidance for users on different operating systems
- Documenting all major client platforms (mobile, desktop, browser)
- Clarifying the server/client architecture upfront
- Consolidating SSH vs. Cockpit setup into a single code block with clear conditions

This transforms the guide from "here's how to configure tmux" to "here's how to set up persistent Claude sessions from any device."

https://claude.ai/code/session_01FcpJAJgFJ1qi2bueEpwtHT