### PR TITLE
Harden external links across all docs pages

### DIFF
--- a/docs/autocontext/index.html
+++ b/docs/autocontext/index.html
@@ -148,7 +148,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <nav aria-label="Primary" class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-ink/5">
         <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
             <a href="../" class="text-sm font-medium text-mist hover:text-ink transition-colors">&#8592; Back to all skills</a>
-            <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/autocontext" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">View on GitHub &#8594;</a>
+            <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism/tree/master/autocontext" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">View on GitHub &#8594;</a>
         </div>
     </nav>
 
@@ -504,7 +504,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section id="install" class="py-24 px-6">
             <div class="max-w-4xl mx-auto reveal">
                 <h2 class="font-display text-4xl md:text-5xl font-light italic text-center mb-6">Get started</h2>
-                <p class="text-center text-mist text-lg mb-16 max-w-2xl mx-auto">You need <strong><a href="https://docs.anthropic.com/en/docs/claude-code/overview" class="text-accentDark hover:underline">Claude Code</a></strong> installed. Open your terminal and run <code>claude --version</code> to check.</p>
+                <p class="text-center text-mist text-lg mb-16 max-w-2xl mx-auto">You need <strong><a target="_blank" rel="noopener noreferrer" href="https://docs.anthropic.com/en/docs/claude-code/overview" class="text-accentDark hover:underline">Claude Code</a></strong> installed. Open your terminal and run <code>claude --version</code> to check.</p>
                 <div class="space-y-8">
                     <div class="feature-card p-8 rounded-xl">
                         <div class="flex items-center gap-4 mb-4"><span class="w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">1</span><h3 class="font-display text-xl font-bold">Add the plugin source</h3></div>
@@ -563,11 +563,11 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <div class="max-w-4xl mx-auto text-center reveal">
                 <h2 class="font-display text-3xl font-light italic mb-6">Inspired by</h2>
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-2xl mx-auto">
-                    <a href="https://github.com/greyhaven-ai/autocontext" class="feature-card p-6 rounded-xl text-left hover:border-accent/30">
+                    <a target="_blank" rel="noopener noreferrer" href="https://github.com/greyhaven-ai/autocontext" class="feature-card p-6 rounded-xl text-left hover:border-accent/30">
                         <h3 class="font-display text-lg font-bold mb-2">greyhaven-ai/autocontext</h3>
                         <p class="text-mist text-sm">A closed-loop system for improving agent behavior over repeated runs. Persistent playbooks, curator agents, and confidence-scored knowledge shaped how this plugin handles lesson persistence and validation.</p>
                     </a>
-                    <a href="https://github.com/karpathy/autoresearch" class="feature-card p-6 rounded-xl text-left hover:border-accent/30">
+                    <a target="_blank" rel="noopener noreferrer" href="https://github.com/karpathy/autoresearch" class="feature-card p-6 rounded-xl text-left hover:border-accent/30">
                         <h3 class="font-display text-lg font-bold mb-2">karpathy/autoresearch</h3>
                         <p class="text-mist text-sm">AI agents running autonomous research loops. The pattern of accumulating structured knowledge across sessions and reinforcing successful strategies influenced the session lifecycle design.</p>
                     </a>
@@ -578,9 +578,9 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <footer class="relative z-10 py-12 px-6 border-t border-ink/5">
         <div class="max-w-6xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
-            <div class="text-sm text-mist">Built by <a href="https://github.com/jamditis" class="text-accentDark hover:underline">Joe Amditis</a></div>
+            <div class="text-sm text-mist">Built by <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis" class="text-accentDark hover:underline">Joe Amditis</a></div>
             <div class="flex items-center gap-6 text-sm text-mist">
-                <a href="https://github.com/jamditis/claude-skills-journalism" class="hover:text-ink transition-colors">GitHub</a>
+                <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism" class="hover:text-ink transition-colors">GitHub</a>
                 <a href="../" class="hover:text-ink transition-colors">All skills</a>
             </div>
         </div>

--- a/docs/data-journalism/index.html
+++ b/docs/data-journalism/index.html
@@ -139,7 +139,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <nav aria-label="Primary" class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-ink/5">
         <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
             <a href="../" class="text-sm font-medium text-mist hover:text-ink transition-colors">← Back to all skills</a>
-            <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/data-journalism" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">View on GitHub →</a>
+            <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/data-journalism" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">View on GitHub →</a>
         </div>
     </nav>
 
