### PR TITLE
v2.0.0: finalize project-memory language + bundling milestone

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-skills-journalism",
-  "version": "1.8.0",
+  "version": "2.0.0",
   "description": "Claude Code plugins for journalism, research, and media organizations",
   "owner": {
     "name": "Joe Amditis",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-05-11
+
+The bundling milestone: every skill in the repo now lives inside a registered plugin, so the marketplace install path is the only first-class install path. Headline numbers: 10 plugins registered (was 4 at v1.9.0), zero bare skill directories at the repo root, marketplace manifest version bumped 1.8.0 → 2.0.0 to signal the breaking layout change.
+
+### Breaking
+
+- **Bare-path skill installs no longer work.** Every skill moved from `<repo>/<skill>/` to `<repo>/<plugin>/skills/<skill>/` across Phases 1-6 (PRs #60-#69). Anyone scripting `cp -r ~/projects/claude-skills-journalism/<skill> ~/.claude/skills/` against the old paths will get "no such file." Updated install paths are documented on each `docs/<skill>/index.html` landing page (PR #71) and in the top-level README. Recommended fix: switch to `/plugin install <plugin>@claude-skills-journalism`.
+- **Two skills removed (#65)**: `animated-sprite-gen` and `nano-banana-image-gen`. Off-theme for a journalism-skills repo; never bundled into a plugin. No replacement.
+
+### Added
+
+- **journalism-core plugin v1.1.0 (#60, #61)**: 13 skills — `ai-writing-detox`, `crisis-communications`, `data-journalism`, `editorial-workflow`, `fact-check-workflow`, `foia-requests`, `interview-prep`, `interview-transcription`, `newsletter-publishing`, `newsroom-style`, `social-media-intelligence`, `source-verification`, `story-pitch`. Phase 2 (#61) absorbed `data-journalism` and `social-media-intelligence` from the bare-skill set.
+- **research-toolkit plugin v1.1.0 (#62, #69)**: 6 skills — `academic-writing`, `content-access`, `digital-archive`, `free-apis-catalog`, `page-monitoring`, `web-archiving`. v1.1.0 (#69) absorbed `free-apis-catalog` from the bare-skill set.
+- **dev-toolkit plugin v1.0.0 (#63)**: 10 skills — `accessibility-compliance`, `electron-dev`, `mobile-debugging`, `one-way-door`, `python-pipeline`, `test-first-bugs`, `vibe-coding`, `web-scraping`, `web-ui-best-practices`, `zero-build-frontend`.
+- **security-toolkit plugin v1.0.0 (#64)**: 3 skills — `api-hardening`, `secure-auth`, `security-checklist`. Includes 2026 currency sweep aligned to OWASP Top 10:2025, NIST SP 800-63B-4, OAuth 2.1, WebAuthn L3.
+- **project-templates-toolkit plugin v1.0.0 (#68)**: 3 skills — `project-memory`, `project-retrospective`, `template-selector`.
+- **visual-explainer plugin (#68 registration)**: registered in marketplace.json alongside the v0.7.1 backport (#66) that pulled in the upstream nicobailon/visual-explainer fork while preserving journalism overlays.
+
+### Changed
+
+- **Currency sweeps across multiple skills** (Phase 3 #62, Phase 5 #64, Phase 6c #67): updated `data-journalism`, `social-media-intelligence`, `source-verification`, `web-archiving`, `page-monitoring`, `api-hardening`, `secure-auth`, `security-checklist`, `project-memory`, `project-retrospective`, `free-apis-catalog` against authoritative 2026 sources (NIST, IETF, W3C, OWASP, vendor docs, CVE DBs).
+- **visual-explainer backported v0.1.0 → upstream v0.7.1 (#66)**: pulled in the upstream nicobailon/visual-explainer fork at v0.7.1, preserved the journalism-specific palette and design sensibilities as overlays.
+- **Docs site sweep (#71)**: 36 landing pages updated for the bundling reorg — install snippets switched from `cp -r <skill>` to the plugin-install pattern with the new plugin-nested bare path as a fallback. 41 GitHub tree links rewritten to the new paths. 28 pages got real `<meta name="description">` tags sourced from each SKILL.md frontmatter (previously many had placeholder OG descriptions like "A Claude Code skill for X"). 5 pages had lead-paragraph drift fixed against their SKILL.md.
+- **project-memory: "tribal knowledge" → "institutional knowledge" (this release)**: SKILL.md body lines 8 and 140, plus `docs/project-memory/index.html` lines 237 and 381, now match the canonical phrasing from the SKILL.md frontmatter description (which already said "institutional knowledge" after Phase 6c). Closes the last drift loose-thread from PR #71.
+
+### Fixed
+
+- **Indentation drift on 2 docs pages (#71)**: install-snippet bulk fixer hardcoded a 16-space leading indent, which broke on `web-ui-best-practices/index.html` and `one-way-door/index.html` where the install block sits inside an Option-1/Option-2 wrapper at 24-space context. Surgically re-indented both before PR #71 merged.
+
 ## [1.9.0] - 2026-05-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ The bundling milestone: every skill in the repo now lives inside a registered pl
 - **Currency sweeps across multiple skills** (Phase 3 #62, Phase 5 #64, Phase 6c #67): updated `data-journalism`, `social-media-intelligence`, `source-verification`, `web-archiving`, `page-monitoring`, `api-hardening`, `secure-auth`, `security-checklist`, `project-memory`, `project-retrospective`, `free-apis-catalog` against authoritative 2026 sources (NIST, IETF, W3C, OWASP, vendor docs, CVE DBs).
 - **visual-explainer backported v0.1.0 → upstream v0.7.1 (#66)**: pulled in the upstream nicobailon/visual-explainer fork at v0.7.1, preserved the journalism-specific palette and design sensibilities as overlays.
 - **Docs site sweep (#71)**: 36 landing pages updated for the bundling reorg — install snippets switched from `cp -r <skill>` to the plugin-install pattern with the new plugin-nested bare path as a fallback. 41 GitHub tree links rewritten to the new paths. 28 pages got real `<meta name="description">` tags sourced from each SKILL.md frontmatter (previously many had placeholder OG descriptions like "A Claude Code skill for X"). 5 pages had lead-paragraph drift fixed against their SKILL.md.
-- **project-memory: "tribal knowledge" → "institutional knowledge" (this release)**: SKILL.md body lines 8 and 140, plus `docs/project-memory/index.html` lines 237 and 381, now match the canonical phrasing from the SKILL.md frontmatter description (which already said "institutional knowledge" after Phase 6c). Closes the last drift loose-thread from PR #71.
+- **project-memory language drift fix (this release)**: SKILL.md body lines 8 and 140, plus `docs/project-memory/index.html` lines 237 and 381, now consistently use "institutional knowledge" — matching the canonical phrasing from the SKILL.md frontmatter description (which already used that phrasing after Phase 6c). Closes the last drift loose-thread from PR #71.
 
 ### Fixed
 
@@ -444,6 +444,17 @@ Initial commit with foundational skills.
 
 ---
 
+[2.0.0]: https://github.com/jamditis/claude-skills-journalism/compare/v1.9.0...v2.0.0
+[1.9.0]: https://github.com/jamditis/claude-skills-journalism/compare/v1.8.0...v1.9.0
+[1.8.0]: https://github.com/jamditis/claude-skills-journalism/compare/v1.7.0...v1.8.0
+[1.7.0]: https://github.com/jamditis/claude-skills-journalism/compare/v1.6.2...v1.7.0
+[1.6.2]: https://github.com/jamditis/claude-skills-journalism/compare/v1.6.1...v1.6.2
+[1.6.1]: https://github.com/jamditis/claude-skills-journalism/compare/v1.6.0...v1.6.1
+[1.6.0]: https://github.com/jamditis/claude-skills-journalism/compare/v1.5.1...v1.6.0
+[1.5.1]: https://github.com/jamditis/claude-skills-journalism/compare/v1.5.0...v1.5.1
+[1.5.0]: https://github.com/jamditis/claude-skills-journalism/compare/v1.4.1...v1.5.0
+[1.4.1]: https://github.com/jamditis/claude-skills-journalism/compare/v1.4.0...v1.4.1
+[1.4.0]: https://github.com/jamditis/claude-skills-journalism/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/jamditis/claude-skills-journalism/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/jamditis/claude-skills-journalism/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/jamditis/claude-skills-journalism/compare/v1.1.0...v1.1.1

--- a/docs/project-memory/index.html
+++ b/docs/project-memory/index.html
@@ -234,7 +234,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 </div>
                 <div class="bg-white rounded-xl p-5 border border-mist/30">
                     <h3 class="font-semibold mb-2">Good vs. bad examples</h3>
-                    <p class="text-sm text-clay/70">Side-by-side comparisons of verbose documentation vs. tribal knowledge only.</p>
+                    <p class="text-sm text-clay/70">Side-by-side comparisons of verbose documentation vs. institutional knowledge only.</p>
                 </div>
             </div>
         </section>
@@ -378,7 +378,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <div class="bg-gradient-to-br from-accent to-accentDark rounded-xl p-8 text-white">
                 <h2 class="font-display text-xl font-bold mb-3">Document what matters</h2>
                 <p class="text-white/80 mb-6 max-w-lg mx-auto text-sm">
-                    Templates for tribal knowledge, not generic documentation.
+                    Templates for institutional knowledge, not generic documentation.
                 </p>
                 <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/project-templates-toolkit/skills/project-memory" target="_blank" class="inline-flex items-center gap-2 bg-white text-accentDark px-5 py-2.5 rounded-full font-semibold text-sm hover:bg-white/95 transition-colors" rel="noopener noreferrer">
                     View on GitHub

--- a/project-templates-toolkit/skills/project-memory/SKILL.md
+++ b/project-templates-toolkit/skills/project-memory/SKILL.md
@@ -5,7 +5,7 @@ description: Generate CLAUDE.md project memory files that transfer institutional
 
 # Project memory generator
 
-Create CLAUDE.md files that transfer tribal knowledge, not obvious information. Think like a senior journalist onboarding a competent colleague — you don't explain how journalism works, you explain YOUR project's quirks.
+Create CLAUDE.md files that transfer institutional knowledge, not obvious information. Think like a senior journalist onboarding a competent colleague — you don't explain how journalism works, you explain YOUR project's quirks.
 
 ## CLAUDE.md is advisory, not enforced
 
@@ -137,7 +137,7 @@ npm install
 npm start
 ```
 
-**Good (tribal knowledge only):**
+**Good (institutional knowledge only):**
 ```markdown
 # CLAUDE.md
 


### PR DESCRIPTION
## Summary

Major version cut for the bundling milestone. Two things land together:

1. **Final project-memory language fix.** The SKILL.md frontmatter `description:` and the docs page lead/meta both said "institutional knowledge" after Phase 6c. But the SKILL.md body (lines 8 + 140) and the docs page (lines 237 + 381) still said "tribal knowledge." Closes the last loose thread from PR #71.
2. **Marketplace.json 1.8.0 → 2.0.0.** Signals the breaking layout change: every skill now lives inside a registered plugin, and bare-path installs no longer resolve.

## Why a major bump

Two things broke for existing users:
- Anyone scripting `cp -r ~/projects/claude-skills-journalism/<skill> ~/.claude/skills/` against the old paths gets "no such file" — every skill moved from `<repo>/<skill>/` to `<repo>/<plugin>/skills/<skill>/` across PRs #60-#69.
- Two skills removed entirely (#65): `animated-sprite-gen` and `nano-banana-image-gen`.

The recommended `/plugin install <plugin>@claude-skills-journalism` path was never broken — the marketplace surface is stable. But the secondary install path documented in every landing page changed, which is enough to warrant the major.

## Scope since v1.9.0

- **6 plugin packages registered**: journalism-core (#60, #61), research-toolkit (#62, #69), dev-toolkit (#63), security-toolkit (#64), project-templates-toolkit (#68), visual-explainer (#68 registration after #66 backport)
- **2 skills removed**: animated-sprite-gen, nano-banana-image-gen (#65)
- **Currency sweeps** across data/security/research/project skills (#62, #64, #67)
- **visual-explainer backport** v0.1.0 → upstream v0.7.1 (#66)
- **Docs sweep across 36 landing pages** (#71): install snippets, GitHub tree links, meta descriptions, 5 lead-paragraph drift fixes
- **This PR**: final project-memory language fix + v2.0.0 cut

## Test plan

- [ ] Confirm zero remaining "tribal" references in repo (already verified — `grep -rn tribal` returns nothing in .md/.html files)
- [ ] Confirm marketplace.json validates as JSON
- [ ] After merge: tag v2.0.0 + cut GitHub release pointing at the new CHANGELOG entry