### PR TITLE
docs: sweep landing page drift after Phase 6 bundling (closes #70)

### DIFF
--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="About Joe Amditis, associate director of operations at the Center for Cooperative Media (Montclair State University), and the maintainer of Claude skills for journalism — modular instruction sets for journalism, research, and media production workflows.">
     <title>About - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -92,7 +93,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="About - Claude skills for journalism">
-    <meta property="og:description" content="A Claude Code skill for about">
+    <meta property="og:description" content="About Joe Amditis, associate director of operations at the Center for Cooperative Media (Montclair State University), and the maintainer of Claude skills for journalism — modular instruction sets for journalism, research, and media production workflows.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/about/">
     <meta property="og:image" content="https://skills.amditis.tech/about/og-image.png">
@@ -102,7 +103,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="About - Claude skills for journalism">
-    <meta name="twitter:description" content="A Claude Code skill for about">
+    <meta name="twitter:description" content="About Joe Amditis, associate director of operations at the Center for Cooperative Media (Montclair State University), and the maintainer of Claude skills for journalism — modular instruction sets for journalism, research, and media production workflows.">
     <meta name="twitter:image" content="https://skills.amditis.tech/about/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->

--- a/docs/academic-writing/index.html
+++ b/docs/academic-writing/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Academic writing, research methodology, and scholarly communication workflows. Use when writing papers, literature reviews, grant proposals, conducting research, managing citations, preparing for peer review, choosing OA routes under Plan S / 2026 OSTP Nelson Memo, posting preprints, working with persistent identifiers (ORCID, DOI, ROR), assigning CRediT contributor roles, preregistering analyses on OSF / AsPredicted, or disclosing LLM use to journals and funders. Essential for researchers, graduate students, and academics across disciplines.">
     <title>Academic writing - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Academic writing - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Academic writing, research methodology, and scholarly communication workflows. Use when writing papers, literature reviews, grant proposals, conducting research, managing citations, preparing for peer review, choosing OA routes under Plan S / 2026 OSTP Nelson Memo, posting preprints, working with persistent identifiers (ORCID, DOI, ROR), assigning CRediT contributor roles, preregistering analyses on OSF / AsPredicted, or disclosing LLM use to journals and funders. Essential for researchers, graduate students, and academics across disciplines.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/academic-writing/">
     <meta property="og:image" content="https://skills.amditis.tech/academic-writing/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Academic writing - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Academic writing, research methodology, and scholarly communication workflows. Use when writing papers, literature reviews, grant proposals, conducting research, managing citations, preparing for peer review, choosing OA routes under Plan S / 2026 OSTP Nelson Memo, posting preprints, working with persistent identifiers (ORCID, DOI, ROR), assigning CRediT contributor roles, preregistering analyses on OSF / AsPredicted, or disclosing LLM use to journals and funders. Essential for researchers, graduate students, and academics across disciplines.">
     <meta name="twitter:image" content="https://skills.amditis.tech/academic-writing/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -336,14 +337,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/academic-writing ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the research-toolkit plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install research-toolkit@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/research-toolkit/skills/academic-writing ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/academic-writing" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/research-toolkit/skills/academic-writing" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -364,7 +367,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     Research design, paper structure, peer review, and grant writing in one skill.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/academic-writing" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/research-toolkit/skills/academic-writing" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/accessibility-compliance/index.html
+++ b/docs/accessibility-compliance/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Web accessibility patterns for news sites, journalism tools, and academic platforms. Use when building accessible interfaces, auditing existing sites for WCAG compliance, writing alt text for news images, creating accessible data visualizations, or ensuring content reaches all readers including those using assistive technologies. Essential for newsroom developers and anyone publishing web content.">
     <title>Accessibility compliance - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -119,7 +120,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Accessibility compliance - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Web accessibility patterns for news sites, journalism tools, and academic platforms. Use when building accessible interfaces, auditing existing sites for WCAG compliance, writing alt text for news images, creating accessible data visualizations, or ensuring content reaches all readers including those using assistive technologies. Essential for newsroom developers and anyone publishing web content.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/accessibility-compliance/">
     <meta property="og:image" content="https://skills.amditis.tech/accessibility-compliance/og-image.png">
@@ -129,7 +130,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Accessibility compliance - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Web accessibility patterns for news sites, journalism tools, and academic platforms. Use when building accessible interfaces, auditing existing sites for WCAG compliance, writing alt text for news images, creating accessible data visualizations, or ensuring content reaches all readers including those using assistive technologies. Essential for newsroom developers and anyone publishing web content.">
     <meta name="twitter:image" content="https://skills.amditis.tech/accessibility-compliance/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -617,14 +618,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-20">
             <h2 class="font-display text-2xl font-semibold mb-6">Installation</h2>
             <div class="bg-ink rounded-2xl p-6 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/accessibility-compliance ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the dev-toolkit plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install dev-toolkit@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/dev-toolkit/skills/accessibility-compliance ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70">
                 Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/accessibility-compliance" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/accessibility-compliance" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -635,7 +638,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-8 max-w-xl mx-auto">
                     Ensure your journalism reaches all readers, including those using assistive technologies.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/accessibility-compliance" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-6 py-3 rounded-full font-semibold hover:bg-white/95 transition-colors shadow-lg" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/accessibility-compliance" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-6 py-3 rounded-full font-semibold hover:bg-white/95 transition-colors shadow-lg" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/ai-writing-detox/index.html
+++ b/docs/ai-writing-detox/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Eliminate AI-generated writing patterns that erode reader trust. Activate when writing articles, documentation, press releases, or any content where AI patterns would undermine credibility. For journalists using AI assistance who need human-sounding output.">
     <title>AI writing detox - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -127,7 +128,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="AI writing detox - Claude skills for journalism">
-    <meta property="og:description" content="If readers notice the writing style, it's distracting from the content. AI patterns are noticeable—they break trust.">
+    <meta property="og:description" content="Eliminate AI-generated writing patterns that erode reader trust. Activate when writing articles, documentation, press releases, or any content where AI patterns would undermine credibility. For journalists using AI assistance who need human-sounding output.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/ai-writing-detox/">
     <meta property="og:image" content="https://skills.amditis.tech/ai-writing-detox/og-image.png">
@@ -137,7 +138,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="AI writing detox - Claude skills for journalism">
-    <meta name="twitter:description" content="If readers notice the writing style, it's distracting from the content. AI patterns are noticeable—they break trust.">
+    <meta name="twitter:description" content="Eliminate AI-generated writing patterns that erode reader trust. Activate when writing articles, documentation, press releases, or any content where AI patterns would undermine credibility. For journalists using AI assistance who need human-sounding output.">
     <meta name="twitter:image" content="https://skills.amditis.tech/ai-writing-detox/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -532,14 +533,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-20">
             <h2 class="font-display text-2xl font-semibold mb-6">Installation</h2>
             <div class="bg-ink rounded-2xl p-6 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/ai-writing-detox ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the journalism-core plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install journalism-core@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/journalism-core/skills/ai-writing-detox ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70">
                 Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/ai-writing-detox" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/ai-writing-detox" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -550,7 +553,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-8 max-w-xl mx-auto">
                     If readers think "AI wrote this," you've already lost their trust.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/ai-writing-detox" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-6 py-3 rounded-full font-semibold hover:bg-white/95 transition-colors shadow-lg" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/ai-writing-detox" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-6 py-3 rounded-full font-semibold hover:bg-white/95 transition-colors shadow-lg" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/api-hardening/index.html
+++ b/docs/api-hardening/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="API security hardening patterns. Use when implementing rate limiting, input validation, CORS configuration, API key management, request throttling, or protecting endpoints from abuse. Covers defense-in-depth strategies for REST APIs with practical implementations for Express, FastAPI, and serverless, oriented around the OWASP API Security Top 10:2023.">
     <title>API hardening - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="API hardening - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="API security hardening patterns. Use when implementing rate limiting, input validation, CORS configuration, API key management, request throttling, or protecting endpoints from abuse. Covers defense-in-depth strategies for REST APIs with practical implementations for Express, FastAPI, and serverless, oriented around the OWASP API Security Top 10:2023.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/api-hardening/">
     <meta property="og:image" content="https://skills.amditis.tech/api-hardening/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="API hardening - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="API security hardening patterns. Use when implementing rate limiting, input validation, CORS configuration, API key management, request throttling, or protecting endpoints from abuse. Covers defense-in-depth strategies for REST APIs with practical implementations for Express, FastAPI, and serverless, oriented around the OWASP API Security Top 10:2023.">
     <meta name="twitter:image" content="https://skills.amditis.tech/api-hardening/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -178,7 +179,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">API hardening</h1>
             <p class="text-xl text-white/90 max-w-2xl">
-                Defense-in-depth patterns for protecting APIs from abuse, injection attacks, and data leakage.
+                Defense-in-depth patterns for protecting APIs from abuse, injection attacks, and data leakage. Oriented around the OWASP API Security Top 10:2023, with practical implementations for Express, FastAPI, and serverless.
             </p>
         </div>
     </header>
@@ -352,14 +353,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/api-hardening ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the security-toolkit plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install security-toolkit@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/security-toolkit/skills/api-hardening ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/api-hardening" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/security-toolkit/skills/api-hardening" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -380,7 +383,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     Rate limiting, input validation, CORS, and API key management patterns for Express.js and FastAPI.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/api-hardening" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/security-toolkit/skills/api-hardening" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/content-access/index.html
+++ b/docs/content-access/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Legal methods for accessing paywalled and geo-blocked content. Use when researching behind paywalls, accessing academic papers, bypassing geographic restrictions, or finding open access alternatives. Covers Unpaywall, library databases, VPNs, and ethical access strategies for journalists and researchers.">
     <title>Content access - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Content access - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Legal methods for accessing paywalled and geo-blocked content. Use when researching behind paywalls, accessing academic papers, bypassing geographic restrictions, or finding open access alternatives. Covers Unpaywall, library databases, VPNs, and ethical access strategies for journalists and researchers.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/content-access/">
     <meta property="og:image" content="https://skills.amditis.tech/content-access/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Content access - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Legal methods for accessing paywalled and geo-blocked content. Use when researching behind paywalls, accessing academic papers, bypassing geographic restrictions, or finding open access alternatives. Covers Unpaywall, library databases, VPNs, and ethical access strategies for journalists and researchers.">
     <meta name="twitter:image" content="https://skills.amditis.tech/content-access/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -337,14 +338,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/content-access ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the research-toolkit plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install research-toolkit@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/research-toolkit/skills/content-access ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/content-access" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/research-toolkit/skills/content-access" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -365,7 +368,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     Open access tools, library databases, and legal strategies for journalists and researchers.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/content-access" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/research-toolkit/skills/content-access" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/crisis-communications/index.html
+++ b/docs/crisis-communications/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Crisis communication and rapid response workflows for journalists and communications professionals. Use when covering breaking news events, managing organizational communications during crises, coordinating rapid fact-checking efforts, or developing crisis response plans. Essential for newsrooms, PR teams, and anyone who needs to communicate accurately under time pressure.">
     <title>Crisis communications - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Crisis communications - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Crisis communication and rapid response workflows for journalists and communications professionals. Use when covering breaking news events, managing organizational communications during crises, coordinating rapid fact-checking efforts, or developing crisis response plans. Essential for newsrooms, PR teams, and anyone who needs to communicate accurately under time pressure.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/crisis-communications/">
     <meta property="og:image" content="https://skills.amditis.tech/crisis-communications/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Crisis communications - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Crisis communication and rapid response workflows for journalists and communications professionals. Use when covering breaking news events, managing organizational communications during crises, coordinating rapid fact-checking efforts, or developing crisis response plans. Essential for newsrooms, PR teams, and anyone who needs to communicate accurately under time pressure.">
     <meta name="twitter:image" content="https://skills.amditis.tech/crisis-communications/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -376,14 +377,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/crisis-communications ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the journalism-core plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install journalism-core@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/journalism-core/skills/crisis-communications ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/crisis-communications" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/crisis-communications" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -404,7 +407,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     Breaking news protocols, verification checklists, and communication templates for crisis situations.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/crisis-communications" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/crisis-communications" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/data-journalism/index.html
+++ b/docs/data-journalism/index.html
@@ -139,7 +139,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <nav aria-label="Primary" class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-ink/5">
         <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
             <a href="../" class="text-sm font-medium text-mist hover:text-ink transition-colors">← Back to all skills</a>
-            <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/data-journalism" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">View on GitHub →</a>
+            <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/data-journalism" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">View on GitHub →</a>
         </div>
     </nav>
 
@@ -347,17 +347,20 @@ print(f"${salary_2010:,} in 2010 = ${salary_2024_dollars:,.0f} in 2024")
                     <div class="bg-white/5 p-6 rounded-xl">
                         <h3 class="font-semibold mb-3 flex items-center gap-2">
                             <span class="w-6 h-6 bg-accent rounded-full flex items-center justify-center text-xs">1</span>
-                            Clone the repository
+                            Recommended: install the journalism-core plugin
                         </h3>
-                        <pre tabindex="0"><code>git clone https://github.com/jamditis/claude-skills-journalism.git</code></pre>
+                        <pre tabindex="0"><code>/plugin marketplace add jamditis/claude-skills-journalism
+/plugin install journalism-core@claude-skills-journalism</code></pre>
+                        <p class="text-sm text-white/70 mt-3">Ships with twelve sibling skills covering AP-style writing, FOIA, fact-checking, interview workflows, and more.</p>
                     </div>
 
                     <div class="bg-white/5 p-6 rounded-xl">
                         <h3 class="font-semibold mb-3 flex items-center gap-2">
                             <span class="w-6 h-6 bg-accent rounded-full flex items-center justify-center text-xs">2</span>
-                            Copy skill to Claude skills directory
+                            Or copy just this skill from the plugin tree
                         </h3>
-                        <pre tabindex="0"><code>cp -r data-journalism ~/.claude/skills/</code></pre>
+                        <pre tabindex="0"><code>git clone https://github.com/jamditis/claude-skills-journalism.git
+cp -r claude-skills-journalism/journalism-core/skills/data-journalism ~/.claude/skills/</code></pre>
                     </div>
 
                     <div class="bg-white/5 p-6 rounded-xl">

--- a/docs/digital-archive/index.html
+++ b/docs/digital-archive/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Digital archiving workflows with AI enrichment, entity extraction, and knowledge graph construction. Use when building content archives, implementing AI-powered categorization, extracting entities and relationships, or integrating multiple data sources. Covers patterns from the Jay Rosen Digital Archive project.">
     <title>Digital archive - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Digital archive - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Digital archiving workflows with AI enrichment, entity extraction, and knowledge graph construction. Use when building content archives, implementing AI-powered categorization, extracting entities and relationships, or integrating multiple data sources. Covers patterns from the Jay Rosen Digital Archive project.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/digital-archive/">
     <meta property="og:image" content="https://skills.amditis.tech/digital-archive/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Digital archive - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Digital archiving workflows with AI enrichment, entity extraction, and knowledge graph construction. Use when building content archives, implementing AI-powered categorization, extracting entities and relationships, or integrating multiple data sources. Covers patterns from the Jay Rosen Digital Archive project.">
     <meta name="twitter:image" content="https://skills.amditis.tech/digital-archive/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -390,14 +391,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/digital-archive ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the research-toolkit plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install research-toolkit@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/research-toolkit/skills/digital-archive ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/digital-archive" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/research-toolkit/skills/digital-archive" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -418,7 +421,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     Multi-source integration, AI categorization, entity extraction, and knowledge graph patterns.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/digital-archive" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/research-toolkit/skills/digital-archive" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/editorial-workflow/index.html
+++ b/docs/editorial-workflow/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Manage editorial workflows for newsrooms and publications. Use when tracking story assignments, managing deadlines, coordinating editorial calendars, or establishing handoff protocols between reporters and editors. Includes templates for assignment tracking, editorial calendars, and workflow documentation.">
     <title>Editorial workflow - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Editorial workflow - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Manage editorial workflows for newsrooms and publications. Use when tracking story assignments, managing deadlines, coordinating editorial calendars, or establishing handoff protocols between reporters and editors. Includes templates for assignment tracking, editorial calendars, and workflow documentation.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/editorial-workflow/">
     <meta property="og:image" content="https://skills.amditis.tech/editorial-workflow/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Editorial workflow - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Manage editorial workflows for newsrooms and publications. Use when tracking story assignments, managing deadlines, coordinating editorial calendars, or establishing handoff protocols between reporters and editors. Includes templates for assignment tracking, editorial calendars, and workflow documentation.">
     <meta name="twitter:image" content="https://skills.amditis.tech/editorial-workflow/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -339,14 +340,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/editorial-workflow ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the journalism-core plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install journalism-core@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/journalism-core/skills/editorial-workflow ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/editorial-workflow" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/editorial-workflow" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -367,7 +370,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     You only notice them when they break. Set up systems that work.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/editorial-workflow" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/editorial-workflow" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/electron-dev/index.html
+++ b/docs/electron-dev/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Electron desktop application development with React, TypeScript, and Vite. Use when building desktop apps, implementing IPC communication, managing windows/tray, handling PTY terminals, integrating WebRTC/audio, or packaging with electron-builder. Covers patterns from AudioBash, Yap, and Pisscord projects.">
     <title>Electron dev - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Electron dev - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Electron desktop application development with React, TypeScript, and Vite. Use when building desktop apps, implementing IPC communication, managing windows/tray, handling PTY terminals, integrating WebRTC/audio, or packaging with electron-builder. Covers patterns from AudioBash, Yap, and Pisscord projects.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/electron-dev/">
     <meta property="og:image" content="https://skills.amditis.tech/electron-dev/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Electron dev - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Electron desktop application development with React, TypeScript, and Vite. Use when building desktop apps, implementing IPC communication, managing windows/tray, handling PTY terminals, integrating WebRTC/audio, or packaging with electron-builder. Covers patterns from AudioBash, Yap, and Pisscord projects.">
     <meta name="twitter:image" content="https://skills.amditis.tech/electron-dev/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -309,14 +310,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/electron-dev ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the dev-toolkit plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install dev-toolkit@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/dev-toolkit/skills/electron-dev ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/electron-dev" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/electron-dev" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -337,7 +340,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     IPC patterns, system tray integration, and electron-builder configuration.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/electron-dev" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/electron-dev" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/fact-check-workflow/index.html
+++ b/docs/fact-check-workflow/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Structured workflow for fact-checking claims in journalism. Use when verifying statements for publication, rating claims for fact-check articles, or building pre-publication verification processes. Includes claim extraction, evidence gathering, rating scales, and correction protocols.">
     <title>Fact-check workflow - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Fact-check workflow - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Structured workflow for fact-checking claims in journalism. Use when verifying statements for publication, rating claims for fact-check articles, or building pre-publication verification processes. Includes claim extraction, evidence gathering, rating scales, and correction protocols.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/fact-check-workflow/">
     <meta property="og:image" content="https://skills.amditis.tech/fact-check-workflow/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Fact-check workflow - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Structured workflow for fact-checking claims in journalism. Use when verifying statements for publication, rating claims for fact-check articles, or building pre-publication verification processes. Includes claim extraction, evidence gathering, rating scales, and correction protocols.">
     <meta name="twitter:image" content="https://skills.amditis.tech/fact-check-workflow/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -353,14 +354,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/fact-check-workflow ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the journalism-core plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install journalism-core@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/journalism-core/skills/fact-check-workflow ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/fact-check-workflow" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/fact-check-workflow" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -381,7 +384,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     Fact-checking is systematic, not intuitive. Get the structure right.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/fact-check-workflow" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/fact-check-workflow" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/foia-requests/index.html
+++ b/docs/foia-requests/index.html
@@ -179,7 +179,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <a href="../" class="text-sm font-medium text-mist hover:text-ink transition-colors">
                 ← Back to all skills
             </a>
-            <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/foia-requests" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">
+            <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/foia-requests" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">
                 View on GitHub →
             </a>
         </div>
@@ -531,17 +531,20 @@ format as they become available.</code></pre>
                     <div class="feature-card p-8 rounded-xl">
                         <div class="flex items-center gap-4 mb-4">
                             <span class="w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">1</span>
-                            <h3 class="font-display text-xl font-bold">Clone the repository</h3>
+                            <h3 class="font-display text-xl font-bold">Recommended: install the journalism-core plugin</h3>
                         </div>
-                        <pre tabindex="0"><code>git clone https://github.com/jamditis/claude-skills-journalism.git</code></pre>
+                        <pre tabindex="0"><code>/plugin marketplace add jamditis/claude-skills-journalism
+/plugin install journalism-core@claude-skills-journalism</code></pre>
+                        <p class="text-mist text-sm mt-3">Ships with twelve sibling skills covering AP-style writing, source verification, fact-checking, interview workflows, and more.</p>
                     </div>
 
                     <div class="feature-card p-8 rounded-xl">
                         <div class="flex items-center gap-4 mb-4">
                             <span class="w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">2</span>
-                            <h3 class="font-display text-xl font-bold">Copy the skill to your Claude config</h3>
+                            <h3 class="font-display text-xl font-bold">Or copy just this skill from the plugin tree</h3>
                         </div>
-                        <pre tabindex="0"><code>cp -r claude-skills-journalism/foia-requests ~/.claude/skills/</code></pre>
+                        <pre tabindex="0"><code>git clone https://github.com/jamditis/claude-skills-journalism.git
+cp -r claude-skills-journalism/journalism-core/skills/foia-requests ~/.claude/skills/</code></pre>
                     </div>
 
                     <div class="feature-card p-8 rounded-xl">
@@ -581,7 +584,7 @@ format as they become available.</code></pre>
                 </div>
 
                 <div class="mt-12 text-center">
-                    <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/foia-requests" class="inline-flex items-center gap-2 bg-accent text-white font-semibold px-6 py-3 rounded-lg hover:bg-accentDark transition-colors">
+                    <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/foia-requests" class="inline-flex items-center gap-2 bg-accent text-white font-semibold px-6 py-3 rounded-lg hover:bg-accentDark transition-colors">
                         <i data-lucide="github" class="w-5 h-5"></i>
                         View full skill on GitHub
                     </a>

--- a/docs/free-apis-catalog/index.html
+++ b/docs/free-apis-catalog/index.html
@@ -142,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <nav aria-label="Primary" class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-ink/5">
         <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
             <a href="../" class="text-sm font-medium text-mist hover:text-ink transition-colors">&larr; Back to all skills</a>
-            <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/free-apis-catalog" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">View on GitHub &rarr;</a>
+            <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/research-toolkit/skills/free-apis-catalog" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">View on GitHub &rarr;</a>
         </div>
     </nav>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1030,8 +1030,8 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         <div>git clone https://github.com/jamditis/claude-skills-journalism.git ~/projects/claude-skills-journalism</div>
                         <div>cd ~/projects/claude-skills-journalism</div>
                         <div>mkdir -p ~/.claude/skills</div>
-                        <div>cp -r source-verification ~/.claude/skills/</div>
-                        <div># or: ln -sfn "$PWD/source-verification" ~/.claude/skills/source-verification</div>
+                        <div>cp -r journalism-core/skills/source-verification ~/.claude/skills/</div>
+                        <div># or: ln -sfn "$PWD/journalism-core/skills/source-verification" ~/.claude/skills/source-verification</div>
                     </div>
                     <p class="text-sm text-mist">Skills activate automatically. For example, asking Claude to verify a source will use the source-verification skill. Don't clone the whole repo into <code>~/.claude/skills/journalism-skills/</code> — that nests each <code>SKILL.md</code> two levels deep and Claude Code won't find them.</p>
                 </div>

--- a/docs/interview-prep/index.html
+++ b/docs/interview-prep/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Prepare for journalism interviews with research checklists, question frameworks, and attribution guidelines. Use when preparing to interview sources, planning follow-up questions, or managing interview logistics. Covers consent, recording laws, and professional protocols.">
     <title>Interview prep - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Interview prep - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Prepare for journalism interviews with research checklists, question frameworks, and attribution guidelines. Use when preparing to interview sources, planning follow-up questions, or managing interview logistics. Covers consent, recording laws, and professional protocols.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/interview-prep/">
     <meta property="og:image" content="https://skills.amditis.tech/interview-prep/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Interview prep - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Prepare for journalism interviews with research checklists, question frameworks, and attribution guidelines. Use when preparing to interview sources, planning follow-up questions, or managing interview logistics. Covers consent, recording laws, and professional protocols.">
     <meta name="twitter:image" content="https://skills.amditis.tech/interview-prep/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -328,14 +329,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/interview-prep ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the journalism-core plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install journalism-core@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/journalism-core/skills/interview-prep ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/interview-prep" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/interview-prep" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -356,7 +359,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     Research, question design, and consent protocols in one skill.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/interview-prep" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/interview-prep" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/interview-transcription/index.html
+++ b/docs/interview-transcription/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Transcription workflows, recording management, and quote extraction for journalists. Use when processing audio/video recordings, generating transcripts with timestamps, extracting quotes for fact-checking, or building source-and-recording databases. For interview question design and pre-interview preparation, see the interview-prep skill.">
     <title>Interview transcription - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Interview transcription - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Transcription workflows, recording management, and quote extraction for journalists. Use when processing audio/video recordings, generating transcripts with timestamps, extracting quotes for fact-checking, or building source-and-recording databases. For interview question design and pre-interview preparation, see the interview-prep skill.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/interview-transcription/">
     <meta property="og:image" content="https://skills.amditis.tech/interview-transcription/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Interview transcription - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Transcription workflows, recording management, and quote extraction for journalists. Use when processing audio/video recordings, generating transcripts with timestamps, extracting quotes for fact-checking, or building source-and-recording databases. For interview question design and pre-interview preparation, see the interview-prep skill.">
     <meta name="twitter:image" content="https://skills.amditis.tech/interview-transcription/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -334,14 +335,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/interview-transcription ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the journalism-core plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install journalism-core@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/journalism-core/skills/interview-transcription ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/interview-transcription" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/interview-transcription" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -362,7 +365,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     Transcription workflows, quote verification, and source management in one skill.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/interview-transcription" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/interview-transcription" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/mobile-debugging/index.html
+++ b/docs/mobile-debugging/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Remote JavaScript console access and debugging on mobile devices. Use when debugging web pages on phones/tablets, accessing console errors without desktop DevTools, testing responsive designs on real devices, or diagnosing mobile-specific issues. Covers Eruda, vConsole, Chrome/Safari remote debugging, and cloud testing platforms.">
     <title>Mobile debugging - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Mobile debugging - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Remote JavaScript console access and debugging on mobile devices. Use when debugging web pages on phones/tablets, accessing console errors without desktop DevTools, testing responsive designs on real devices, or diagnosing mobile-specific issues. Covers Eruda, vConsole, Chrome/Safari remote debugging, and cloud testing platforms.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/mobile-debugging/">
     <meta property="og:image" content="https://skills.amditis.tech/mobile-debugging/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Mobile debugging - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Remote JavaScript console access and debugging on mobile devices. Use when debugging web pages on phones/tablets, accessing console errors without desktop DevTools, testing responsive designs on real devices, or diagnosing mobile-specific issues. Covers Eruda, vConsole, Chrome/Safari remote debugging, and cloud testing platforms.">
     <meta name="twitter:image" content="https://skills.amditis.tech/mobile-debugging/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -348,14 +349,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/mobile-debugging ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the dev-toolkit plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install dev-toolkit@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/dev-toolkit/skills/mobile-debugging ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/mobile-debugging" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/mobile-debugging" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -376,7 +379,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     In-page consoles, remote debugging, and cloud testing for mobile web.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/mobile-debugging" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/mobile-debugging" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/newsletter-publishing/index.html
+++ b/docs/newsletter-publishing/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Email newsletter workflows for journalists and researchers. Use when creating, managing, or optimizing email newsletters, building subscriber lists, designing email templates, analyzing engagement metrics, or planning newsletter content calendars. For independent journalists, academic communicators, and media organizations building direct audience relationships.">
     <title>Newsletter publishing - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Newsletter publishing - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Email newsletter workflows for journalists and researchers. Use when creating, managing, or optimizing email newsletters, building subscriber lists, designing email templates, analyzing engagement metrics, or planning newsletter content calendars. For independent journalists, academic communicators, and media organizations building direct audience relationships.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/newsletter-publishing/">
     <meta property="og:image" content="https://skills.amditis.tech/newsletter-publishing/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Newsletter publishing - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Email newsletter workflows for journalists and researchers. Use when creating, managing, or optimizing email newsletters, building subscriber lists, designing email templates, analyzing engagement metrics, or planning newsletter content calendars. For independent journalists, academic communicators, and media organizations building direct audience relationships.">
     <meta name="twitter:image" content="https://skills.amditis.tech/newsletter-publishing/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -325,14 +326,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/newsletter-publishing ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the journalism-core plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install journalism-core@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/journalism-core/skills/newsletter-publishing ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/newsletter-publishing" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/newsletter-publishing" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -353,7 +356,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     Strategy frameworks, templates, and deliverability guidance in one skill.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/newsletter-publishing" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/newsletter-publishing" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/newsroom-style/index.html
+++ b/docs/newsroom-style/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Enforce AP Style and newsroom conventions for journalism writing. Use when writing news articles, editing drafts, creating headlines, or converting notes into publishable copy. Ensures professional standards for attribution, numbers, dates, and formatting.">
     <title>Newsroom style - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Newsroom style - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Enforce AP Style and newsroom conventions for journalism writing. Use when writing news articles, editing drafts, creating headlines, or converting notes into publishable copy. Ensures professional standards for attribution, numbers, dates, and formatting.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/newsroom-style/">
     <meta property="og:image" content="https://skills.amditis.tech/newsroom-style/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Newsroom style - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Enforce AP Style and newsroom conventions for journalism writing. Use when writing news articles, editing drafts, creating headlines, or converting notes into publishable copy. Ensures professional standards for attribution, numbers, dates, and formatting.">
     <meta name="twitter:image" content="https://skills.amditis.tech/newsroom-style/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -367,14 +368,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/newsroom-style ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the journalism-core plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install journalism-core@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/journalism-core/skills/newsroom-style ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/newsroom-style" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/newsroom-style" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -395,7 +398,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     AP Style rules, attribution guidelines, and formatting standards in one skill.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/newsroom-style" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/newsroom-style" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/one-way-door/index.html
+++ b/docs/one-way-door/index.html
@@ -372,7 +372,7 @@ exit 0  # Allow two-way doors</code></pre>
             </div>
             <p class="text-sm text-clay/80 mt-3">
                 Full script with all 8 categories available in the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/one-way-door" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">skill directory</a>.
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/one-way-door" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">skill directory</a>.
             </p>
         </section>
 
@@ -424,10 +424,12 @@ exit 0  # Allow two-way doors</code></pre>
                 <div>
                     <h3 class="font-semibold mb-3">Option 1: Install the skill</h3>
                     <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                        <p class="text-white/50 mb-2"># Clone the repository</p>
-                        <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                        <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                        <p class="text-white">cp -r claude-skills-journalism/one-way-door ~/.claude/skills/</p>
+                        <p class="text-white/50 mb-2"># Recommended: install the dev-toolkit plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install dev-toolkit@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/dev-toolkit/skills/one-way-door ~/.claude/skills/</p>
                     </div>
                 </div>
 
@@ -466,8 +468,8 @@ committing.</code></pre>
             </div>
 
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/one-way-door" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/one-way-door" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -488,7 +490,7 @@ committing.</code></pre>
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     Pause before irreversible decisions. A five-minute conversation about trade-offs saves weeks of migration pain.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/one-way-door" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/one-way-door" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/one-way-door/index.html
+++ b/docs/one-way-door/index.html
@@ -425,11 +425,11 @@ exit 0  # Allow two-way doors</code></pre>
                     <h3 class="font-semibold mb-3">Option 1: Install the skill</h3>
                     <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
                         <p class="text-white/50 mb-2"># Recommended: install the dev-toolkit plugin</p>
-                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
-                <p class="text-white mb-4">/plugin install dev-toolkit@claude-skills-journalism</p>
-                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
-                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white">cp -r claude-skills-journalism/dev-toolkit/skills/one-way-door ~/.claude/skills/</p>
+                        <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                        <p class="text-white mb-4">/plugin install dev-toolkit@claude-skills-journalism</p>
+                        <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                        <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                        <p class="text-white">cp -r claude-skills-journalism/dev-toolkit/skills/one-way-door ~/.claude/skills/</p>
                     </div>
                 </div>
 

--- a/docs/page-monitoring/index.html
+++ b/docs/page-monitoring/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Web page monitoring, change detection, and availability tracking. Use when tracking content changes, detecting when pages go down, monitoring for updates, preserving content before deletion, or generating feeds for pages without RSS. Covers Visualping, ChangeTower, Distill.io, and self-hosted monitoring solutions.">
     <title>Page monitoring - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Page monitoring - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Web page monitoring, change detection, and availability tracking. Use when tracking content changes, detecting when pages go down, monitoring for updates, preserving content before deletion, or generating feeds for pages without RSS. Covers Visualping, ChangeTower, Distill.io, and self-hosted monitoring solutions.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/page-monitoring/">
     <meta property="og:image" content="https://skills.amditis.tech/page-monitoring/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Page monitoring - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Web page monitoring, change detection, and availability tracking. Use when tracking content changes, detecting when pages go down, monitoring for updates, preserving content before deletion, or generating feeds for pages without RSS. Covers Visualping, ChangeTower, Distill.io, and self-hosted monitoring solutions.">
     <meta name="twitter:image" content="https://skills.amditis.tech/page-monitoring/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -326,14 +327,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/page-monitoring ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the research-toolkit plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install research-toolkit@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/research-toolkit/skills/page-monitoring ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/page-monitoring" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/research-toolkit/skills/page-monitoring" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -354,7 +357,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     Change detection, uptime monitoring, and RSS generation in one skill.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/page-monitoring" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/research-toolkit/skills/page-monitoring" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/pdf-design/index.html
+++ b/docs/pdf-design/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Design and edit professional PDF reports and proposals with live preview">
     <title>PDF design - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="PDF design - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Design and edit professional PDF reports and proposals with live preview">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/pdf-design/">
     <meta property="og:image" content="https://skills.amditis.tech/pdf-design/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="PDF design - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Design and edit professional PDF reports and proposals with live preview">
     <meta name="twitter:image" content="https://skills.amditis.tech/pdf-design/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -330,13 +331,15 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white/50 mb-2"># Recommended: install the pdf-design plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install pdf-design@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
                 <p class="text-white">cp -r claude-skills-journalism/pdf-design ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
+                Or browse this skill in the
                 <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/pdf-design" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>

--- a/docs/project-memory/index.html
+++ b/docs/project-memory/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Generate CLAUDE.md project memory files that transfer institutional knowledge, not obvious information. Use when setting up new journalism projects, onboarding collaborators, or documenting project-specific quirks. Includes templates for editorial tools, event websites, publications, research projects, content pipelines, and digital archives.">
     <title>Project memory - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Project memory - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Generate CLAUDE.md project memory files that transfer institutional knowledge, not obvious information. Use when setting up new journalism projects, onboarding collaborators, or documenting project-specific quirks. Includes templates for editorial tools, event websites, publications, research projects, content pipelines, and digital archives.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/project-memory/">
     <meta property="og:image" content="https://skills.amditis.tech/project-memory/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Project memory - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Generate CLAUDE.md project memory files that transfer institutional knowledge, not obvious information. Use when setting up new journalism projects, onboarding collaborators, or documenting project-specific quirks. Includes templates for editorial tools, event websites, publications, research projects, content pipelines, and digital archives.">
     <meta name="twitter:image" content="https://skills.amditis.tech/project-memory/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -178,7 +179,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Project memory</h1>
             <p class="text-xl text-white/90 max-w-2xl">
-                Generate CLAUDE.md files that transfer tribal knowledge, not obvious information.
+                Generate CLAUDE.md project memory files that transfer institutional knowledge, not obvious information.
             </p>
         </div>
     </header>
@@ -349,14 +350,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/project-memory ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the project-templates-toolkit plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install project-templates-toolkit@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/project-templates-toolkit/skills/project-memory ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/project-memory" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/project-templates-toolkit/skills/project-memory" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -377,7 +380,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     Templates for tribal knowledge, not generic documentation.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/project-memory" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/project-templates-toolkit/skills/project-memory" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/project-retrospective/index.html
+++ b/docs/project-retrospective/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Generate LESSONS.md retrospective files that capture institutional knowledge, especially failures. Use when closing out journalism projects, investigations, events, or publications. Includes templates for research projects, event post-mortems, editorial tools, and publications.">
     <title>Project retrospective - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -119,7 +120,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Project retrospective - Claude skills for journalism">
-    <meta property="og:description" content="If you find yourself writing these, stop and be more specific. These are placeholders for real insights:">
+    <meta property="og:description" content="Generate LESSONS.md retrospective files that capture institutional knowledge, especially failures. Use when closing out journalism projects, investigations, events, or publications. Includes templates for research projects, event post-mortems, editorial tools, and publications.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/project-retrospective/">
     <meta property="og:image" content="https://skills.amditis.tech/project-retrospective/og-image.png">
@@ -129,7 +130,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Project retrospective - Claude skills for journalism">
-    <meta name="twitter:description" content="If you find yourself writing these, stop and be more specific. These are placeholders for real insights:">
+    <meta name="twitter:description" content="Generate LESSONS.md retrospective files that capture institutional knowledge, especially failures. Use when closing out journalism projects, investigations, events, or publications. Includes templates for research projects, event post-mortems, editorial tools, and publications.">
     <meta name="twitter:image" content="https://skills.amditis.tech/project-retrospective/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -514,14 +515,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-20">
             <h2 class="font-display text-2xl font-semibold mb-6">Installation</h2>
             <div class="bg-ink rounded-2xl p-6 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/project-retrospective ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the project-templates-toolkit plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install project-templates-toolkit@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/project-templates-toolkit/skills/project-retrospective ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70">
                 Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/project-retrospective" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/project-templates-toolkit/skills/project-retrospective" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -532,7 +535,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-8 max-w-xl mx-auto">
                     The best retrospectives are written by people who got burned and want to save others from the same fate.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/project-retrospective" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-6 py-3 rounded-full font-semibold hover:bg-white/95 transition-colors shadow-lg" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/project-templates-toolkit/skills/project-retrospective" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-6 py-3 rounded-full font-semibold hover:bg-white/95 transition-colors shadow-lg" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/python-pipeline/index.html
+++ b/docs/python-pipeline/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Python data processing pipelines with modular architecture. Use when building content processing workflows, implementing dispatcher patterns, integrating Google Sheets/Drive APIs, or creating batch processing systems. Covers patterns from rosen-scraper, image-analyzer, and social-scraper projects.">
     <title>Python pipeline - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Python pipeline - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Python data processing pipelines with modular architecture. Use when building content processing workflows, implementing dispatcher patterns, integrating Google Sheets/Drive APIs, or creating batch processing systems. Covers patterns from rosen-scraper, image-analyzer, and social-scraper projects.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/python-pipeline/">
     <meta property="og:image" content="https://skills.amditis.tech/python-pipeline/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Python pipeline - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Python data processing pipelines with modular architecture. Use when building content processing workflows, implementing dispatcher patterns, integrating Google Sheets/Drive APIs, or creating batch processing systems. Covers patterns from rosen-scraper, image-analyzer, and social-scraper projects.">
     <meta name="twitter:image" content="https://skills.amditis.tech/python-pipeline/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -329,14 +330,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/python-pipeline ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the dev-toolkit plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install dev-toolkit@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/dev-toolkit/skills/python-pipeline ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/python-pipeline" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/python-pipeline" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -357,7 +360,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     Modular architecture, rate limiting, and progress tracking in one skill.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/python-pipeline" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/python-pipeline" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/secure-auth/index.html
+++ b/docs/secure-auth/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Secure authentication implementation patterns. Use when implementing user login, registration, password reset, session management, JWT authentication, OAuth, MFA, or passkeys. Provides production-ready patterns aligned with NIST SP 800-63B-4, OWASP 2026 cheat sheets, OAuth 2.1, and WebAuthn L3, with breach-driven lessons.">
     <title>Secure auth - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Secure auth - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Secure authentication implementation patterns. Use when implementing user login, registration, password reset, session management, JWT authentication, OAuth, MFA, or passkeys. Provides production-ready patterns aligned with NIST SP 800-63B-4, OWASP 2026 cheat sheets, OAuth 2.1, and WebAuthn L3, with breach-driven lessons.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/secure-auth/">
     <meta property="og:image" content="https://skills.amditis.tech/secure-auth/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Secure auth - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Secure authentication implementation patterns. Use when implementing user login, registration, password reset, session management, JWT authentication, OAuth, MFA, or passkeys. Provides production-ready patterns aligned with NIST SP 800-63B-4, OWASP 2026 cheat sheets, OAuth 2.1, and WebAuthn L3, with breach-driven lessons.">
     <meta name="twitter:image" content="https://skills.amditis.tech/secure-auth/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -178,7 +179,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Secure auth</h1>
             <p class="text-xl text-white/90 max-w-2xl">
-                Production-ready authentication patterns. These aren't the simplest implementations - they're the ones that won't get you sued.
+                Production-ready authentication patterns aligned with NIST SP 800-63B-4, OWASP 2026 cheat sheets, OAuth 2.1, and WebAuthn L3 — with breach-driven lessons.
             </p>
         </div>
     </header>
@@ -327,14 +328,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/secure-auth ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the security-toolkit plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install security-toolkit@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/security-toolkit/skills/secure-auth ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/secure-auth" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/security-toolkit/skills/secure-auth" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -354,7 +357,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     Sessions, JWTs, password reset, OAuth, and MFA - all production-ready.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/secure-auth" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/security-toolkit/skills/secure-auth" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/security-checklist/index.html
+++ b/docs/security-checklist/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Pre-deployment security audit for web applications, organized by OWASP Top 10:2025 categories. Use when reviewing code before shipping, auditing an existing application, or when users mention &quot;security review,&quot; &quot;ready to deploy,&quot; &quot;going to production,&quot; or express concern about vulnerabilities. Covers access control, supply chain, cryptography, injection, auth, integrity, logging, and exception handling.">
     <title>Security checklist - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Security checklist - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Pre-deployment security audit for web applications, organized by OWASP Top 10:2025 categories. Use when reviewing code before shipping, auditing an existing application, or when users mention &quot;security review,&quot; &quot;ready to deploy,&quot; &quot;going to production,&quot; or express concern about vulnerabilities. Covers access control, supply chain, cryptography, injection, auth, integrity, logging, and exception handling.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/security-checklist/">
     <meta property="og:image" content="https://skills.amditis.tech/security-checklist/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Security checklist - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Pre-deployment security audit for web applications, organized by OWASP Top 10:2025 categories. Use when reviewing code before shipping, auditing an existing application, or when users mention &quot;security review,&quot; &quot;ready to deploy,&quot; &quot;going to production,&quot; or express concern about vulnerabilities. Covers access control, supply chain, cryptography, injection, auth, integrity, logging, and exception handling.">
     <meta name="twitter:image" content="https://skills.amditis.tech/security-checklist/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -178,7 +179,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Security checklist</h1>
             <p class="text-xl text-white/90 max-w-2xl">
-                Minimum viable security before shipping any web application. This is the baseline that prevents obvious disasters.
+                Pre-deployment security audit organized around the OWASP Top 10:2025 categories. The baseline that prevents obvious disasters — not a substitute for a real penetration test.
             </p>
         </div>
     </header>
@@ -348,14 +349,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/security-checklist ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the security-toolkit plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install security-toolkit@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/security-toolkit/skills/security-checklist ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/security-checklist" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/security-toolkit/skills/security-checklist" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -375,7 +378,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     The baseline security audit that prevents obvious disasters.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/security-checklist" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/security-toolkit/skills/security-checklist" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/social-media-intelligence/index.html
+++ b/docs/social-media-intelligence/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Social media monitoring, narrative tracking, and open-source intelligence for journalists. Use when tracking viral content spread, analyzing coordinated campaigns, monitoring breaking news on social platforms, investigating accounts for authenticity, or detecting misinformation patterns. Essential for reporters covering online narratives and digital investigations.">
     <title>Social media intelligence - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Social media intelligence - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Social media monitoring, narrative tracking, and open-source intelligence for journalists. Use when tracking viral content spread, analyzing coordinated campaigns, monitoring breaking news on social platforms, investigating accounts for authenticity, or detecting misinformation patterns. Essential for reporters covering online narratives and digital investigations.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/social-media-intelligence/">
     <meta property="og:image" content="https://skills.amditis.tech/social-media-intelligence/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Social media intelligence - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Social media monitoring, narrative tracking, and open-source intelligence for journalists. Use when tracking viral content spread, analyzing coordinated campaigns, monitoring breaking news on social platforms, investigating accounts for authenticity, or detecting misinformation patterns. Essential for reporters covering online narratives and digital investigations.">
     <meta name="twitter:image" content="https://skills.amditis.tech/social-media-intelligence/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -377,14 +378,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/social-media-intelligence ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the journalism-core plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install journalism-core@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/journalism-core/skills/social-media-intelligence ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/social-media-intelligence" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/social-media-intelligence" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -405,7 +408,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     Monitoring, analysis, and investigation tools for social media journalism.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/social-media-intelligence" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/social-media-intelligence" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/source-verification/index.html
+++ b/docs/source-verification/index.html
@@ -139,7 +139,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <a href="../" class="text-sm font-medium text-mist hover:text-ink transition-colors">
                 ← Back to all skills
             </a>
-            <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/source-verification" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">
+            <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/source-verification" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">
                 View on GitHub →
             </a>
         </div>
@@ -424,17 +424,20 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                     <div class="bg-white/5 p-6 rounded-xl">
                         <h3 class="font-semibold mb-3 flex items-center gap-2">
                             <span class="w-6 h-6 bg-accent rounded-full flex items-center justify-center text-xs">1</span>
-                            Clone the repository
+                            Recommended: install the journalism-core plugin
                         </h3>
-                        <pre tabindex="0"><code>git clone https://github.com/jamditis/claude-skills-journalism.git</code></pre>
+                        <pre tabindex="0"><code>/plugin marketplace add jamditis/claude-skills-journalism
+/plugin install journalism-core@claude-skills-journalism</code></pre>
+                        <p class="text-sm text-white/70 mt-3">Ships with twelve sibling skills covering AP-style writing, FOIA, fact-checking, interview workflows, and more.</p>
                     </div>
 
                     <div class="bg-white/5 p-6 rounded-xl">
                         <h3 class="font-semibold mb-3 flex items-center gap-2">
                             <span class="w-6 h-6 bg-accent rounded-full flex items-center justify-center text-xs">2</span>
-                            Copy skill to Claude skills directory
+                            Or copy just this skill from the plugin tree
                         </h3>
-                        <pre tabindex="0"><code>cp -r source-verification ~/.claude/skills/</code></pre>
+                        <pre tabindex="0"><code>git clone https://github.com/jamditis/claude-skills-journalism.git
+cp -r claude-skills-journalism/journalism-core/skills/source-verification ~/.claude/skills/</code></pre>
                     </div>
 
                     <div class="bg-white/5 p-6 rounded-xl">

--- a/docs/story-pitch/index.html
+++ b/docs/story-pitch/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Craft effective story pitches for different publication types and formats. Use when pitching to editors, preparing query letters, or developing story angles. Includes templates for daily news, features, investigations, op-eds, and freelance queries.">
     <title>Story pitch - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Story pitch - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Craft effective story pitches for different publication types and formats. Use when pitching to editors, preparing query letters, or developing story angles. Includes templates for daily news, features, investigations, op-eds, and freelance queries.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/story-pitch/">
     <meta property="og:image" content="https://skills.amditis.tech/story-pitch/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Story pitch - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Craft effective story pitches for different publication types and formats. Use when pitching to editors, preparing query letters, or developing story angles. Includes templates for daily news, features, investigations, op-eds, and freelance queries.">
     <meta name="twitter:image" content="https://skills.amditis.tech/story-pitch/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -326,14 +327,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/story-pitch ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the journalism-core plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install journalism-core@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/journalism-core/skills/story-pitch ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/story-pitch" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/story-pitch" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -354,7 +357,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     Templates, angle development, and the "so what" test in one skill.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/story-pitch" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/story-pitch" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/template-selector/index.html
+++ b/docs/template-selector/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Choose the correct CLAUDE.md or LESSONS.md template for journalism projects. Use when starting a new project, setting up documentation, or unsure which template category fits best. Provides decision trees and selection guidance for 6 journalism-focused template types.">
     <title>Template selector - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Template selector - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Choose the correct CLAUDE.md or LESSONS.md template for journalism projects. Use when starting a new project, setting up documentation, or unsure which template category fits best. Provides decision trees and selection guidance for 6 journalism-focused template types.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/template-selector/">
     <meta property="og:image" content="https://skills.amditis.tech/template-selector/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Template selector - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Choose the correct CLAUDE.md or LESSONS.md template for journalism projects. Use when starting a new project, setting up documentation, or unsure which template category fits best. Provides decision trees and selection guidance for 6 journalism-focused template types.">
     <meta name="twitter:image" content="https://skills.amditis.tech/template-selector/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -318,14 +319,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/template-selector ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the project-templates-toolkit plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install project-templates-toolkit@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/project-templates-toolkit/skills/template-selector ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/template-selector" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/project-templates-toolkit/skills/template-selector" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -345,7 +348,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     Decision trees, category descriptions, and common mistakes in one skill.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/template-selector" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/project-templates-toolkit/skills/template-selector" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/test-first-bugs/index.html
+++ b/docs/test-first-bugs/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="This skill should be used when the user reports a bug, describes unexpected behavior, says something is &quot;broken&quot;, &quot;not working&quot;, &quot;failing&quot;, mentions an &quot;error&quot;, &quot;issue&quot;, or &quot;problem&quot; in code, or asks to &quot;fix&quot; something. Enforces test-driven bug fixing workflow.">
     <title>Test-first bugs - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Test-first bugs - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="This skill should be used when the user reports a bug, describes unexpected behavior, says something is &quot;broken&quot;, &quot;not working&quot;, &quot;failing&quot;, mentions an &quot;error&quot;, &quot;issue&quot;, or &quot;problem&quot; in code, or asks to &quot;fix&quot; something. Enforces test-driven bug fixing workflow.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/test-first-bugs/">
     <meta property="og:image" content="https://skills.amditis.tech/test-first-bugs/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Test-first bugs - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="This skill should be used when the user reports a bug, describes unexpected behavior, says something is &quot;broken&quot;, &quot;not working&quot;, &quot;failing&quot;, mentions an &quot;error&quot;, &quot;issue&quot;, or &quot;problem&quot; in code, or asks to &quot;fix&quot; something. Enforces test-driven bug fixing workflow.">
     <meta name="twitter:image" content="https://skills.amditis.tech/test-first-bugs/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -304,14 +305,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/test-first-bugs ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the dev-toolkit plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install dev-toolkit@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/dev-toolkit/skills/test-first-bugs ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/test-first-bugs" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/test-first-bugs" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -331,7 +334,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     Test-driven bug fixing, parallel subagents, and regression prevention in one skill.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/test-first-bugs" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/test-first-bugs" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/vibe-coding/index.html
+++ b/docs/vibe-coding/index.html
@@ -179,7 +179,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <a href="../" class="text-sm font-medium text-mist hover:text-ink transition-colors">
                 ← Back to all skills
             </a>
-            <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/vibe-coding" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">
+            <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/vibe-coding" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">
                 View on GitHub →
             </a>
         </div>
@@ -481,17 +481,20 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                     <div class="feature-card p-8 rounded-xl">
                         <div class="flex items-center gap-4 mb-4">
                             <span class="w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">1</span>
-                            <h3 class="font-display text-xl font-bold">Clone the repository</h3>
+                            <h3 class="font-display text-xl font-bold">Recommended: install the dev-toolkit plugin</h3>
                         </div>
-                        <pre tabindex="0"><code>git clone https://github.com/jamditis/claude-skills-journalism.git</code></pre>
+                        <pre tabindex="0"><code>/plugin marketplace add jamditis/claude-skills-journalism
+/plugin install dev-toolkit@claude-skills-journalism</code></pre>
+                        <p class="text-mist text-sm mt-3">Ships with nine sibling skills (accessibility, mobile-debugging, python-pipeline, test-first-bugs, web-scraping, web-ui-best-practices, zero-build-frontend, electron-dev, one-way-door).</p>
                     </div>
 
                     <div class="feature-card p-8 rounded-xl">
                         <div class="flex items-center gap-4 mb-4">
                             <span class="w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">2</span>
-                            <h3 class="font-display text-xl font-bold">Copy the skill to your Claude config</h3>
+                            <h3 class="font-display text-xl font-bold">Or copy just this skill from the plugin tree</h3>
                         </div>
-                        <pre tabindex="0"><code>cp -r claude-skills-journalism/vibe-coding ~/.claude/skills/</code></pre>
+                        <pre tabindex="0"><code>git clone https://github.com/jamditis/claude-skills-journalism.git
+cp -r claude-skills-journalism/dev-toolkit/skills/vibe-coding ~/.claude/skills/</code></pre>
                     </div>
 
                     <div class="feature-card p-8 rounded-xl">
@@ -531,7 +534,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 </div>
 
                 <div class="mt-12 text-center">
-                    <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/vibe-coding" class="inline-flex items-center gap-2 bg-accent text-white font-semibold px-6 py-3 rounded-lg hover:bg-accentDark transition-colors">
+                    <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/vibe-coding" class="inline-flex items-center gap-2 bg-accent text-white font-semibold px-6 py-3 rounded-lg hover:bg-accentDark transition-colors">
                         <i data-lucide="github" class="w-5 h-5"></i>
                         View full skill on GitHub
                     </a>

--- a/docs/visual-explainer/index.html
+++ b/docs/visual-explainer/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Generate self-contained HTML pages that visually explain systems, data stories, investigations, editorial workflows, and code changes. Use when the user asks for a diagram, architecture overview, diff review, plan review, project recap, source map, comparison table, timeline, or any visual explanation of technical or editorial concepts. Also use proactively when about to render a complex ASCII table (4+ rows or 3+ columns) — present it as a styled HTML page instead. Adapted from nicobailon/visual-explainer with journalism, newsroom, and academic design sensibilities.">
     <title>Visual explainer - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Visual explainer - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Generate self-contained HTML pages that visually explain systems, data stories, investigations, editorial workflows, and code changes. Use when the user asks for a diagram, architecture overview, diff review, plan review, project recap, source map, comparison table, timeline, or any visual explanation of technical or editorial concepts. Also use proactively when about to render a complex ASCII table (4+ rows or 3+ columns) — present it as a styled HTML page instead. Adapted from nicobailon/visual-explainer with journalism, newsroom, and academic design sensibilities.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/visual-explainer/">
     <meta property="og:image" content="https://skills.amditis.tech/visual-explainer/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Visual explainer - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Generate self-contained HTML pages that visually explain systems, data stories, investigations, editorial workflows, and code changes. Use when the user asks for a diagram, architecture overview, diff review, plan review, project recap, source map, comparison table, timeline, or any visual explanation of technical or editorial concepts. Also use proactively when about to render a complex ASCII table (4+ rows or 3+ columns) — present it as a styled HTML page instead. Adapted from nicobailon/visual-explainer with journalism, newsroom, and academic design sensibilities.">
     <meta name="twitter:image" content="https://skills.amditis.tech/visual-explainer/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -178,7 +179,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Visual explainer</h1>
             <p class="text-xl text-white/90 max-w-2xl">
-                Turn complex data and systems into styled HTML pages with diagrams, data tables, flowcharts, timelines, and dashboards.
+                Generate self-contained HTML pages that visually explain systems, data stories, investigations, editorial workflows, and code changes. Adapted from nicobailon/visual-explainer with journalism design sensibilities.
             </p>
         </div>
     </header>
@@ -380,13 +381,15 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
+                <p class="text-white/50 mb-2"># Recommended: install the visual-explainer plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install visual-explainer@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
                 <p class="text-white">cp -r claude-skills-journalism/visual-explainer ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
+                Or browse this skill in the
                 <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/visual-explainer" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>

--- a/docs/web-archiving/index.html
+++ b/docs/web-archiving/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Web page archiving and retrieval from cached/deleted sources. Use when accessing unavailable pages, preserving web content, creating legal evidence archives, or building redundant archival workflows. Covers Wayback Machine, Archive.today, ArchiveBox, and evidence preservation tools.">
     <title>Web archiving - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Web archiving - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Web page archiving and retrieval from cached/deleted sources. Use when accessing unavailable pages, preserving web content, creating legal evidence archives, or building redundant archival workflows. Covers Wayback Machine, Archive.today, ArchiveBox, and evidence preservation tools.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/web-archiving/">
     <meta property="og:image" content="https://skills.amditis.tech/web-archiving/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Web archiving - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Web page archiving and retrieval from cached/deleted sources. Use when accessing unavailable pages, preserving web content, creating legal evidence archives, or building redundant archival workflows. Covers Wayback Machine, Archive.today, ArchiveBox, and evidence preservation tools.">
     <meta name="twitter:image" content="https://skills.amditis.tech/web-archiving/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -344,14 +345,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/web-archiving ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the research-toolkit plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install research-toolkit@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/research-toolkit/skills/web-archiving ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/web-archiving" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/research-toolkit/skills/web-archiving" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -372,7 +375,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     Wayback Machine API, multi-archive redundancy, and legal evidence preservation in one skill.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/web-archiving" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/research-toolkit/skills/web-archiving" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/web-scraping/index.html
+++ b/docs/web-scraping/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Web scraping with anti-bot bypass, content extraction, undocumented APIs and poison pill detection. Use when extracting content from websites, handling paywalls, implementing scraping cascades or processing social media. Covers requests, trafilatura, Playwright with stealth mode, yt-dlp and instaloader patterns.">
     <title>Web scraping - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Web scraping - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Web scraping with anti-bot bypass, content extraction, undocumented APIs and poison pill detection. Use when extracting content from websites, handling paywalls, implementing scraping cascades or processing social media. Covers requests, trafilatura, Playwright with stealth mode, yt-dlp and instaloader patterns.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/web-scraping/">
     <meta property="og:image" content="https://skills.amditis.tech/web-scraping/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Web scraping - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Web scraping with anti-bot bypass, content extraction, undocumented APIs and poison pill detection. Use when extracting content from websites, handling paywalls, implementing scraping cascades or processing social media. Covers requests, trafilatura, Playwright with stealth mode, yt-dlp and instaloader patterns.">
     <meta name="twitter:image" content="https://skills.amditis.tech/web-scraping/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -320,14 +321,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/web-scraping ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the dev-toolkit plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install dev-toolkit@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/dev-toolkit/skills/web-scraping ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/web-scraping" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/web-scraping" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -348,7 +351,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     Cascade architecture, poison pill detection, and social media tools in one skill.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/web-scraping" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/web-scraping" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/web-ui-best-practices/index.html
+++ b/docs/web-ui-best-practices/index.html
@@ -717,16 +717,18 @@ useEffect(() => {
                 <div>
                     <h3 class="font-semibold mb-3">Install the skill</h3>
                     <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                        <p class="text-white/50 mb-2"># Clone the repository</p>
-                        <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                        <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                        <p class="text-white">cp -r claude-skills-journalism/web-ui-best-practices ~/.claude/skills/</p>
+                        <p class="text-white/50 mb-2"># Recommended: install the dev-toolkit plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install dev-toolkit@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/dev-toolkit/skills/web-ui-best-practices ~/.claude/skills/</p>
                     </div>
                 </div>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/web-ui-best-practices" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/web-ui-best-practices" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -748,7 +750,7 @@ useEffect(() => {
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     18 principles. Zero tolerance for dark patterns. Every interaction under 100ms.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/web-ui-best-practices" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/web-ui-best-practices" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>

--- a/docs/web-ui-best-practices/index.html
+++ b/docs/web-ui-best-practices/index.html
@@ -718,11 +718,11 @@ useEffect(() => {
                     <h3 class="font-semibold mb-3">Install the skill</h3>
                     <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
                         <p class="text-white/50 mb-2"># Recommended: install the dev-toolkit plugin</p>
-                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
-                <p class="text-white mb-4">/plugin install dev-toolkit@claude-skills-journalism</p>
-                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
-                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white">cp -r claude-skills-journalism/dev-toolkit/skills/web-ui-best-practices ~/.claude/skills/</p>
+                        <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                        <p class="text-white mb-4">/plugin install dev-toolkit@claude-skills-journalism</p>
+                        <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                        <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                        <p class="text-white">cp -r claude-skills-journalism/dev-toolkit/skills/web-ui-best-practices ~/.claude/skills/</p>
                     </div>
                 </div>
             </div>

--- a/docs/zero-build-frontend/index.html
+++ b/docs/zero-build-frontend/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Zero-build frontend development with CDN-loaded React, Tailwind CSS, and vanilla JavaScript. Use when building static web apps without bundlers, creating Leaflet maps, integrating Google Sheets as database, or developing browser extensions. Covers patterns from rosen-frontend, NJCIC map, and PocketLink projects.">
     <title>Zero-build frontend - Claude skills for journalism</title>
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -131,7 +132,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Zero-build frontend - Claude skills for journalism">
-    <meta property="og:description" content="# Clone the repository">
+    <meta property="og:description" content="Zero-build frontend development with CDN-loaded React, Tailwind CSS, and vanilla JavaScript. Use when building static web apps without bundlers, creating Leaflet maps, integrating Google Sheets as database, or developing browser extensions. Covers patterns from rosen-frontend, NJCIC map, and PocketLink projects.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/zero-build-frontend/">
     <meta property="og:image" content="https://skills.amditis.tech/zero-build-frontend/og-image.png">
@@ -141,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Zero-build frontend - Claude skills for journalism">
-    <meta name="twitter:description" content="# Clone the repository">
+    <meta name="twitter:description" content="Zero-build frontend development with CDN-loaded React, Tailwind CSS, and vanilla JavaScript. Use when building static web apps without bundlers, creating Leaflet maps, integrating Google Sheets as database, or developing browser extensions. Covers patterns from rosen-frontend, NJCIC map, and PocketLink projects.">
     <meta name="twitter:image" content="https://skills.amditis.tech/zero-build-frontend/og-image.png">
 <script src="../ask-ai.js" defer></script>
     <!-- a11y-patch-v1 -->
@@ -323,14 +324,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Installation</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># Clone the repository</p>
-                <p class="text-white mb-4">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
-                <p class="text-white/50 mb-2"># Copy the skill to your Claude config</p>
-                <p class="text-white">cp -r claude-skills-journalism/zero-build-frontend ~/.claude/skills/</p>
+                <p class="text-white/50 mb-2"># Recommended: install the dev-toolkit plugin</p>
+                <p class="text-white mb-1">/plugin marketplace add jamditis/claude-skills-journalism</p>
+                <p class="text-white mb-4">/plugin install dev-toolkit@claude-skills-journalism</p>
+                <p class="text-white/50 mb-2"># Or copy just this skill from the plugin tree</p>
+                <p class="text-white mb-1">git clone https://github.com/jamditis/claude-skills-journalism.git</p>
+                <p class="text-white">cp -r claude-skills-journalism/dev-toolkit/skills/zero-build-frontend ~/.claude/skills/</p>
             </div>
             <p class="mt-4 text-clay/70 text-sm">
-                Or download just this skill from the
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/zero-build-frontend" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+                Or browse this skill in the
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/zero-build-frontend" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
             </p>
         </section>
 
@@ -350,7 +353,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
                     CDN-loaded React, Leaflet maps, Google Sheets data, and browser extensions in one skill.
                 </p>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/zero-build-frontend" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
+                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/zero-build-frontend" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub
                     <svg aria-hidden="true" focusable="false" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>


### PR DESCRIPTION
## Summary

After Phase 6 bundled every skill into a plugin, the per-skill landing pages under `docs/` still pointed at bare paths that 404. The page-generator template also left most pages without `<meta name="description">` and carried placeholder `og:description` / `twitter:description` values (most commonly `"# Clone the repository"` — the first line of the install snippet).

This sweeps all three drift classes in one diff.

## What changed

**Install snippets (tier 2).** 36 skill pages plus one inline catalog example now use the plugin-install recommendation with a plugin-nested bare path as the alternate. Same shape Copilot flagged on `free-apis-catalog` in PR #69, now applied uniformly. View-on-GitHub CTA links rewritten in the same pass — `tree/master/<bare>` → `tree/master/<plugin>/skills/<bare>` for bundled skills; plugin-level pages (`pdf-design`, `visual-explainer`) keep `tree/master/<plugin>`.

**Meta descriptions (tier 3).** 30 pages get a real `<meta name="description">` + matching `og:description` + `twitter:description`, all sourced from each `SKILL.md`'s frontmatter `description:` field. About page got a hand-written description because it has no SKILL.md source.

**Lead paragraphs (tier 3, content drift).** Five Phase 5/6 sweep targets had hero leads that predated their content rewrites:
- `security-checklist` — now references OWASP Top 10:2025
- `secure-auth` — now references NIST SP 800-63B-4 / OWASP 2026 / OAuth 2.1 / WebAuthn L3
- `api-hardening` — now references OWASP API Security Top 10:2023
- `visual-explainer` — now reflects post-v0.7.1 backport breadth (investigations, editorial workflows, code changes)
- `project-memory` — "institutional knowledge" instead of "tribal knowledge" to match the SKILL.md description (SKILL.md body still says "tribal" — separate inconsistency that should get its own follow-up)

## Verification

- Every `docs/*/index.html` now has exactly one `<meta name="description">`, one `og:description`, and one `twitter:description`, all carrying identical content.
- No remaining bare-path `cp -r` install snippets anywhere under `docs/`.
- Every `tree/master/<slug>` URL now resolves to a path that actually exists in the repo.
- `<head>`, `<body>`, and `<section>` tag balance preserved on every touched file.

## Out of scope (filed as follow-up if needed)

`project-memory/SKILL.md` body still says "tribal knowledge" while its description says "institutional knowledge" — that's a SKILL.md-internal inconsistency, separate from docs drift.