@@ -378,8 +378,8 @@ cp -r claude-skills-journalism/journalism-core/skills/data-journalism ~/.claude/
         <section class="py-16 px-6 border-t border-ink/10">
             <div class="max-w-6xl mx-auto text-center">
                 <p class="text-mist text-sm mb-4">
-                    Created by <a href="https://github.com/jamditis" class="text-accentDark hover:underline">Joe Amditis</a> at the
-                    <a href="https://centerforcooperativemedia.org" class="text-accentDark hover:underline">Center for Cooperative Media</a>
+                    Created by <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis" class="text-accentDark hover:underline">Joe Amditis</a> at the
+                    <a target="_blank" rel="noopener noreferrer" href="https://centerforcooperativemedia.org" class="text-accentDark hover:underline">Center for Cooperative Media</a>
                 </p>
                 <p class="text-mist text-xs">Part of <a href="../" class="hover:underline">Claude Skills for Journalism</a> • MIT License</p>
             </div>

--- a/docs/foia-requests/index.html
+++ b/docs/foia-requests/index.html
@@ -179,7 +179,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <a href="../" class="text-sm font-medium text-mist hover:text-ink transition-colors">
                 ← Back to all skills
             </a>
-            <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/foia-requests" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">
+            <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/foia-requests" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">
                 View on GitHub →
             </a>
         </div>
@@ -584,7 +584,7 @@ cp -r claude-skills-journalism/journalism-core/skills/foia-requests ~/.claude/sk
                 </div>
 
                 <div class="mt-12 text-center">
-                    <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/foia-requests" class="inline-flex items-center gap-2 bg-accent text-white font-semibold px-6 py-3 rounded-lg hover:bg-accentDark transition-colors">
+                    <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/foia-requests" class="inline-flex items-center gap-2 bg-accent text-white font-semibold px-6 py-3 rounded-lg hover:bg-accentDark transition-colors">
                         <i data-lucide="github" class="w-5 h-5"></i>
                         View full skill on GitHub
                     </a>
@@ -625,8 +625,8 @@ cp -r claude-skills-journalism/journalism-core/skills/foia-requests ~/.claude/sk
         <section class="py-16 px-6 border-t border-ink/10">
             <div class="max-w-6xl mx-auto text-center">
                 <p class="text-mist text-sm mb-4">
-                    Created by <a href="https://github.com/jamditis" class="text-accentDark hover:underline">Joe Amditis</a> at the
-                    <a href="https://centerforcooperativemedia.org" class="text-accentDark hover:underline">Center for Cooperative Media</a>
+                    Created by <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis" class="text-accentDark hover:underline">Joe Amditis</a> at the
+                    <a target="_blank" rel="noopener noreferrer" href="https://centerforcooperativemedia.org" class="text-accentDark hover:underline">Center for Cooperative Media</a>
                 </p>
                 <p class="text-mist text-xs">
                     Part of <a href="../" class="hover:underline">Claude Skills for Journalism</a> • MIT License

--- a/docs/free-apis-catalog/index.html
+++ b/docs/free-apis-catalog/index.html
@@ -142,7 +142,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <nav aria-label="Primary" class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-ink/5">
         <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
             <a href="../" class="text-sm font-medium text-mist hover:text-ink transition-colors">&larr; Back to all skills</a>
-            <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/research-toolkit/skills/free-apis-catalog" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">View on GitHub &rarr;</a>
+            <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism/tree/master/research-toolkit/skills/free-apis-catalog" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">View on GitHub &rarr;</a>
         </div>
     </nav>
 
@@ -424,11 +424,11 @@ cp -r claude-skills-journalism/research-toolkit/skills/free-apis-catalog ~/.clau
         <section class="py-16 px-6 border-t border-ink/10">
             <div class="max-w-6xl mx-auto text-center">
                 <p class="text-mist text-sm mb-2">
-                    Canonical breadth reference: <a href="https://github.com/public-apis/public-apis" class="text-accentDark hover:underline">public-apis/public-apis</a>
+                    Canonical breadth reference: <a target="_blank" rel="noopener noreferrer" href="https://github.com/public-apis/public-apis" class="text-accentDark hover:underline">public-apis/public-apis</a>
                 </p>
                 <p class="text-mist text-sm mb-4">
