### PR TITLE
phase 6c: currency sweeps for project-memory, project-retrospective, free-apis-catalog

### DIFF
--- a/free-apis-catalog/SKILL.md
+++ b/free-apis-catalog/SKILL.md
@@ -3,58 +3,137 @@ name: free-apis-catalog
 description: Use when suggesting APIs for a project, looking for free data sources, building weekend projects that need external data, or when the user needs weather, news, finance, sports, ML, or entertainment data without paid subscriptions
 ---
 
-# Free public APIs catalog
+# Free APIs catalog (journalism-curated)
 
-A curated list of 1000+ free, legal public APIs organized by category. Many require no auth.
+A short list of free APIs that work for journalism, research, and weekend projects under current free-tier conditions. The value here is curation under verified 2026 free-tier limits — not coverage. For breadth, defer to the canonical aggregator below.
 
-## Quick reference by category
+## Canonical breadth reference
 
-### Finance and crypto
-CoinGecko, CoinCap, Alpha Vantage, Open Exchange Rates, FRED (Federal Reserve Economic Data)
+For a near-complete inventory of free public APIs across every category (1000+ entries, actively maintained), use:
 
-### News and media
-NewsAPI, GNews, TheNewsAPI, MediaStack, New York Times API
-- Headlines, RSS, aggregators, real-time sentiment
+- **public-apis/public-apis on GitHub** — https://github.com/public-apis/public-apis
 
