### PR TITLE
Anti-slop pass on the landing page: fix false hooks claim + a repeat

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -889,7 +889,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                     <span class="section-label">14 Automated Checks</span>
                 </div>
 
-                <p class="text-mist mb-8 max-w-3xl">Hooks run automatically at specific workflow events. All are <strong>non-blocking warnings</strong>—they provide guidance but don't prevent actions.</p>
+                <p class="text-mist mb-8 max-w-3xl">Hooks run automatically at specific workflow events. Most are <strong>non-blocking warnings</strong>, but two &mdash; one-way-door-check and enforce-test-first &mdash; block intentionally until you resolve them.</p>
 
                 <div class="deckle-card-solid p-8">
                     <!-- Writing Quality Hooks -->
@@ -1051,7 +1051,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         <div>cp -r journalism-core/skills/source-verification ~/.claude/skills/</div>
                         <div># or: ln -sfn "$PWD/journalism-core/skills/source-verification" ~/.claude/skills/source-verification</div>
                     </div>
-                    <p class="text-sm text-mist">Skills activate automatically. For example, asking Claude to verify a source will use the source-verification skill. Don't clone the whole repo into <code>~/.claude/skills/journalism-skills/</code> — that nests each <code>SKILL.md</code> two levels deep and Claude Code won't find them.</p>
+                    <p class="text-sm text-mist">For example, asking Claude to verify a source will use the source-verification skill. Don't clone the whole repo into <code>~/.claude/skills/journalism-skills/</code> — that nests each <code>SKILL.md</code> two levels deep and Claude Code won't find them.</p>
                 </div>
             </section>
 


### PR DESCRIPTION
Same adversarial anti-slop pass as #93, applied to `docs/index.html`.

The landing page is mostly terse, factual skill-card descriptions, so it was already clean on banned words, "the whole ___" tics, and filler. Two real issues surfaced:

| # | Issue | Fix |
|---|-------|-----|
| 1 | **Factual contradiction.** Hooks intro said "All are non-blocking warnings … don't prevent actions" — but the page's own cards show `one-way-door-check` and `enforce-test-first` both **block**, and the repo `CLAUDE.md` agrees | Reworded to "Most are non-blocking warnings, but two — one-way-door-check and enforce-test-first — block intentionally until you resolve them" |
| 2 | **Redundancy.** The "Install individual skills" card said skills "load automatically", then "activate automatically" two sentences later | Cut the repeat |

**Deliberately not changed:**
- `curated` — an approved word in the repo's own style guide; the hero/footer repeat is an intentional bookend.
- The title-case label spans ("Get Started", "14 Automated Checks", "Interactive Plugin") — all forced uppercase by CSS, so source case is invisible to users, and they match the page's existing label convention. Editing three of ~15 would create inconsistency, not fix it.

No skill descriptions, claims, links, or layout changed beyond the two items above.