-                    Curated by <a href="https://github.com/jamditis" class="text-accentDark hover:underline">Joe Amditis</a> at the
-                    <a href="https://centerforcooperativemedia.org" class="text-accentDark hover:underline">Center for Cooperative Media</a>
+                    Curated by <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis" class="text-accentDark hover:underline">Joe Amditis</a> at the
+                    <a target="_blank" rel="noopener noreferrer" href="https://centerforcooperativemedia.org" class="text-accentDark hover:underline">Center for Cooperative Media</a>
                 </p>
                 <p class="text-mist text-xs">Part of <a href="../" class="hover:underline">Claude Skills for Journalism</a> &bull; MIT License</p>
             </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -318,13 +318,13 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <a href="#hooks" class="nav-link relative">Hooks</a>
                 <a href="#install" class="nav-link relative">Install</a>
                 <a href="about/" class="nav-link relative">About</a>
-                <a href="https://github.com/jamditis/claude-skills-journalism" class="bg-ink text-canvas px-5 py-2 hover:bg-accent transition-all">
+                <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism" class="bg-ink text-canvas px-5 py-2 hover:bg-accent transition-all">
                     GitHub
                 </a>
             </div>
 
             <!-- Mobile Menu -->
-            <a href="https://github.com/jamditis/claude-skills-journalism" class="md:hidden text-[10px] font-bold uppercase tracking-widest">
+            <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism" class="md:hidden text-[10px] font-bold uppercase tracking-widest">
                 GitHub &rarr;
             </a>
         </nav>
@@ -347,7 +347,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         </p>
                         <div class="flex flex-wrap gap-4">
                             <a href="#install" class="btn-primary">Install Now</a>
-                            <a href="https://github.com/jamditis/claude-skills-journalism" class="btn-outline">View on GitHub</a>
+                            <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism" class="btn-outline">View on GitHub</a>
                         </div>
                     </div>
                 </div>
@@ -1015,7 +1015,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                     <span class="section-label">Get Started</span>
                 </div>
 
-                <p class="text-mist mb-8">You need <strong><a href="https://docs.anthropic.com/en/docs/claude-code/overview" class="text-accentDark hover:underline">Claude Code</a></strong> installed. Run <code class="bg-ink/5 px-2 py-0.5 rounded text-sm">claude --version</code> in your terminal to check.</p>
+                <p class="text-mist mb-8">You need <strong><a target="_blank" rel="noopener noreferrer" href="https://docs.anthropic.com/en/docs/claude-code/overview" class="text-accentDark hover:underline">Claude Code</a></strong> installed. Run <code class="bg-ink/5 px-2 py-0.5 rounded text-sm">claude --version</code> in your terminal to check.</p>
 
                 <!-- Plugins (recommended) -->
                 <div class="deckle-card-solid p-8 mb-6">
@@ -1061,17 +1061,17 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                     <div class="space-y-6">
                         <h6 class="text-[10px] font-bold tracking-[0.5em] text-canvas/70 uppercase">Resources</h6>
                         <ul class="space-y-4 text-sm font-semibold tracking-wide">
-                            <li><a href="https://github.com/jamditis/claude-skills-journalism" class="hover:text-accent transition-colors">GitHub</a></li>
-                            <li><a href="https://tools.amditis.tech" class="hover:text-accent transition-colors">AI Tools Kit</a></li>
-                            <li><a href="https://centerforcooperativemedia.org" class="hover:text-accent transition-colors">CCM</a></li>
+                            <li><a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism" class="hover:text-accent transition-colors">GitHub</a></li>
+                            <li><a target="_blank" rel="noopener noreferrer" href="https://tools.amditis.tech" class="hover:text-accent transition-colors">AI Tools Kit</a></li>
+                            <li><a target="_blank" rel="noopener noreferrer" href="https://centerforcooperativemedia.org" class="hover:text-accent transition-colors">CCM</a></li>
                         </ul>
                     </div>
                     <div class="space-y-6">
                         <h6 class="text-[10px] font-bold tracking-[0.5em] text-canvas/70 uppercase">Related</h6>
                         <ul class="space-y-4 text-sm font-semibold tracking-wide">
-                            <li><a href="https://verificationhandbook.com/" class="hover:text-accent transition-colors">Verification Handbook</a></li>
-                            <li><a href="https://www.bellingcat.com/resources/" class="hover:text-accent transition-colors">Bellingcat OSINT</a></li>
-                            <li><a href="https://www.apstylebook.com/" class="hover:text-accent transition-colors">AP Stylebook</a></li>
+                            <li><a target="_blank" rel="noopener noreferrer" href="https://verificationhandbook.com/" class="hover:text-accent transition-colors">Verification Handbook</a></li>
+                            <li><a target="_blank" rel="noopener noreferrer" href="https://www.bellingcat.com/resources/" class="hover:text-accent transition-colors">Bellingcat OSINT</a></li>
+                            <li><a target="_blank" rel="noopener noreferrer" href="https://www.apstylebook.com/" class="hover:text-accent transition-colors">AP Stylebook</a></li>
                         </ul>
                     </div>
                 </div>
