### PR TITLE
docs: add npx skills CLI install section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,24 @@ Then restart Claude Code (close and reopen). See the [PDF Playground README](./p
 | [superjawn](./superjawn/) | Research-augmented fork of obra/superpowers. Default-on research phase fires before brainstorming, systematic-debugging, and writing-skills. v1.0.0 ships all 14 skills with no soft dependencies on the upstream `superpowers` plugin | invoked indirectly via skills (e.g. `superjawn:brainstorming`, `superjawn:systematic-debugging`, `superjawn:writing-plans`) |
 | [visual-explainer](./visual-explainer/) | HTML diagrams, data tables, architecture views, slide decks, and KPI dashboards adapted from nicobailon/visual-explainer with journalism, newsroom, and academic design sensibilities | `/visual-explainer:project-recap` |
 
+### Install via npx (skills CLI)
+
+Requires [Node.js](https://nodejs.org/) (ships with `npx`). To drop the `npx` prefix, install the CLI globally once: `npm i -g skills`. `cd` into the project folder where you want the skills installed before running.
+
+```bash
+# Pick which skills to install into the current project (interactive)
+npx skills add jamditis/claude-skills-journalism
+
+# Pick from one plugin (replace journalism-core with any plugin name above)
+npx skills add jamditis/claude-skills-journalism/journalism-core
+
+# Install all skills into the current project
+npx skills add jamditis/claude-skills-journalism --all
+
+# Install all skills globally (user-level, available across all projects)
+npx skills add jamditis/claude-skills-journalism --all -g
+```
+
 ### Skills (manual installation)
 
 Every skill in this repo now lives inside a plugin's `skills/` directory. To install just one without taking the whole plugin, clone the repo and copy or symlink the nested skill folder. Claude Code discovers skills at `~/.claude/skills/<skill-name>/SKILL.md` — one level deep:


### PR DESCRIPTION
Documents the existing vercel-labs/skills CLI install path against this repo, mirroring the per-plugin marketplace structure. Four commands cover:
- interactive selection across all 53 skills
- interactive selection inside one plugin (via GitHub subpath)
- non-interactive install of everything into the current project
- non-interactive install globally (user-level)

No code changes; the existing repo layout (`<plugin>/skills/<name>/SKILL.md`) already matches what `npx skills add` expects.

## What does this PR do?

<!-- Brief description of the change -->

## Type of change

- [ ] New skill
- [ ] New hook
- [ ] Plugin update
- [ ] Bug fix
- [x] Documentation
- [ ] Other (describe below)

## Checklist

- [x] `SKILL.md` has valid frontmatter (`name` and `description`)
- [x] Skill directory follows the standard structure (`SKILL.md`, optional `templates/`, `examples/`, `scripts/`)
- [x] Tested with Claude Code locally -- Verified `npx skills add [username]/claude-skills-journalism[/<plugin>] --list` resolves the expected counts (journalism-core: 13, security-toolkit: 4, full repo: 53)
- [x] README.md updated (if adding a new skill/hook) -- This PR is the README update
- [ ] CHANGELOG.md updated -- Left CHANGELOG.md alone since this is a docs-only addition

## For new skills

- [ ] Includes actionable workflows, not just reference info
- [ ] Provides templates where applicable
- [ ] Cites sources for verification methods and standards
- [ ] Targets journalism, media, communications, or academic use cases

## Notes

CHANGELOG.md update recommendation: 

under "Added" in the next release block, something like 
- "README "Install via npx (skills CLI)" section — documents the vercel-labs/skills CLI install path with GitHub subpath syntax."
