### PR TITLE
release v1.9.0: superjawn v1.0.0 standalone + persistent-sessions guide expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.0] - 2026-05-08
+
+### Changed
+
+- **superjawn v1.0.0 — standalone (#58)**: decouples superjawn's runtime dispatch from the upstream `superpowers` plugin. The four `superpowers:code-reviewer` agent dispatches that v0.6.0 left in place (three in `requesting-code-review/SKILL.md`, one in `subagent-driven-development/code-quality-reviewer-prompt.md`) now target `pr-review-toolkit:code-reviewer`, an Anthropic-maintained agent in `@claude-code-plugins`. After this release, no skill in `superjawn` requires the upstream `superpowers` plugin to be installed. The original "≥2 weeks of real use" readiness gate is waived ahead of ship; reinstall path for the upstream plugin is `/plugin install superpowers@claude-plugins-official`. Manifest: `requesting-code-review` drops `skill_md_parity` from `true` to `false` (the rewrite breaks byte-identity); `subagent-driven-development` adds a `supporting_file_overrides` entry for `code-quality-reviewer-prompt.md`. Three documentation example mentions of `superpowers:code-reviewer` in `using-superjawn/references/{codex,copilot}-tools.md` are intentionally preserved as references to upstream's canonical agent name.
+- **persistent-sessions guide expanded (#57)**: promotes the SSH path to first-class alongside Cockpit in the auto-attach step, marks the Cockpit `IdleTimeout` step as Cockpit-only with an anchor link, adds an "Installing tmux" table covering Debian/Ubuntu, Fedora/RHEL, Arch, openSUSE, Alpine, macOS, FreeBSD, and WSL2 (plus notes on Windows-as-server and macOS-as-server), and adds a "Connecting from different devices" section covering macOS, Windows, Linux, iOS/iPadOS, Android, ChromeOS, Cockpit, and mosh. Notes the Ctrl-prefix alternative for mobile keyboards and updates the CTA so it no longer claims the skill requires Cockpit.
+- **Marketplace landing page: superjawn card refreshed**. The featured-plugin card on `docs/index.html` previously read "v0.6.0 ships all 14 skills; v1.0.0 (disabling the upstream plugin) gates on 2 weeks of real use." Now reads as the v1.0.0 standalone description, matching `docs/superjawn/index.html` (which was updated in PR #58).
+
+### Fixed
+
+- **README skill-status table for `superjawn` (#58 fold-in)**: eight rows still read "Pending (Batch 3/4/5)" for skills that had already shipped, one category was wrong (`subagent-driven-development` listed as freshness check instead of consumer), and the phase-shape counts were off by one (1 freshness + 10 consumer, was written as 2 + 9). All corrected as part of the v1.0.0 cut.
+- **`superjawn:debugging` typo in top-level `README.md` plugin catalog (#58 round 1 Copilot)**: the row's "fires before brainstorming, debugging, and writing-skills" copy and the example invocation `superjawn:debugging` referenced a skill that does not exist; the actual skill is `systematic-debugging`. Updated both occurrences so the example invocation resolves to a real skill.
+
 ## [1.8.0] - 2026-05-07
 
 ### Added

--- a/docs/index.html
+++ b/docs/index.html
@@ -370,9 +370,9 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         </div>
                         <div class="relative z-10 p-8 md:p-12 flex flex-col md:flex-row items-start md:items-center gap-6 md:gap-12">
                             <div class="flex-1">
-                                <div class="inline-block px-3 py-1 bg-white/15 rounded-full text-[10px] font-bold tracking-[0.3em] uppercase text-white/90 mb-4">New in v0.6.0</div>
+                                <div class="inline-block px-3 py-1 bg-white/15 rounded-full text-[10px] font-bold tracking-[0.3em] uppercase text-white/90 mb-4">v1.0.0 &middot; standalone</div>
                                 <h2 class="font-display text-3xl md:text-4xl font-black text-white leading-tight mb-3">Skills that do their homework first.</h2>
-                                <p class="text-white/75 text-base md:text-lg max-w-xl">Superjawn is a research-augmented fork of <code class="bg-white/10 px-2 py-0.5 rounded text-white/90 text-sm">obra/superpowers</code>. A default-on research phase fires before brainstorming, debugging, and writing skills &mdash; pulling from the web, your codebase, and authoritative docs before any plan gets drafted. Skip it when you already know the answer; otherwise the homework happens automatically. All 14 skills ported.</p>
+                                <p class="text-white/75 text-base md:text-lg max-w-xl">Superjawn is a research-augmented fork of <code class="bg-white/10 px-2 py-0.5 rounded text-white/90 text-sm">obra/superpowers</code>. A default-on research phase fires before brainstorming, systematic-debugging, and writing-skills &mdash; pulling from the web, your codebase, and authoritative docs before any plan gets drafted. Skip it when you already know the answer; otherwise the homework happens automatically. All 14 skills ported, no upstream dependency.</p>
                             </div>
                             <div class="flex-shrink-0">
                                 <span class="inline-flex items-center gap-2 bg-white text-[#1e3a8a] font-bold text-sm px-6 py-3 rounded-lg group-hover:bg-white/90 transition-colors">Learn more <span class="group-hover:translate-x-1 transition-transform">&rarr;</span></span>
@@ -410,7 +410,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                             <span class="featured-badge" style="background: linear-gradient(135deg, #1e3a8a 0%, #1e40af 100%);">Research-augmented</span>
                         </div>
                         <h3 class="font-display text-lg font-bold mb-2 group-hover:text-[#1e3a8a] transition-colors">superjawn</h3>
-                        <p class="text-sm text-mist leading-relaxed">Research-augmented fork of obra/superpowers. Default-on research phase fires before brainstorming, debugging, and writing-skills. v0.6.0 ships all 14 skills; v1.0.0 (disabling the upstream plugin) gates on 2 weeks of real use.</p>
+                        <p class="text-sm text-mist leading-relaxed">Research-augmented fork of obra/superpowers. Default-on research phase fires before brainstorming, systematic-debugging, and writing-skills. v1.0.0 ships all 14 skills with no soft dependencies on the upstream <code>superpowers</code> plugin &mdash; standalone replacement.</p>
                         <div class="flex flex-wrap gap-2 mt-3">
                             <span class="text-[8px] bg-[#1e3a8a]/10 text-[#1e3a8a] px-2 py-1 rounded font-semibold">Research phase</span>
                             <span class="text-[8px] bg-[#1e3a8a]/10 text-[#1e3a8a] px-2 py-1 rounded font-semibold">Subagents</span>


### PR DESCRIPTION
## Summary

Cut a v1.9.0 release tagging the repo state after PRs #57 and #58 merged.

- **superjawn v1.0.0 standalone (#58)**: ports the four `superpowers:code-reviewer` agent dispatches to `pr-review-toolkit:code-reviewer`, drops the upstream `superpowers` plugin as a runtime dependency. Manifest `skill_md_parity` and `supporting_file_overrides` updated to reflect the rewrite.
- **persistent-sessions guide expansion (#57)**: SSH path promoted to first-class alongside Cockpit, "Installing tmux" table added (8 OS/distro rows), "Connecting from different devices" section added (8 client rows + Ctrl-prefix note for mobile keyboards).
- **Marketplace landing page refresh**: hero pill `New in v0.6.0` &rarr; `v1.0.0 &middot; standalone`. Hero copy and featured-plugin card both updated from `before brainstorming, debugging, and writing skills` (a non-existent skill) to `systematic-debugging` and `writing-skills` (the real names). Featured card description rewritten to match `docs/superjawn/index.html`'s v1.0.0 standalone framing.

## Files

- `CHANGELOG.md` &mdash; new `[1.9.0] - 2026-05-08` section with `Changed` and `Fixed` subsections
- `docs/index.html` &mdash; hero pill, hero paragraph, featured-plugin card description (3 string changes, 2 logical regions)

No skill files, no plugin manifests, no hooks, no scripts touched in this PR. The substantive work shipped in #57 and #58.

## Test plan

- [ ] `docs/index.html` renders correctly at `/` &mdash; hero pill shows `v1.0.0 &middot; standalone`, hero copy mentions `systematic-debugging` and `writing-skills`
- [ ] Featured-plugin card on `/` matches the v1.0.0 standalone copy on `/superjawn/`
- [ ] `CHANGELOG.md` `[1.9.0]` section is well-formed (Keep a Changelog conventions)
- [ ] `grep -nE "v0\.6|0\.6\.0|New in v|superpowers:code-reviewer" docs/index.html` returns no hits
- [ ] After merge: tag `v1.9.0` on master, `gh release create v1.9.0` with notes derived from the CHANGELOG section