@@ -1079,7 +1079,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <div class="flex flex-col md:flex-row justify-between items-center pt-12 border-t border-canvas/5 gap-6">
                 <div class="font-display text-2xl italic font-black">AMDITIS.</div>
                 <div class="text-[10px] font-bold tracking-[0.3em] text-canvas/70 uppercase">
-                    <a href="https://github.com/jamditis" class="hover:text-canvas transition-colors">Joe Amditis</a>
+                    <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis" class="hover:text-canvas transition-colors">Joe Amditis</a>
                     <span class="mx-2">//</span>
                     MIT License
                 </div>

--- a/docs/pdf-playground/index.html
+++ b/docs/pdf-playground/index.html
@@ -189,7 +189,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <a href="../" class="text-sm font-medium text-mist hover:text-ink transition-colors">
                 ← Back to all skills
             </a>
-            <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/pdf-playground" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">
+            <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism/tree/master/pdf-playground" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">
                 View on GitHub →
             </a>
         </div>
@@ -559,8 +559,8 @@ style:
             <div class="max-w-4xl mx-auto">
                 <h2 class="font-display text-4xl md:text-5xl font-light italic text-center mb-6">Get started</h2>
                 <p class="text-center text-mist text-lg mb-16 max-w-2xl mx-auto">
-                    You need <strong><a href="https://docs.anthropic.com/en/docs/claude-code/overview" class="text-accentDark hover:underline">Claude Code</a></strong> installed on your computer.
-                    Open your terminal and run <code>claude --version</code> to check. If you get "command not found," <a href="https://docs.anthropic.com/en/docs/claude-code/overview" class="text-accentDark hover:underline">install Claude Code first</a>.
+                    You need <strong><a target="_blank" rel="noopener noreferrer" href="https://docs.anthropic.com/en/docs/claude-code/overview" class="text-accentDark hover:underline">Claude Code</a></strong> installed on your computer.
+                    Open your terminal and run <code>claude --version</code> to check. If you get "command not found," <a target="_blank" rel="noopener noreferrer" href="https://docs.anthropic.com/en/docs/claude-code/overview" class="text-accentDark hover:underline">install Claude Code first</a>.
                 </p>
 
                 <div class="space-y-8">
@@ -599,7 +599,7 @@ style:
                         <div class="bg-ink/5 border border-ink/10 rounded-lg p-4 mb-4">
                             <p class="text-sm italic text-ink/80">"Create a brand config for PDF Playground. My organization is called [your org name] and our main color is [your color]."</p>
                         </div>
-                        <p class="text-mist text-sm mb-4">Claude will create the config file in the right place. Or you can create the file manually — see the <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/pdf-playground#customizing-your-brand-optional" class="text-accentDark font-semibold hover:underline">full setup guide</a> for details.</p>
+                        <p class="text-mist text-sm mb-4">Claude will create the config file in the right place. Or you can create the file manually — see the <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism/tree/master/pdf-playground#customizing-your-brand-optional" class="text-accentDark font-semibold hover:underline">full setup guide</a> for details.</p>
                     </div>
                 </div>
 
@@ -609,7 +609,7 @@ style:
                     <div class="space-y-4">
                         <details class="feature-card rounded-xl overflow-hidden">
                             <summary class="p-6 cursor-pointer hover:bg-ink/5 transition-colors font-semibold">"command not found" when running <code>claude</code></summary>
-                            <div class="px-6 pb-6 text-mist text-sm">Claude Code isn't installed yet. Follow the <a href="https://docs.anthropic.com/en/docs/claude-code/overview" class="text-accentDark hover:underline">installation guide</a>, then come back here.</div>
+                            <div class="px-6 pb-6 text-mist text-sm">Claude Code isn't installed yet. Follow the <a target="_blank" rel="noopener noreferrer" href="https://docs.anthropic.com/en/docs/claude-code/overview" class="text-accentDark hover:underline">installation guide</a>, then come back here.</div>
                         </details>
                         <details class="feature-card rounded-xl overflow-hidden">
                             <summary class="p-6 cursor-pointer hover:bg-ink/5 transition-colors font-semibold">The install command gives an error</summary>