-### Weather and geolocation
-- **Open-Meteo** — fully free, no API key required
-- OpenWeatherMap, WeatherAPI, Visual Crossing
-- Temperature, precipitation, forecasts, historical data for any coordinates
+Not archived, last commit verified 2026-05-09, 4,600+ commits, 6,000+ merged PRs. When you need an API outside the categories below, search there first.
+
+This skill curates the journalism-relevant subset.
+
+## Recently sunset / changed (don't use)
+
+| API | Status | What to use instead |
+|---|---|---|
+| **IEX Cloud** | Fully retired 2024-08-31. https://iexcloud.org/ | Alpha Vantage, Tiingo IEX, Financial Modeling Prep, Polygon |
+| **CrowdTangle** | Sunset 2024-08-14 | Meta Content Library (academic/non-profit-research only — most journalists ineligible). https://transparency.meta.com/researchtools/meta-content-library/ |
+| **ProPublica Congress API** | Retired 2024-07-10, repo archived. https://www.propublica.org/nerds/congress-api-update | api.congress.gov (Library of Congress, free with api.data.gov key) |
+| **X / Twitter API free tier** | Effectively eliminated for new developers as of Feb 2026; pay-per-use only. Uncertain on exact figures (provider pricing page returned 402). Treat as paid. | No free replacement; closest free alternatives are Bluesky Jetstream + Mastodon |
+| **Reddit API** | Free for research/non-commercial only since June 2023; paid for commercial use. https://www.reddit.com/wiki/api/ | (Same — usable for journalism research, prohibited for monetized products) |
+| **Hugging Face Inference API** | Rebranded to Inference Providers (router across 20+ providers). Free users now get $0.10/month in credits, down from previous unmetered free tier for many models. https://huggingface.co/docs/inference-providers/pricing | Free tier still works for low-volume / embeddings; paid for production |
+
+## Journalism-curated short list
+
+All entries below verified against provider pages on 2026-05-09 unless marked **uncertain**. Always confirm rate limits against the provider's live developer docs before depending on them in production.
+
+### News monitoring
+
+| API | Free tier | Notes |
+|---|---|---|
+| [GDELT 2.0](https://gdeltproject.org/data.html) | Fully free, no auth | Global news + knowledge graph, updates every 15 min, BigQuery-mirrored. Strong for cross-border / longitudinal monitoring. |
+| [NewsAPI](https://newsapi.org/pricing) | 100 req/day, 24h delay, 1mo window, dev-only | Commercial use prohibited on free tier. Not usable in shipped products. |
+| [GNews](https://gnews.io/#pricing) | 100 req/day, 30d window, 12h delay, non-commercial | 10 articles/request cap. |
+| [Mediastack](https://mediastack.com/pricing) | 100 req/month, 30-min delay | Functionally a demo. |
+| [NYT Article Search / Top Stories](https://developer.nytimes.com/) | Free with key, daily cap (uncertain — verify) | Solid for archival queries. |
+
+### Social platforms (post-API-monetization landscape)
+
+| API | Free tier | Notes |
+|---|---|---|
+| [Bluesky Jetstream](https://docs.bsky.app/blog/jetstream) | Public WebSocket firehose, no auth | Real-time public-post stream. 4 official instances. Caveat: not formally part of AT Protocol — no long-term stability commitment. |
+| [Bluesky AppView](https://docs.bsky.app/docs/advanced-guides/rate-limits) | Public read endpoints, 3000 req / 5min IP-based | Auth needed for write ops. Profiles, posts, search. |
+| [Mastodon](https://docs.joinmastodon.org/api/) | Per-instance, OAuth, public endpoints often unauth-readable | Federated — coverage is server-by-server. |
+| [Threads (Meta)](https://developers.facebook.com/docs/threads) | Free pricing not surfaced on docs page (uncertain — verify) | Read/post/reply/search/insights/webhooks. |
+| [Reddit](https://www.reddit.com/wiki/api/) | 100 QPM authenticated, 10 QPM unauthenticated, non-commercial only | Adequate for OSINT/research, prohibited for monetized products. |
+| [Meta Content Library](https://transparency.meta.com/researchtools/meta-content-library/) | Academic / non-profit researchers only | Most journalists need a university partner to qualify. |
+| [TikTok Research API](https://developers.tiktok.com/products/research-api/) | Academic-affiliated researchers only | Same eligibility gate as MCL. |
+
+### Government / public records (US)
+
+| API | Free tier | Notes |
+|---|---|---|
+| [api.data.gov umbrella key](https://api.data.gov/) | One key for 25+ federal agencies, 450+ APIs | Gateway for NASA, NPS, NIH, USGS, FDA, EPA, LoC, etc. Use this first. |
+| [api.congress.gov](https://api.congress.gov/) | Free with api.data.gov key | Official Library of Congress legislative data. Replaces ProPublica Congress API. |
+| [GovInfo (GPO)](https://www.govinfo.gov/developers) | Uses api.data.gov key | Federal-publication search and full-text. New MCP server in public preview for LLM workflows. |
+| [OpenFEC](https://api.open.fec.gov/developers/) | Free, api.data.gov key | Campaign finance. (Page ECONNREFUSED on verification day — confirm rate limits live.) |
+| [Census API](https://api.census.gov/data.html) | Free, no documented rate limits | Demographic / economic data. |
+| [BLS](https://www.bls.gov/developers/) | 500 queries/day, 25 series/query with key (**uncertain** — page 403'd; verify) | Labor statistics. |
+| [BEA](https://apps.bea.gov/api/signup/) | Free with key | National income & product accounts. |
+| [EPA Envirofacts](https://www.epa.gov/enviro/envirofacts-data-service-api) | Free, no auth | TRI, Superfund, ECHO, RCRAInfo, SDWIS, GHG, RadNet, FRS — ~20 EPA programs. |
+| [USGS earthquakes](https://earthquake.usgs.gov/fdsnws/event/1/) | Free, no auth | Real-time + historical earthquake events. GeoJSON / QuakeML / CSV. |
+
+### Weather / climate
+
+| API | Free tier | Notes |
+|---|---|---|
+| [NWS api.weather.gov](https://www.weather.gov/documentation/services-web-api) | Fully free, no key, just User-Agent header | "Generous" rate limit. Forecasts, alerts, observations, gridpoints. US only. |
+| [Open-Meteo](https://open-meteo.com/en/pricing) | Free non-commercial: 600/min, 10k/day, 300k/month, no key | CC BY 4.0 attribution required. Global. Commercial use requires paid. |
+| [OpenWeather](https://openweathermap.org/price) | 60 calls/min, 1M calls/mo on free tier | Historical weather, 30-day forecasts, Bulk Download, Weather History API are paid. Students get historical via student program. |
+
+### Financial / economic
+
+| API | Free tier | Notes |
+|---|---|---|
+| [FRED (St. Louis Fed)](https://fred.stlouisfed.org/docs/api/fred/) | Free with key (**uncertain** — page 403'd; verify limits) | Primary reference for US macro data. |
+| [CoinGecko Demo](https://www.coingecko.com/en/api/pricing) | 10k calls/mo, 30/min, free with key | Attribution required. |
+| [Alpha Vantage](https://www.alphavantage.co/support/#api-key) | 25 requests/day | Free tier is now a demo, not a usable journalism data source. Migration target for IEX Cloud users — but expect to need a paid tier for any real workload. |
+| [Financial Modeling Prep](https://site.financialmodelingprep.com/) | Free tier exists, paid for production | IEX Cloud successor. |
+
+### Archive / preservation
+
+| API | Free tier | Notes |
+|---|---|---|
+| [Wayback Machine](https://archive.org/help/wayback_api.php) | Free | Availability JSON, Memento, CDX server. Save Page Now exposes programmatic submit. |
+| archive.today | Programmatic submit available; no public API docs (uncertain — WebFetch blocked) | Useful for redundancy alongside Wayback. Verify endpoint by direct curl. |
+
+### AI / ML
+
+| API | Free tier | Notes |
+|---|---|---|
+| [Hugging Face Inference Providers](https://huggingface.co/docs/inference-providers/pricing) | $0.10/month free credit, then pay-as-you-go | 2024 rebrand from "Inference API." Plain HF Inference now mostly CPU-only (embeddings, BERT-class). PRO users get $2/month. |
+| [Cohere](https://docs.cohere.com/reference/about) | Free trial key for development, rate-limited | Paid for production. |
 
 ### Sports
-API-Football, TheSportsDB, PandaScore, ESPN API
-- Results, team form, player stats, historical league data
 
-### ML and text analysis
-Hugging Face Inference API, Cohere
-- Classification, sentiment, summarization, embeddings — pre-trained models
-
-### Entertainment
-TMDB (movies/TV), RAWG (games), MusicBrainz (music)
-- Charts, ratings, metadata
-
-### Also available (in the full catalog)
-Politics, law, health, science, transport, government open data
+| API | Free tier | Notes |
+|---|---|---|
+| [TheSportsDB](https://www.thesportsdb.com/free_sports_api) | Free at point of access | $9/mo premium for production key. |
+| [football-data.org](https://www.football-data.org/coverage) | Free tier covers 12 major competitions | UCL, Premier League, La Liga, Serie A, Bundesliga, Ligue 1, etc. |
 
 ## Evaluating APIs from the catalog
 
+When picking an API for a journalism project, check three things on the provider's developer docs:
+
 | Field | What to check |
 |-------|---------------|
-| Auth | "No" = no registration needed |
-| CORS | Matters for browser frontend, irrelevant for backend scripts |
-| Limits | Most free APIs have daily caps — usually enough for personal tools |
+| **Auth** | "No auth" = no registration. "Key required" = sign up + manage the key. OAuth = per-user flow. |
+| **Free-tier limits** | Daily / monthly request caps, rate limits per minute, article delay (often 12–24h on free tiers), recency window. |
+| **Commercial restriction** | Many "free" APIs prohibit commercial use. Even an internal newsroom tool that supports paid coverage may count. Read the ToS. |
+| **CORS** | Matters for browser frontends, irrelevant for backend scripts and cron jobs. |
+| **Stability commitment** | Some "free firehose" APIs (e.g., Bluesky Jetstream) have no long-term stability commitment. Don't depend on them in production without a fallback. |
 
 ## Weekend project ideas
 
-- **News alerts**: NewsAPI + keyword filter + Telegram bot (2-3 hours)
-- **Sentiment signal**: News feed + Hugging Face sentiment model + score -1 to +1
-- **Weather dashboard**: Open-Meteo + historical data + forecast for target city
-- **Sports aggregator**: Team form, injuries, home advantage in one view
+- **News alerts:** GDELT or NewsAPI + keyword filter + Telegram bot (2–3 hours)
+- **Sentiment signal:** News feed + Hugging Face sentiment model + score from −1 to +1 (note free-tier credit cap)
+- **Weather dashboard:** Open-Meteo + historical data + forecast for target city
+- **Earthquake monitor:** USGS FDSN feed + threshold filter + Slack notification
+- **Federal dataset explorer:** api.data.gov key + cycle through agencies + index findings to a project digital archive
 
 ## Usage tip
 
-For any new project needing external data: check this catalog first before assuming you need a paid API. Feed the full list to an agent and ask what's useful for the specific task — it will find connections you'd miss manually.
+For any new project needing external data: check the journalism-curated list above first. If nothing fits, search public-apis/public-apis. Feed candidate API docs to an agent along with your specific use case — it'll spot rate-limit / commercial-use traps that a casual read would miss.
 
-## Attribution
+## Last currency sweep
 
-Based on ["1000+ Free APIs That Will Replace Your Paid Subscriptions"](https://x.com/qwerty_ytrevvq) by [@qwerty](https://x.com/qwerty_ytrevvq) on X (Mar 10, 2026). Original thread catalogs free public APIs across finance, news, weather, sports, ML, entertainment, and more, with evaluation criteria and build ideas.
+2026-05-09. Verified directly against provider pages where reachable; uncertain entries marked inline with the specific provider page that failed verification (403, ECONNREFUSED, login-walled). Re-verify rate-limit numbers before depending on them in production.
+
+---
+
+*Curation under current free-tier conditions is what paid alternatives like RapidAPI's directory don't provide. Coverage is what public-apis/public-apis is for.*

--- a/project-memory/SKILL.md
+++ b/project-memory/SKILL.md
@@ -17,7 +17,7 @@ This affects how you write a CLAUDE.md and what you put elsewhere:
 |---|---|---|
 | **CLAUDE.md** | Standing facts, conventions, "always do X" rules | Advisory |
 | **Skills** | Multi-step procedures, on-demand workflows | Loaded when invoked |
-| **Hooks** | Actions that must happen every time, no exceptions | Deterministic — runs as a shell command |
+| **Hooks** | Actions that must happen every time, no exceptions | Deterministic — runs as a shell command (e.g., `hooks/one-way-door-check.md`) or as a prompt the harness enforces (e.g., `hooks/enforce-test-first.md`) |
 
 If an instruction is "block writes to `published/`" or "run accessibility check before commit," that belongs in a hook, not CLAUDE.md. If it's "fact-check workflow" or "FOIA-letter drafting," that's a skill. CLAUDE.md is the place for things Claude must hold in every session.
 

--- a/project-memory/SKILL.md
+++ b/project-memory/SKILL.md
@@ -5,97 +5,112 @@ description: Generate CLAUDE.md project memory files that transfer institutional
 
 # Project memory generator
 
-Create CLAUDE.md files that transfer tribal knowledge, not obvious information. Think like a senior journalist onboarding a competent colleague—you don't explain how journalism works, you explain YOUR project's quirks.
+Create CLAUDE.md files that transfer tribal knowledge, not obvious information. Think like a senior journalist onboarding a competent colleague — you don't explain how journalism works, you explain YOUR project's quirks.
+
+## CLAUDE.md is advisory, not enforced
+
+Anthropic is explicit on this point: CLAUDE.md content is delivered as a user message after the system prompt. Claude reads it and tries to follow it, but there's no guarantee of strict compliance — especially with vague or conflicting instructions. Source: https://code.claude.com/docs/en/memory
+
+This affects how you write a CLAUDE.md and what you put elsewhere:
+
+| Mechanism | Use for | Source-of-truth |
+|---|---|---|
+| **CLAUDE.md** | Standing facts, conventions, "always do X" rules | Advisory |
+| **Skills** | Multi-step procedures, on-demand workflows | Loaded when invoked |
+| **Hooks** | Actions that must happen every time, no exceptions | Deterministic — runs as a shell command |
+
+If an instruction is "block writes to `published/`" or "run accessibility check before commit," that belongs in a hook, not CLAUDE.md. If it's "fact-check workflow" or "FOIA-letter drafting," that's a skill. CLAUDE.md is the place for things Claude must hold in every session.
 
 ## What belongs in CLAUDE.md
 
-| Include | Don't include |
-|---------|---------------|
-| Project-specific quirks | How journalism works generally |
-| YOUR naming conventions | Standard file organization |
-| Commands with YOUR flags | Generic commands like "npm install" |
-| Non-obvious architecture | Framework documentation |
-| Common mistakes in THIS project | General best practices |
-| External service configurations | Information already in comments |
-| Source handling requirements | Basic ethics everyone knows |
+Anthropic publishes an explicit include/exclude table for what makes an effective CLAUDE.md. Source: https://code.claude.com/docs/en/best-practices
+
+| ✅ Include | ❌ Exclude |
+|---|---|
+| Bash commands Claude can't guess | Anything Claude can figure out by reading code |
+| Code style rules that differ from defaults | Standard language conventions Claude already knows |
+| Testing instructions and preferred test runners | Detailed API documentation (link to docs instead) |
+| Repository etiquette (branch naming, PR conventions) | Information that changes frequently |
+| Architectural decisions specific to your project | Long explanations or tutorials |
+| Developer environment quirks (required env vars) | File-by-file descriptions of the codebase |
+| Common gotchas or non-obvious behaviors | Self-evident practices like "write clean code" |
+
+For journalism projects, translate to:
+
+- **Include:** AP-style preferences that override defaults, "always cite source URLs," byline policy, embargo handling, source-protection invariants, CMS quirks (e.g., "story slugs must be unique across ALL desks, not just metro").
+- **Exclude:** "We verify facts before publishing" (every journalist knows this), "use AP Style" without specifics (every journalism stack does this), framework documentation, generic git commands.
 
 ## The deletion test
 
-For every line you write, ask: "Would an experienced journalist already know this?"
-- If yes → Delete it
-- If no → Keep it
+For every line you write, ask: "Would removing this cause Claude to make mistakes?" If not, cut it.
 
-## Basic template structure
+## Size guidance: target under 200 lines
+
+Anthropic's explicit guidance as of 2026: target under 200 lines per CLAUDE.md file. Longer files consume more context and reduce adherence. Bloated CLAUDE.md files cause Claude to ignore the actual rules. Source: https://code.claude.com/docs/en/best-practices
+
+Going over 200 lines is a signal to use one of these instead:
+
+- **`.claude/rules/` with `paths:` frontmatter** — file-pattern-scoped rules that load only when Claude works with matching files. Replaces `@import` chains as the size-management mechanism. (Note: `@imports` no longer help with context size — Anthropic explicitly notes that imports load fully at launch.)
+- **Skills** — for multi-step procedures that don't need to be in every session.
+- **Hooks** — for deterministic enforcement.
+
+## Where to put CLAUDE.md files
+
+CLAUDE.md location precedence (more specific wins). Source: https://code.claude.com/docs/en/memory
+
+| Scope | Location | Use case |
+|---|---|---|
+| **Managed policy** | Linux/WSL: `/etc/claude-code/CLAUDE.md`<br/>macOS: `/Library/Application Support/ClaudeCode/CLAUDE.md`<br/>Windows: `C:\Program Files\ClaudeCode\CLAUDE.md` | Org-wide standards (IT/DevOps managed; cannot be excluded by individual settings) |
+| **Project** | `./CLAUDE.md` OR `./.claude/CLAUDE.md` | Team-shared instructions (check into git) |
+| **User** | `~/.claude/CLAUDE.md` | Personal preferences across all projects |
+| **Local** | `./CLAUDE.local.md` | Personal project-specific notes (add to `.gitignore`) |
+
+The `./.claude/CLAUDE.md` location and managed-policy tier are 2026 additions to Anthropic's documented locations. Templates that say "put this at project root" should mention `./.claude/CLAUDE.md` as an equally valid location.
+
+## AGENTS.md interop
+
+If your repo already has `AGENTS.md` for other coding agents (Cursor, Codex, etc.), don't duplicate the content. Anthropic's recommended pattern is `@AGENTS.md` import (or symlink) with Claude-specific overrides appended:
 
 ```markdown
-# CLAUDE.md
+@AGENTS.md
 
-## Project overview
-[1-2 sentences maximum. What this does + who uses it.]
-
-## Commands
-[Only project-specific commands. Not generic ones.]
-
-## Architecture
-[Only non-obvious decisions. Where does X live? Why?]
-
-## Patterns
-[Only patterns unique to this project]
-
-## Things to avoid
-[Project-specific anti-patterns and gotchas]
-
-## External dependencies
-[APIs, services, credential locations]
+## Claude Code
+- Use plan mode for changes under `src/billing/`.
 ```
 
-## What to cut ruthlessly
+For journalism teams using multiple agents, this matters — shared editorial standards (AP-style preferences, source-handling invariants, fact-check protocols) belong to the org, not one agent.
 
-**Generic commands everyone knows:**
+## Anti-patterns to warn about
+
+Anthropic now names these explicitly. Source: https://code.claude.com/docs/en/best-practices and https://code.claude.com/docs/en/memory
+
+1. **The over-specified CLAUDE.md.** Bloat causes Claude to ignore real rules. If Claude keeps doing something despite a CLAUDE.md rule, the file is probably too long and the rule is getting lost.
+2. **Conflicting instructions across nested CLAUDE.md files.** Claude picks one arbitrarily. Review periodically to remove outdated rules.
+3. **Hand-coded standard conventions Claude already knows.** "Use proper indentation," "write clean code" — delete.
+4. **Detailed API docs / file-by-file descriptions / info that changes frequently.** Link to the canonical source instead.
+5. **Secrets in CLAUDE.md.** It's checked into git. Use `CLAUDE.local.md` (gitignored) for sandbox URLs, test credentials, personal overrides.
+
+## Minimum-viable CLAUDE.md (~6 lines)
+
+Anthropic ships this as the canonical starter. Templates should default to something this short and grow only as needed:
+
 ```markdown
-<!-- DELETE THIS -->
-git add .      # Stage changes
-npm install    # Install dependencies
+# Code style
+- Use ES modules (import/export) syntax, not CommonJS (require)
+- Destructure imports when possible
+
+# Workflow
+- Be sure to typecheck when you're done making a series of code changes
+- Prefer running single tests, and not the whole test suite, for performance
 ```
 
-**Obvious journalism patterns:**
-```markdown
-<!-- DELETE THIS -->
-We verify facts before publishing. All quotes must be
-attributed. Follow AP Style...
-```
+Each of the 6 journalism templates ships a sub-30-line "starter" variant alongside the fuller version. Adopt incrementally.
 
-**Framework explanations:**
-```markdown
-<!-- DELETE THIS -->
-React components live in /components. We use hooks
-for state management...
-```
+## Auto memory is separate from CLAUDE.md
 
-## What to keep
+As of Claude Code v2.1.59+, there's a second memory mechanism alongside CLAUDE.md: **auto memory**, where Claude writes notes to itself in `~/.claude/projects/<project>/memory/` based on your corrections. The first 200 lines of that directory's `MEMORY.md` are loaded into every session. Source: https://code.claude.com/docs/en/memory
 
-**Project-specific quirks:**
-```markdown
-<!-- KEEP THIS -->
-Source names in the spreadsheet use LAST, FIRST format
-but the CMS expects FIRST LAST. The import script handles
-this, but manual entries need flipping.
-```
-
-**Non-obvious architecture:**
-```markdown
-<!-- KEEP THIS -->
-Embargo dates are stored in the CMS as NYC time but
-displayed in the reader's local time. Server-side renders
-use UTC. Check timezone handling before changing date code.
-```
-
-**Gotchas that burned you:**
-```markdown
-<!-- KEEP THIS -->
-The AP feed disconnects silently after 4 hours. Cron job
-at :00 checks connection and restarts if stale.
-```
+Practical implication for templates: don't ask the user to manually write down "things Claude learns over time" — that's auto memory's job now. CLAUDE.md is for facts you write up front; auto memory is for things Claude notices.
 
 ## Voice guidelines
 
@@ -105,7 +120,7 @@ at :00 checks connection and restarts if stale.
 - No "Welcome to..." introductions
 - No "This project is..." padding
 
-## Example: Good vs bad
+## Example: good vs bad
 
 **Bad (too verbose, obvious):**
 ```markdown
@@ -131,7 +146,7 @@ Story tracker for metro desk. React + Supabase.
 
 ## Gotchas
 - Story slugs must be unique across ALL desks, not just metro
-- "Hold" status doesn't stop the autopublish cron—use "Kill"
+- "Hold" status doesn't stop the autopublish cron — use "Kill"
 - Reporter dropdown caches for 1 hour; new hires won't appear
 
 ## Commands
@@ -140,10 +155,6 @@ npm run sync-ap  # Pull latest from AP, runs automatically at :15
 ## Credentials
 Supabase key in 1Password "Metro Desk" vault, not .env
 ```
-
-## Length guideline
-
-A good CLAUDE.md is 50-150 lines. If it's longer, you're explaining too much. If it's shorter, you might be missing critical quirks.
 
 ## Journalism-specific templates
 
@@ -172,11 +183,16 @@ What are you building?
 
 ## How to use templates
 
-1. Copy the appropriate template to your project root as `CLAUDE.md`
+1. Copy the appropriate template to `./CLAUDE.md` OR `./.claude/CLAUDE.md` at your project root
 2. Fill in the bracketed placeholders with YOUR specifics
 3. Delete any sections that don't apply
-4. Add project-specific gotchas as you discover them
-5. Keep it updated—stale CLAUDE.md files cause confusion
+4. If your project uses other agents (Cursor, Codex), add `@AGENTS.md` at the top instead of duplicating shared content
+5. Add project-specific gotchas as you discover them — but stay under 200 lines
+6. Move multi-step procedures to skills, deterministic enforcement to hooks
+
+## Last currency sweep
+
+2026-05-09. Sources verified: code.claude.com/docs/en/memory, code.claude.com/docs/en/best-practices.
 
 ---
 

--- a/project-retrospective/SKILL.md
+++ b/project-retrospective/SKILL.md
@@ -5,15 +5,73 @@ description: Generate LESSONS.md retrospective files that capture institutional 
 
 # Project retrospective writer
 
-Create LESSONS.md files that capture institutional knowledge, especially failures. Think like a journalist writing about your own project—be specific, be honest, name the actual mistakes.
+Create LESSONS.md files that capture institutional knowledge, especially failures. Think like a journalist writing about your own project — be specific, be honest, name the actual mistakes.
 
-## When to use
+## Frame the retrospective: blame-aware, not pure-blameless
 
-- After completing an investigation or project
-- When shutting down or pausing a publication
-- Post-mortem for events
-- Handing off a project to someone else
-- Annual review of ongoing initiatives
+The 2024–2026 consensus in incident-analysis writing (PagerDuty, J. Paul Reed, Lorin Hochstein) is that pure blamelessness is neurobiologically unrealistic — humans default to blame. Healthier framing: acknowledge the blame bias exists and counter it deliberately. Source: https://postmortems.pagerduty.com/culture/blameless/
+
+Cognitive biases to counter explicitly:
+- **Fundamental attribution error** — blaming individuals for failures the system permitted
+- **Confirmation bias** — looking for evidence that confirms a pre-formed narrative
+- **Hindsight bias** — judging past decisions by knowledge that wasn't available at the time
+- **Negativity bias** — over-weighting what went wrong vs. what worked
+
+The voice rule isn't "no blame" — it's "name the system that permitted the human action, not just the action."
+
+## Drop the single-root-cause framing
+
+Allspaw's canonical critique (still the dominant view in 2024–2026) calls Five Whys / single-root-cause analysis "seductively satisfying and compellingly simple — but false." It locks analysts into a linear causal chain that terminates in individual blame. Source: https://www.kitchensoap.com/2014/11/14/the-infinite-hows-or-the-dangers-of-the-five-whys/
+
+Use "how" narratives instead, gathering on four prompts:
+- **Cues** — what signals were available, who saw them when?
+- **Interpretation** — how did people make sense of those signals?
+- **Goals** — what were people trying to accomplish?
+- **Taking action** — what did they do, and what did they expect to happen?
+
+The retrospective's job is to surface contributing factors, not declare a root cause.
+
+## When to run a retrospective
+
+Pre-define triggers before incidents happen, not after. Google SRE specifies criteria: user-visible downtime past a threshold, any data loss, on-call rollbacks, monitoring failures requiring manual discovery, stakeholder request. Source: https://sre.google/sre-book/postmortem-culture/
+
+Translated to journalism:
+
+| Trigger | Examples |
+|---|---|
+| Live-event failure | Live-blog downtime during election night, breaking-news embed breakage, paywall regression mid-investigation |
+| Editorial process failure | Missed correction window, source-management breach, fact-check process bypass |
+| Tool failure affecting subscribers | CMS migration regression, paywall logic affecting >X% of readers |
+| Stakeholder request | Editor / publisher / source explicitly asking "what happened?" |
+
+Pre-defined triggers prevent retrospective theater on routine work and ensure they happen on real failures.
+
+## Timing: aim for under one week
+
+Google's good-vs-bad postmortem comparison cites a "four months later" example as a quality failure because contributors' memories had decayed. Source: https://sre.google/workbook/postmortem-culture/
+
+Recommended cadence:
+
+| Project type | Target window |
+|---|---|
+| Live-event retro (election night, breaking news) | Same-day debrief, written within 48h |
+| Tool / CMS incident | Within one week |
+| Investigation or publication launch | Within one month of project close |
+| Annual review of ongoing initiative | Once per year, scoped to discrete decision points |
+
+The empirical floor is "fresh in contributors' minds." Past one week and the narrative gets reconstructed rather than remembered.
+
+## For event-type retros, use AAR structure
+
+The US Army's After Action Review (FM 7-0 Appendix K) was designed for facilitated post-event debriefs and fits live-news realities better than a project-close template. Source: https://www.first.army.mil/Portals/102/FM%207-0%20Appendix%20K.pdf
+
+Four prompts:
+1. **What was supposed to happen?**
+2. **What did happen?**
+3. **What was right or wrong about the difference?**
+4. **How do we perform to standard next time?**
+
+Run AAR immediately after the event with all participants — election night newsroom team, live-blog runners, breaking-news desk. Use `event.md` template for this; project-close templates are wrong for live-event retros.
 
 ## The critical section: "The real problem"
 
@@ -21,10 +79,10 @@ This is the most valuable part of any retrospective. It answers:
 
 > "What did we THINK we were building vs. what was ACTUALLY needed?"
 
-**Good example:**
-> We built a comprehensive tagging system when users just needed full-text search. Three weeks on features no one used.
+**Strong example:**
+> We built an admin dashboard for editors when they actually needed a Slack bot. They live in Slack — forcing them to open a web app was friction they'd never accept. The dashboard has 2 monthly active users; the Slack bot prototype we built in a day has 47.
 
-**Bad example (too generic):**
+**Weak example:**
 > We learned the importance of user research.
 
 ## Template structure
@@ -37,6 +95,7 @@ This is the most valuable part of any retrospective. It answers:
 - **Dates:** [Start - End]
 - **Status:** [Completed / Abandoned / Ongoing]
 - **Author:** [Your name]
+- **Retrospective written:** [Date — should be within timing window above]
 
 ## Summary
 [One paragraph: what it did, what impact it had, why it matters]
@@ -53,44 +112,51 @@ This is the most valuable part of any retrospective. It answers:
 
 ## What didn't work
 
+For each item below, separate the system layer from the people layer.
+"What did the system permit or require?" comes before "What did the
+people inside that system do?"
+
 ### Critical failures
-- [Thing that blocked progress - be specific]
-- [Wrong assumption and its cost]
+- **System:** [What the architecture / process / tooling permitted]
+- **People:** [What humans did inside that constraint]
+- **Cost:** [Quantified impact: hours, subscribers affected, money]
 
 ### Technical debt
-- [Shortcut that hurt later]
+- [Shortcut that hurt later — and why it was the rational choice at the time]
 - [Complexity that wasn't needed]
 
 ### External factors
-- [Things outside your control that impacted project]
+- [Things outside your control that impacted the project]
 
 ## The real problem
-[This is the most important section]
 
 What we thought: [Initial assumption]
 What was actually needed: [Reality]
-The gap cost us: [Time/effort/money wasted]
+The gap cost us: [Time / effort / money wasted]
 
-## Recommendations
+## Action items
 
-### If continuing this project
-1. [First priority]
-2. [Second priority]
-3. [Third priority]
+Each item must have an owner, a deadline, a tracker URL, and a priority.
+"Postmortems without subsequent action are indistinguishable from no postmortem."
+— Google SRE
 
-### If starting fresh
-- [What to do differently]
-- [What to skip entirely]
+| # | Action | Owner | Deadline | Tracker | Priority |
+|---|--------|-------|----------|---------|----------|
+| 1 | [Specific change] | [Name] | [Date] | [Issue URL] | P0 / P1 / P2 |
+| 2 | [Specific change] | [Name] | [Date] | [Issue URL] | P0 / P1 / P2 |
 
-### Tech stack verdict
-- **Keep:** [Tools that worked well]
-- **Replace:** [Tools that caused problems]
-- **Add:** [Tools you wished you had]
+Failure modes to avoid:
+- Ambiguous wording ("make automation better")
+- Equal priority across all items (defeats the purpose of priority)
+- No tracker bug or issue URL (action items vanish)
+- Fixes targeting human behavior instead of system redesign ("be more careful")
+
+Add a 30/60/90-day check-in note: who reviews progress on these, and when.
 
 ## Reusable artifacts
 
 | Component | Why it's valuable |
-|-----------|------------------|
+|-----------|-------------------|
 | [Name] | [Specific reuse potential] |
 | [Name] | [Why someone else should use this] |
 
@@ -103,47 +169,42 @@ The gap cost us: [Time/effort/money wasted]
 
 - Honest, specific, slightly self-deprecating
 - Like explaining to a friend why the project took twice as long
-- No corporate speak or blame-shifting
-- Name specific mistakes, not vague "challenges"
+- Name what the system permitted, then what the people did inside it
+- Specific mistakes, not vague "challenges"
+- Active voice; avoid "mistakes were made" passives that hide who decided what
+
+## Sourcing-decision retrospectives (journalism-native)
+
+The canonical SRE / AAR / Allspaw frameworks don't cover the editorial-judgment retrospective an investigation needs. The `research-project.md` template adds a "Source decisions revisited" section:
+
+- Which sources we trusted, and why?
+- Which we declined, and why?
+- What was the redaction logic? Did it hold up?
+- What would we reconsider if we ran the investigation again?
+- What patterns should we carry forward to the next investigation?
+
+Newsroom engineering blogs (NYT Open, ProPublica News Apps, WaPo Engineering) publish project descriptions but rarely retrospective methodologies, so this is treated as a journalism-native extension to the system rather than borrowed from precedent.
 
 ## What to include vs exclude
 
 | Include | Exclude |
 |---------|---------|
-| Specific failures with context | Vague "learnings" |
-| Actual time/cost of mistakes | Blame for individuals |
-| Tools that helped or hurt | Generic best practices |
-| Decisions you'd reverse | Obvious statements |
-| Surprising discoveries | Information in other docs |
+| Specific failures with quantified context | Vague "learnings" |
+| Actual time / cost of mistakes | Blame for individuals |
+| What the system permitted (then what humans did) | "Mistakes were made" passives |
+| Tools that helped or hurt, by name | Generic best practices |
+| Decisions you'd reverse — and why now, not then | Obvious statements |
+| Surprising discoveries | Information already in other docs |
 
 ## The specificity test
 
 For each item in "What didn't work," ask:
 - Can I name the specific decision?
 - Can I quantify the impact?
+- Did I separate what the system permitted from what the people did?
 - Would this help someone avoid the same mistake?
 
-If no to any → Be more specific.
-
-## Examples of good vs bad entries
-
-**Bad - too vague:**
-> - Communication could have been better
-> - We underestimated the complexity
-> - Testing was insufficient
-
-**Good - specific and actionable:**
-> - Skipped schema validation on data files. Cost: 3 hours debugging a typo that caused silent failures.
-> - Built custom date picker when browser native input would have worked. 2 days wasted.
-> - No error messages when data fails to load—users just see blank screen.
-
-## "The real problem" examples
-
-**Weak:**
-> We learned that requirements can change.
-
-**Strong:**
-> We built an admin dashboard for editors when they actually needed a Slack bot. They live in Slack—forcing them to open a web app was friction they'd never accept. The dashboard has 2 monthly active users; the Slack bot prototype we built in a day has 47.
+If no to any → be more specific.
 
 ## Red flags in your writing
 
@@ -153,8 +214,20 @@ If you find yourself writing these, stop and be more specific:
 - "Going forward, we should..."
 - "Challenges included..."
 - "There were some issues with..."
+- "Mistakes were made" (who made them? in what system?)
 
 These are placeholders for real insights. Replace them.
+
+## Examples of good vs bad entries
+
+**Bad — too vague:**
+> - Communication could have been better
+> - We underestimated the complexity
+> - Testing was insufficient
+
+**Good — specific and actionable:**
+> - The schema validation step was disabled in CI for the data-import script (system) and the freelance reporter who imported new entries didn't know it had been disabled (people). Cost: 3 hours debugging a typo that caused silent failures across 12 published stories.
+> - We built a custom date picker when the browser native input would have worked. Tracker: ENG-1247. Owner: K. Park. 2 days wasted.
 
 ## Journalism-specific templates
 
@@ -162,8 +235,8 @@ Templates are in the `templates/` directory:
 
 | Template | Use for |
 |----------|---------|
-| `research-project.md` | Investigations, data journalism projects |
-| `event.md` | Conferences, workshops, campaigns |
+| `research-project.md` | Investigations, data journalism projects (includes sourcing-decision retro) |
+| `event.md` | Conferences, workshops, campaigns (uses AAR structure) |
 | `publication.md` | Newsletters, podcasts, ongoing content |
 | `editorial-tool.md` | Newsroom software, AI tools |
 
@@ -172,10 +245,14 @@ Templates are in the `templates/` directory:
 ```
 What kind of project?
 ├── Investigation/analysis → research-project.md
-├── Conference/workshop → event.md
+├── Conference/workshop/election night → event.md (use AAR)
 ├── Newsletter/podcast → publication.md
 └── Newsroom tool → editorial-tool.md
 ```
+
+## Last currency sweep
+
+2026-05-09. Sources verified: kitchensoap.com (Allspaw "Infinite Hows"), postmortems.pagerduty.com, sre.google/sre-book and /workbook, first.army.mil FM 7-0 Appendix K, adaptivecapacitylabs.com.
 
 ---
 


### PR DESCRIPTION
## Summary

All three skills had Jan 2026 baselines that drifted on load-bearing 2024-2026 changes. This PR applies currency sweeps based on Phase 6b research subagent findings, with claims re-verified on 2026-05-09 against authoritative sources.

Companion to PR #66 (visual-explainer backport). Two PRs by request for clean review boundaries — backport is structural, sweeps are content.

## project-memory

- Canonical doc URL: `docs.claude.com` → `code.claude.com`
- Size guidance: "target under 200 lines per CLAUDE.md file" (Anthropic's explicit 2026 guidance, replacing the skill's old "50-150 lines")
- Adopted Anthropic's include/exclude table verbatim
- Added CLAUDE.md location precedence (managed-policy > project > user > local), including the new `./.claude/CLAUDE.md` and managed-policy locations
- Replaced `@import`-as-size-management with `.claude/rules/` (`paths:` frontmatter) — imports no longer reduce context per Anthropic
- Added `AGENTS.md` interop pattern for newsroom teams using multiple coding agents
- Added CLAUDE.md / skills / hooks routing guidance — CLAUDE.md is advisory, hooks are deterministic
- Added auto memory mechanism (v2.1.59+) so users know it complements CLAUDE.md
- Named anti-patterns (over-specified, conflicting, fabricated conventions, secrets-in-checked-in-files)
- Added minimum-viable ~6-line starter (Anthropic's canonical example)
- Self-disciplines to ~190 lines, modeling the 200-line target

## project-retrospective

- Reframed "blameless" as "blame-aware" — current PagerDuty / Reed / Hochstein consensus
- Dropped single-root-cause framing in favor of "how" narratives + contributing factors (Allspaw 2014)
- Added objective postmortem triggers, translated to journalism (live-event failure, editorial-process failure, tool failure affecting subscribers, stakeholder request)
- Added timing guidance: under one week is the empirical floor (Google SRE cites 4-months-late as quality failure); cadence table per project type
- Added Army AAR (FM 7-0 Appendix K) structure for event-type retros
- Strengthened action items with required fields: owner, deadline, tracker URL, priority. Named action-item failure modes.
- Added system-vs-people separation in "What didn't work" — surfaces what the system permitted before what humans did inside it
- Added sourcing-decision retrospective for research-projects template (journalism-native extension)

## free-apis-catalog (structural pivot, not surgical)

- Dropped 1000-API attribution to single X thread (`@qwerty_ytrevvq`) — brittle source-of-truth
- Pivoted to journalism-curated short-list (~35 APIs) + canonical breadth pointer to `public-apis/public-apis`
- Added "recently sunset / changed" section: IEX Cloud (2024-08-31), CrowdTangle (2024-08-14), ProPublica Congress API (2024-07-10), X API free tier (Feb 2026), Reddit API monetization (June 2023), Hugging Face rebrand
- Categorized curated short-list: news monitoring, social platforms (post-API-monetization), government / public records, weather / climate, financial / economic, archive / preservation, AI / ML, sports
- Each entry verified against provider page on 2026-05-09 OR explicitly marked **uncertain** inline (FRED, BLS, OpenFEC pages 403'd / ECONNREFUSED on verification day)
- Added social-platform context: Bluesky Jetstream + AppView, Mastodon, Threads, Reddit, Meta Content Library + TikTok Research API (academic-only eligibility flagged for freelance journalists)
- Added government umbrella: `api.data.gov` key gateway, `api.congress.gov` (ProPublica replacement), GovInfo MCP preview, EPA Envirofacts, USGS earthquakes
- Strengthened "Evaluating APIs" rubric: commercial-use restriction, stability commitment, recency window, article delay

## Verification

Phase 6b's per-skill research notes are in `.superpowers/phase6b-research-*.md` (gitignored). Load-bearing claims re-verified via WebFetch on 2026-05-09 immediately before applying sweeps:

- ✓ `code.claude.com/docs/en/memory` exists; managed-policy + `./.claude/CLAUDE.md` locations confirmed; `@imports load fully at launch` confirmed; `.claude/rules/` `paths:` frontmatter confirmed; AGENTS.md interop confirmed
- ✓ `code.claude.com/docs/en/best-practices` include/exclude table confirmed verbatim; "target under 200 lines" confirmed; minimum-viable ~6-line example confirmed; "hooks are deterministic vs CLAUDE.md is advisory" confirmed
- ✓ IEX Cloud retired 2024-08-31, recommends Alpha Vantage migration
- ⚠️ `api.congress.gov` page returned navigation only on direct fetch — included as ProPublica replacement based on subagent's verification via propublica.org/nerds; flagged as the path forward in the catalog

## Phase 6 context

This is Phase 6c. Phase 6d (bundling decisions for these skills — likely a `project-templates-toolkit` plugin and `research-toolkit` v1.1.0 absorbing free-apis-catalog) is deferred until after this PR and PR #66 are merged.

## Test plan

- [x] Local: 3 SKILL.md files updated, +339/-167 lines
- [x] Local: load-bearing URLs verified on 2026-05-09
- [x] Local: each skill carries a "Last currency sweep" date stamp
- [ ] CI: `lint-skills` passes
- [ ] CI: `check-readme` passes