### PR TITLE
docs: bring README and landing page counts current after PRs #77, #80, #84

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A curated collection of Claude Code skills designed for journalists, researchers, academics, media professionals, and communications practitioners.
 
-**Docs site:** [jamditis.github.io/claude-skills-journalism](https://jamditis.github.io/claude-skills-journalism/) — interactive skill browser, setup guides, and full documentation.
+**Docs site:** [skills.amditis.tech](https://skills.amditis.tech) — interactive skill browser, setup guides, and full documentation.
 
 ## Guides
 
@@ -10,7 +10,7 @@ Setup and workflow guides, separate from the skills themselves:
 
 | Guide | Description |
 |-------|-------------|
-| [Persistent sessions](https://jamditis.github.io/claude-skills-journalism/persistent-sessions/) | Keep Claude Code sessions alive through disconnects using tmux — setup, key bindings, activity notifications, and scheduler coexistence |
+| [Persistent sessions](https://skills.amditis.tech/persistent-sessions/) | Keep Claude Code sessions alive through disconnects using tmux — setup, key bindings, activity notifications, and scheduler coexistence |
 
 ## What are Claude skills?
 
@@ -42,7 +42,7 @@ Then restart Claude Code (close and reopen). See the [PDF Playground README](./p
 | [pdf-playground](./pdf-playground/) | Create branded proposals, reports, one-pagers, newsletters, slides, and event materials with an interactive control panel for live design editing (colors, fonts, spacing, sections) and a guided wizard for proposals | `/pdf-playground:proposal`, `/pdf-playground:report`, `/pdf-playground:onepager`, `/pdf-playground:newsletter`, `/pdf-playground:slides`, `/pdf-playground:event`, `/pdf-playground:preview` |
 | [project-templates-toolkit](./project-templates-toolkit/) | Three skills for setting up and closing out journalism projects: a CLAUDE.md project-memory writer (institutional knowledge), a LESSONS.md retrospective writer (failures and decisions), and a template-selector decision tree across 6 project types | n/a — skills only |
 | [research-toolkit](./research-toolkit/) | Six skills for research, source preservation, and academic workflows: academic writing, legal paywall-bypass via Unpaywall and library databases, web archiving (Wayback / Archive.today / ArchiveBox), web page change monitoring, AI-enriched digital archive construction, and a curated free-API catalog with sunset currency notes (IEX Cloud, CrowdTangle, ProPublica Congress, X, Reddit) | n/a — skills only |
-| [security-toolkit](./security-toolkit/) | Three defensive web application security skills covering OWASP Top 10 fundamentals: pre-deployment audit checklists (auth, input validation, secrets management), secure authentication implementation patterns (password hashing, session management, JWT, OAuth, passkeys), and API hardening (rate limiting, CORS, request throttling, defense-in-depth for Express, FastAPI, and serverless) | n/a — skills only |
+| [security-toolkit](./security-toolkit/) | Four defensive security skills covering OWASP Top 10 fundamentals and supply-chain hardening: pre-deployment audit checklists (auth, input validation, secrets management), secure authentication patterns (password hashing, session management, JWT, OAuth, passkeys), API hardening (rate limiting, CORS, request throttling, defense-in-depth for Express, FastAPI, and serverless), and npm/bun supply-chain hardening with install-time cooldown plus a sandboxed pre-install scan for the bypass case (defends against Mini Shai-Hulud-class worms) | `/security-toolkit:hotpatch` |
 | [superjawn](./superjawn/) | Research-augmented fork of obra/superpowers. Default-on research phase fires before brainstorming, systematic-debugging, and writing-skills. v1.0.0 ships all 14 skills with no soft dependencies on the upstream `superpowers` plugin | invoked indirectly via skills (e.g. `superjawn:brainstorming`, `superjawn:systematic-debugging`, `superjawn:writing-plans`) |
 | [visual-explainer](./visual-explainer/) | HTML diagrams, data tables, architecture views, slide decks, and KPI dashboards adapted from nicobailon/visual-explainer with journalism, newsroom, and academic design sensibilities | `/visual-explainer:project-recap` |
 
@@ -144,13 +144,14 @@ These ten skills ship together as the [dev-toolkit](./dev-toolkit/) plugin. Inst
 
 ### Security skills (in `security-toolkit` plugin)
 
-These three skills ship together as the [security-toolkit](./security-toolkit/) plugin. Install via `/plugin install security-toolkit@claude-skills-journalism` to get all of them at once.
+These four skills ship together as the [security-toolkit](./security-toolkit/) plugin, paired with the `/security-toolkit:hotpatch` slash command. Install via `/plugin install security-toolkit@claude-skills-journalism` to get all of them at once.
 
 | Skill | Description |
 |-------|-------------|
 | [api-hardening](./security-toolkit/skills/api-hardening/) | Rate limiting, input validation, CORS, security headers, API key management, defense-in-depth for Express, FastAPI, and serverless |
 | [secure-auth](./security-toolkit/skills/secure-auth/) | Production-ready authentication patterns: password hashing, session management, JWT, OAuth, passkeys / WebAuthn, MFA |
 | [security-checklist](./security-toolkit/skills/security-checklist/) | Pre-deployment security audit covering OWASP Top 10 fundamentals: authentication, input validation, secrets, database security, compliance basics |
+| [supply-chain-hardening](./security-toolkit/skills/supply-chain-hardening/) | npm/bun install-time cooldown plus sandboxed pre-install scan (bwrap on Linux, sandbox-exec on macOS). Defends against Mini Shai-Hulud-class worms; paired with `/security-toolkit:hotpatch` for the cooldown-bypass case |
 
 ## Hooks
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -260,7 +260,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Claude skills for journalism">
-    <meta property="og:description" content="39 skills and 14 hooks for journalists, researchers, academics, and media professionals.">
+    <meta property="og:description" content="53 skills and 14 hooks for journalists, researchers, academics, and media professionals.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/">
     <meta property="og:image" content="https://skills.amditis.tech/og-image.png">
@@ -270,7 +270,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Claude skills for journalism">
-    <meta name="twitter:description" content="39 skills and 14 hooks for journalists, researchers, academics, and media professionals.">
+    <meta name="twitter:description" content="53 skills and 14 hooks for journalists, researchers, academics, and media professionals.">
     <meta name="twitter:image" content="https://skills.amditis.tech/og-image.png">
 <script src="ask-ai.js" defer></script>
 
@@ -280,7 +280,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
   "@context": "https://schema.org",
   "@type": "SoftwareSourceCode",
   "name": "Claude skills for journalism",
-  "description": "39 Claude Code skills and 14 workflow hooks for verification, FOIA, data journalism, academic writing, and more. Built for journalists, researchers, and media professionals.",
+  "description": "53 Claude Code skills and 14 workflow hooks for verification, FOIA, data journalism, academic writing, and more. Built for journalists, researchers, and media professionals.",
   "url": "https://skills.amditis.tech",
   "codeRepository": "https://github.com/jamditis/claude-skills-journalism",
   "programmingLanguage": "Markdown",
@@ -335,7 +335,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <!-- Hero -->
             <header class="mb-32 md:mb-44 animate-page-in">
                 <div class="inline-block px-4 py-1 border border-ink/10 mb-6">
-                    <span class="text-[9px] font-bold tracking-[0.4em] uppercase opacity-50">39 Skills // 4 Plugins // 14 Hooks</span>
+                    <span class="text-[9px] font-bold tracking-[0.4em] uppercase opacity-50">53 Skills // 10 Plugins // 14 Hooks</span>
                 </div>
                 <h1 class="font-display fluid-title text-[11vw] md:text-[8.5vw] font-light leading-[0.85] tracking-tight mb-12 text-ink">
                     Skills for <br> <span class="italic font-black">journalism.</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -386,7 +386,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <section id="skills" class="reveal-section mb-32">
                 <div class="section-header flex flex-col md:flex-row md:items-end justify-between gap-4" style="border-bottom: 2px solid rgba(61, 75, 64, 0.2); background: linear-gradient(90deg, rgba(61, 75, 64, 0.04) 0%, transparent 100%); padding: 1rem; margin-bottom: 2rem;">
                     <h2 class="font-display text-4xl font-light italic">01 / Plugins</h2>
-                    <span class="section-label">4 Plugins</span>
+                    <span class="section-label">10 Plugins</span>
                 </div>
 
                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">


### PR DESCRIPTION
## Summary

PRs #80 and #84 shipped the supply-chain-hardening docs page and the cross-platform sandbox port, but the surrounding marketing surface still reflected pre-supply-chain counts and the pre-canonical GitHub Pages URL. This PR walks that surface area.

### README.md

- Lines 5, 13: \`jamditis.github.io/claude-skills-journalism\` → \`skills.amditis.tech\` (matches PR #80's robots.txt fix).
- Line 45: security-toolkit description row now reads "Four defensive security skills covering OWASP Top 10 fundamentals and supply-chain hardening..." and surfaces \`/security-toolkit:hotpatch\` in the commands column (was "n/a — skills only").
- Lines 147 + new row 154: "These three skills ship together" → "These four skills ship together... paired with the \`/security-toolkit:hotpatch\` slash command." Added supply-chain-hardening row to the Security skills table.

### docs/index.html

- Lines 263 (\`og:description\`), 273 (\`twitter:description\`), 283 (JSON-LD schema description): "39 skills" → "53 skills" / "39 Claude Code skills" → "53 Claude Code skills". Brings social-card previews and structured data in line with the actual count in \`docs/llms.txt\`.
- Line 338 visible hero badge: "39 Skills // 4 Plugins // 14 Hooks" → "53 Skills // 10 Plugins // 14 Hooks". Plugin count was also stale — \`marketplace.json\` lists 10.

## Test plan

- [ ] Pages deploy succeeds.
- [ ] Live landing page at skills.amditis.tech shows "53 Skills // 10 Plugins // 14 Hooks" in the hero strip.
- [ ] Live page source shows the new og:description and twitter:description.
- [ ] \`view-source:skills.amditis.tech\` JSON-LD block reflects "53 Claude Code skills."