@@ -634,19 +634,19 @@ style:
                 <h2 class="font-display text-4xl md:text-5xl font-light italic text-center mb-16">Documentation</h2>
 
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-                    <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/pdf-playground#readme" class="block p-6 bg-white/5 rounded-xl hover:bg-white/10 transition-colors">
+                    <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism/tree/master/pdf-playground#readme" class="block p-6 bg-white/5 rounded-xl hover:bg-white/10 transition-colors">
                         <i data-lucide="book" class="w-8 h-8 mb-4 text-accent"></i>
                         <h3 class="font-display text-xl font-bold mb-2">README</h3>
                         <p class="text-white/70 text-sm">Full installation instructions and usage guide.</p>
                     </a>
 
-                    <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/pdf-playground/brands" class="block p-6 bg-white/5 rounded-xl hover:bg-white/10 transition-colors">
+                    <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism/tree/master/pdf-playground/brands" class="block p-6 bg-white/5 rounded-xl hover:bg-white/10 transition-colors">
                         <i data-lucide="palette" class="w-8 h-8 mb-4 text-accent"></i>
                         <h3 class="font-display text-xl font-bold mb-2">Brand configs</h3>
                         <p class="text-white/70 text-sm">Example brand configurations to copy and customize.</p>
                     </a>
 
-                    <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/pdf-playground/templates" class="block p-6 bg-white/5 rounded-xl hover:bg-white/10 transition-colors">
+                    <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism/tree/master/pdf-playground/templates" class="block p-6 bg-white/5 rounded-xl hover:bg-white/10 transition-colors">
                         <i data-lucide="layout-template" class="w-8 h-8 mb-4 text-accent"></i>
                         <h3 class="font-display text-xl font-bold mb-2">Templates</h3>
                         <p class="text-white/70 text-sm">HTML templates for all document types.</p>
@@ -735,8 +735,8 @@ style:
         <section class="py-16 px-6 border-t border-ink/10">
             <div class="max-w-6xl mx-auto text-center">
                 <p class="text-mist text-sm mb-4">
-                    Created by <a href="https://github.com/jamditis" class="text-accentDark hover:underline">Joe Amditis</a> at the
-                    <a href="https://centerforcooperativemedia.org" class="text-accentDark hover:underline">Center for Cooperative Media</a>
+                    Created by <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis" class="text-accentDark hover:underline">Joe Amditis</a> at the
+                    <a target="_blank" rel="noopener noreferrer" href="https://centerforcooperativemedia.org" class="text-accentDark hover:underline">Center for Cooperative Media</a>
                 </p>
                 <p class="text-mist text-xs">
                     Part of <a href="../" class="hover:underline">Claude Skills for Journalism</a> • MIT License

--- a/docs/source-verification/index.html
+++ b/docs/source-verification/index.html
@@ -139,7 +139,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <a href="../" class="text-sm font-medium text-mist hover:text-ink transition-colors">
                 ← Back to all skills
             </a>
-            <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/source-verification" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">
+            <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/source-verification" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">
                 View on GitHub →
             </a>
         </div>
@@ -403,12 +403,12 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                             </tr>
                         </thead>
                         <tbody class="divide-y divide-gray-100">
-                            <tr><td class="px-6 py-3 font-medium">InVID/WeVerify</td><td class="px-6 py-3 text-mist">Video verification plugin</td><td class="px-6 py-3"><a href="https://weverify.eu" class="text-accentDark hover:underline">weverify.eu</a></td></tr>
-                            <tr><td class="px-6 py-3 font-medium">TinEye</td><td class="px-6 py-3 text-mist">Reverse image search</td><td class="px-6 py-3"><a href="https://tineye.com" class="text-accentDark hover:underline">tineye.com</a></td></tr>
-                            <tr><td class="px-6 py-3 font-medium">Wayback Machine</td><td class="px-6 py-3 text-mist">Web archives</td><td class="px-6 py-3"><a href="https://web.archive.org" class="text-accentDark hover:underline">web.archive.org</a></td></tr>
-                            <tr><td class="px-6 py-3 font-medium">FotoForensics</td><td class="px-6 py-3 text-mist">Image forensic analysis</td><td class="px-6 py-3"><a href="https://fotoforensics.com" class="text-accentDark hover:underline">fotoforensics.com</a></td></tr>
-                            <tr><td class="px-6 py-3 font-medium">OCCRP Aleph</td><td class="px-6 py-3 text-mist">Document search</td><td class="px-6 py-3"><a href="https://aleph.occrp.org" class="text-accentDark hover:underline">aleph.occrp.org</a></td></tr>
-                            <tr><td class="px-6 py-3 font-medium">Media Bias/Fact Check</td><td class="px-6 py-3 text-mist">Source reliability</td><td class="px-6 py-3"><a href="https://mediabiasfactcheck.com" class="text-accentDark hover:underline">mediabiasfactcheck.com</a></td></tr>
+                            <tr><td class="px-6 py-3 font-medium">InVID/WeVerify</td><td class="px-6 py-3 text-mist">Video verification plugin</td><td class="px-6 py-3"><a target="_blank" rel="noopener noreferrer" href="https://weverify.eu" class="text-accentDark hover:underline">weverify.eu</a></td></tr>
+                            <tr><td class="px-6 py-3 font-medium">TinEye</td><td class="px-6 py-3 text-mist">Reverse image search</td><td class="px-6 py-3"><a target="_blank" rel="noopener noreferrer" href="https://tineye.com" class="text-accentDark hover:underline">tineye.com</a></td></tr>
+                            <tr><td class="px-6 py-3 font-medium">Wayback Machine</td><td class="px-6 py-3 text-mist">Web archives</td><td class="px-6 py-3"><a target="_blank" rel="noopener noreferrer" href="https://web.archive.org" class="text-accentDark hover:underline">web.archive.org</a></td></tr>
+                            <tr><td class="px-6 py-3 font-medium">FotoForensics</td><td class="px-6 py-3 text-mist">Image forensic analysis</td><td class="px-6 py-3"><a target="_blank" rel="noopener noreferrer" href="https://fotoforensics.com" class="text-accentDark hover:underline">fotoforensics.com</a></td></tr>
+                            <tr><td class="px-6 py-3 font-medium">OCCRP Aleph</td><td class="px-6 py-3 text-mist">Document search</td><td class="px-6 py-3"><a target="_blank" rel="noopener noreferrer" href="https://aleph.occrp.org" class="text-accentDark hover:underline">aleph.occrp.org</a></td></tr>
+                            <tr><td class="px-6 py-3 font-medium">Media Bias/Fact Check</td><td class="px-6 py-3 text-mist">Source reliability</td><td class="px-6 py-3"><a target="_blank" rel="noopener noreferrer" href="https://mediabiasfactcheck.com" class="text-accentDark hover:underline">mediabiasfactcheck.com</a></td></tr>
                         </tbody>
                     </table>
                 </div>
@@ -455,8 +455,8 @@ cp -r claude-skills-journalism/journalism-core/skills/source-verification ~/.cla
         <section class="py-16 px-6 border-t border-ink/10">
             <div class="max-w-6xl mx-auto text-center">
                 <p class="text-mist text-sm mb-4">
-                    Created by <a href="https://github.com/jamditis" class="text-accentDark hover:underline">Joe Amditis</a> at the
-                    <a href="https://centerforcooperativemedia.org" class="text-accentDark hover:underline">Center for Cooperative Media</a>
+                    Created by <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis" class="text-accentDark hover:underline">Joe Amditis</a> at the
+                    <a target="_blank" rel="noopener noreferrer" href="https://centerforcooperativemedia.org" class="text-accentDark hover:underline">Center for Cooperative Media</a>
                 </p>
                 <p class="text-mist text-xs">
                     Part of <a href="../" class="hover:underline">Claude Skills for Journalism</a> • MIT License

--- a/docs/superjawn/index.html
+++ b/docs/superjawn/index.html
@@ -150,7 +150,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <nav aria-label="Primary" class="fixed top-0 left-0 right-0 z-50 bg-canvas/90 backdrop-blur-md border-b border-ink/5">
         <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
             <a href="../" class="text-sm font-medium text-mist hover:text-ink transition-colors">&#8592; Back to all skills</a>
-            <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/superjawn" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">View on GitHub &#8594;</a>
+            <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism/tree/master/superjawn" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">View on GitHub &#8594;</a>
         </div>
     </nav>
 
@@ -189,7 +189,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <p class="text-base md:text-lg text-white/70 max-w-2xl mb-10">A fork of obra/superpowers. Each entry-point skill runs research by default — before brainstorming, before debugging, before writing skills. Stale-artifact consumers get a narrow freshness check. Everything else ports clean.</p>
             <div class="flex flex-wrap gap-4">
                 <a href="#install" class="inline-flex items-center gap-2 bg-white text-accentDark font-semibold px-6 py-3 rounded-lg hover:bg-white/90 transition-colors"><i data-lucide="download" class="w-5 h-5"></i> Install plugin</a>
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/superjawn" class="inline-flex items-center gap-2 bg-white/10 text-white font-semibold px-6 py-3 rounded-lg hover:bg-white/20 transition-colors border border-white/20"><i data-lucide="github" class="w-5 h-5"></i> View on GitHub</a>
+                <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism/tree/master/superjawn" class="inline-flex items-center gap-2 bg-white/10 text-white font-semibold px-6 py-3 rounded-lg hover:bg-white/20 transition-colors border border-white/20"><i data-lucide="github" class="w-5 h-5"></i> View on GitHub</a>
             </div>
         </div>
     </header>
@@ -203,7 +203,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                     <div>
                         <h2 class="font-display text-4xl md:text-5xl font-light italic mb-6">What this is</h2>
                         <div class="space-y-4 text-mist leading-relaxed">
-                            <p>superjawn is a research-augmented variant of <a href="https://github.com/obra/superpowers" class="text-accentDark hover:underline">obra/superpowers</a> (MIT, Jesse Vincent, v5.0.7). The upstream plugin ships 14 skills covering the full development workflow — brainstorming through finishing a branch. superjawn forks those skills and adds structured research at entry-point stages.</p>
+                            <p>superjawn is a research-augmented variant of <a target="_blank" rel="noopener noreferrer" href="https://github.com/obra/superpowers" class="text-accentDark hover:underline">obra/superpowers</a> (MIT, Jesse Vincent, v5.0.7). The upstream plugin ships 14 skills covering the full development workflow — brainstorming through finishing a branch. superjawn forks those skills and adds structured research at entry-point stages.</p>
                             <p>The idea: when you start new work without an upstream artifact (a spec, a plan, a test), a brief research phase catches pitfalls, surfaces prior art, and checks your memory before you commit to an approach. When you're consuming an artifact that was already research-baked, re-researching wastes time and risks conflicting conclusions.</p>
                             <p>So research fires in three places only: <strong>brainstorming</strong>, <strong>systematic-debugging</strong>, and <strong>writing-skills</strong>. Stale-artifact skills get a lighter freshness check. Everything else is a straight port.</p>
                         </div>
@@ -487,7 +487,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section id="install" class="py-24 px-6 bg-white/50">
             <div class="max-w-4xl mx-auto reveal">
                 <h2 class="font-display text-4xl md:text-5xl font-light italic text-center mb-6">How to install</h2>
-                <p class="text-center text-mist text-lg mb-16 max-w-2xl mx-auto">You need <a href="https://docs.anthropic.com/en/docs/claude-code/overview" class="text-accentDark hover:underline font-medium">Claude Code</a> installed. Run <code>claude --version</code> to check.</p>
+                <p class="text-center text-mist text-lg mb-16 max-w-2xl mx-auto">You need <a target="_blank" rel="noopener noreferrer" href="https://docs.anthropic.com/en/docs/claude-code/overview" class="text-accentDark hover:underline font-medium">Claude Code</a> installed. Run <code>claude --version</code> to check.</p>
 
                 <div class="space-y-8">
                     <div class="feature-card p-8 rounded-xl">
@@ -561,7 +561,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <div class="max-w-4xl mx-auto text-center reveal">
                 <h2 class="font-display text-3xl font-light italic mb-6">Credits</h2>
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-2xl mx-auto">
-                    <a href="https://github.com/obra/superpowers" class="feature-card p-6 rounded-xl text-left hover:border-accent/30 transition-colors">
+                    <a target="_blank" rel="noopener noreferrer" href="https://github.com/obra/superpowers" class="feature-card p-6 rounded-xl text-left hover:border-accent/30 transition-colors">
                         <div class="flex items-center gap-3 mb-3">
                             <i data-lucide="github" class="w-5 h-5 text-accent"></i>
                             <h3 class="font-display text-lg font-bold">obra/superpowers</h3>
@@ -578,7 +578,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         <div class="mt-3 font-mono text-xs text-mist">Copyright 2026 Joe Amditis</div>
                     </div>
                 </div>
-                <p class="text-sm text-mist mt-8">MIT License — see <a href="https://github.com/jamditis/claude-skills-journalism/blob/master/superjawn/LICENSE" class="text-accentDark hover:underline">superjawn/LICENSE</a> for the full text.</p>
+                <p class="text-sm text-mist mt-8">MIT License — see <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism/blob/master/superjawn/LICENSE" class="text-accentDark hover:underline">superjawn/LICENSE</a> for the full text.</p>
             </div>
         </section>
 
@@ -586,9 +586,9 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <footer class="relative z-10 py-12 px-6 border-t border-ink/5">
         <div class="max-w-6xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
-            <div class="text-sm text-mist">Built by <a href="https://github.com/jamditis" class="text-accentDark hover:underline">Joe Amditis</a></div>
+            <div class="text-sm text-mist">Built by <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis" class="text-accentDark hover:underline">Joe Amditis</a></div>
             <div class="flex items-center gap-6 text-sm text-mist">
-                <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/superjawn" class="hover:text-ink transition-colors">GitHub</a>
+                <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism/tree/master/superjawn" class="hover:text-ink transition-colors">GitHub</a>
                 <a href="../" class="hover:text-ink transition-colors">All skills</a>
             </div>
         </div>

--- a/docs/vibe-coding/index.html
+++ b/docs/vibe-coding/index.html
@@ -179,7 +179,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <a href="../" class="text-sm font-medium text-mist hover:text-ink transition-colors">
                 ← Back to all skills
             </a>
-            <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/vibe-coding" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">
+            <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/vibe-coding" class="text-sm font-semibold text-accentDark hover:text-accentDark transition-colors">
                 View on GitHub →
             </a>
         </div>
@@ -534,7 +534,7 @@ cp -r claude-skills-journalism/dev-toolkit/skills/vibe-coding ~/.claude/skills/<
                 </div>
 
                 <div class="mt-12 text-center">
-                    <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/vibe-coding" class="inline-flex items-center gap-2 bg-accent text-white font-semibold px-6 py-3 rounded-lg hover:bg-accentDark transition-colors">
+                    <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/vibe-coding" class="inline-flex items-center gap-2 bg-accent text-white font-semibold px-6 py-3 rounded-lg hover:bg-accentDark transition-colors">
                         <i data-lucide="github" class="w-5 h-5"></i>
                         View full skill on GitHub
                     </a>
@@ -546,8 +546,8 @@ cp -r claude-skills-journalism/dev-toolkit/skills/vibe-coding ~/.claude/skills/<
         <section class="py-16 px-6 border-t border-ink/10">
             <div class="max-w-6xl mx-auto text-center">
                 <p class="text-mist text-sm mb-4">
-                    Created by <a href="https://github.com/jamditis" class="text-accentDark hover:underline">Joe Amditis</a> at the
-                    <a href="https://centerforcooperativemedia.org" class="text-accentDark hover:underline">Center for Cooperative Media</a>
+                    Created by <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis" class="text-accentDark hover:underline">Joe Amditis</a> at the
+                    <a target="_blank" rel="noopener noreferrer" href="https://centerforcooperativemedia.org" class="text-accentDark hover:underline">Center for Cooperative Media</a>
                 </p>
                 <p class="text-mist text-xs">
                     Part of <a href="../" class="hover:underline">Claude Skills for Journalism</a> • MIT License


### PR DESCRIPTION
## What

Adds `target="_blank" rel="noopener noreferrer"` to every external link across the docs site that lacked it, so all pages match the established convention (external links open in a new tab, with noopener/noreferrer).

## Why

A live site audit first flagged this on `source-verification` and `data-journalism`. Copilot's review correctly noted the two-page scope was an artifact of a four-page audit sample — the same unhardened links existed on other pages. Rather than narrow the description, this expands the fix site-wide.

## Scope

- **Original 2 pages:** source-verification (9), data-journalism (3)
- **Site-wide sweep:** 47 more anchors across 7 files — landing `index.html` (11), `pdf-playground` (10), `autocontext` (6), `superjawn` (8), `foia-requests` (4), `free-apis-catalog` (4), `vibe-coding` (4)
- **Total:** 59 external anchors hardened across 9 files

## Safety

- The sweep only touches anchors missing `rel=`, so already-hardened nav/footer links are untouched — no duplicate `target`/`rel`.
- Verified: zero external anchors without `rel` remain site-wide; tag balance intact on all changed files; landing page renders unchanged; internal relative links untouched.