### PR TITLE
docs: README guides + install-syntax, complete plugins grid, autopunk cross-link (#87, #88, #90)

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Quick version: fork, create your skill with a `SKILL.md` frontmatter file, test 
 - [Anthropic official skills](https://github.com/anthropics/skills)
 - [Claude Code documentation](https://docs.anthropic.com/claude-code)
 - [Agent Skills Standard](http://agentskills.io)
+- [autopunk-media-skills](https://github.com/ur-grue/autopunk-media-skills) — broadcast, TV, podcast, and radio production skills; complements this repo's investigative focus. Free library, paired with a paid product ([autopunk.io](https://autopunk.io))
 - [NICAR (Investigative Reporters & Editors)](https://www.ire.org/nicar/)
 - [First Draft News](https://firstdraftnews.org/)
 - [Verification Handbook](https://verificationhandbook.com/)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Setup and workflow guides, separate from the skills themselves:
 
 | Guide | Description |
 |-------|-------------|
+| [Multi-agent workflows](https://skills.amditis.tech/workflows/) | Plain-language guide to running many AI agents on one job — fan-out, pipeline, and adversarial-verify patterns, with real examples from ICIJ, The Markup, Full Fact, and Elicit, plus honest cautions |
 | [Persistent sessions](https://skills.amditis.tech/persistent-sessions/) | Keep Claude Code sessions alive through disconnects using tmux — setup, key bindings, activity notifications, and scheduler coexistence |
 
 ## What are Claude skills?
@@ -22,11 +23,11 @@ Skills are modular instruction sets that extend Claude's capabilities for specia
 
 ### Plugins (recommended)
 
-Plugins give you slash commands you can run directly inside Claude Code. Run these two commands in your terminal:
+Plugins give you slash commands you can run directly inside Claude Code. Run these two commands inside a Claude Code session:
 
 ```
-claude plugin marketplace add https://github.com/jamditis/claude-skills-journalism
-claude plugin install pdf-playground@claude-skills-journalism
+/plugin marketplace add jamditis/claude-skills-journalism
+/plugin install pdf-playground@claude-skills-journalism
 ```
 
 Then restart Claude Code (close and reopen). See the [PDF Playground README](./pdf-playground/) for detailed setup instructions and troubleshooting.

--- a/docs/index.html
+++ b/docs/index.html
@@ -445,6 +445,90 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                             <span class="text-[8px] bg-[#CA3553]/10 text-[#CA3553] px-2 py-1 rounded font-semibold">Brand system</span>
                         </div>
                     </a>
+
+                    <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
+                        <div class="flex items-start justify-between mb-3">
+                            <i data-lucide="newspaper" class="w-5 h-5 text-accent"></i>
+                            <span class="featured-badge">Plugin</span>
+                        </div>
+                        <h3 class="font-display text-lg font-bold mb-2 group-hover:text-accent transition-colors">journalism-core</h3>
+                        <p class="text-sm text-mist leading-relaxed">Thirteen core journalism skills: AP-style writing, slop detox, source verification (deepfakes/C2PA), FOIA + NJ OPRA, fact-checking, interview prep, pitches, editorial workflow, crisis comms, and newsletter publishing.</p>
+                        <div class="flex flex-wrap gap-2 mt-3">
+                            <span class="text-[8px] bg-accent/10 text-accent px-2 py-1 rounded font-semibold">AP Style</span>
+                            <span class="text-[8px] bg-accent/10 text-accent px-2 py-1 rounded font-semibold">FOIA</span>
+                            <span class="text-[8px] bg-accent/10 text-accent px-2 py-1 rounded font-semibold">Verification</span>
+                        </div>
+                    </a>
+
+                    <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/research-toolkit" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
+                        <div class="flex items-start justify-between mb-3">
+                            <i data-lucide="graduation-cap" class="w-5 h-5 text-accent"></i>
+                            <span class="featured-badge">Plugin</span>
+                        </div>
+                        <h3 class="font-display text-lg font-bold mb-2 group-hover:text-accent transition-colors">research-toolkit</h3>
+                        <p class="text-sm text-mist leading-relaxed">Six skills for research and source preservation: academic writing, paywall bypass via Unpaywall, web archiving, page-change monitoring, AI-enriched archives, and a curated free-API catalog with sunset notes.</p>
+                        <div class="flex flex-wrap gap-2 mt-3">
+                            <span class="text-[8px] bg-accent/10 text-accent px-2 py-1 rounded font-semibold">Academic</span>
+                            <span class="text-[8px] bg-accent/10 text-accent px-2 py-1 rounded font-semibold">Archiving</span>
+                            <span class="text-[8px] bg-accent/10 text-accent px-2 py-1 rounded font-semibold">APIs</span>
+                        </div>
+                    </a>
+
+                    <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
+                        <div class="flex items-start justify-between mb-3">
+                            <i data-lucide="code" class="w-5 h-5 text-accent"></i>
+                            <span class="featured-badge">Plugin</span>
+                        </div>
+                        <h3 class="font-display text-lg font-bold mb-2 group-hover:text-accent transition-colors">dev-toolkit</h3>
+                        <p class="text-sm text-mist leading-relaxed">Ten development skills for small newsroom teams: accessibility (WCAG 2.2), Electron, mobile debugging, Python pipelines, test-first bug fixing, ethical scraping, no-build frontend, and signs-of-taste web UI.</p>
+                        <div class="flex flex-wrap gap-2 mt-3">
+                            <span class="text-[8px] bg-accent/10 text-accent px-2 py-1 rounded font-semibold">Accessibility</span>
+                            <span class="text-[8px] bg-accent/10 text-accent px-2 py-1 rounded font-semibold">Pipelines</span>
+                            <span class="text-[8px] bg-accent/10 text-accent px-2 py-1 rounded font-semibold">Test-first</span>
+                        </div>
+                    </a>
+
+                    <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/project-templates-toolkit" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
+                        <div class="flex items-start justify-between mb-3">
+                            <i data-lucide="files" class="w-5 h-5 text-accent"></i>
+                            <span class="featured-badge">Plugin</span>
+                        </div>
+                        <h3 class="font-display text-lg font-bold mb-2 group-hover:text-accent transition-colors">project-templates-toolkit</h3>
+                        <p class="text-sm text-mist leading-relaxed">Three skills for starting and closing projects: a CLAUDE.md project-memory writer, a LESSONS.md retrospective writer, and a template-selector decision tree across six project types.</p>
+                        <div class="flex flex-wrap gap-2 mt-3">
+                            <span class="text-[8px] bg-accent/10 text-accent px-2 py-1 rounded font-semibold">CLAUDE.md</span>
+                            <span class="text-[8px] bg-accent/10 text-accent px-2 py-1 rounded font-semibold">LESSONS.md</span>
+                            <span class="text-[8px] bg-accent/10 text-accent px-2 py-1 rounded font-semibold">Templates</span>
+                        </div>
+                    </a>
+
+                    <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/security-toolkit" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
+                        <div class="flex items-start justify-between mb-3">
+                            <i data-lucide="shield-check" class="w-5 h-5 text-accent"></i>
+                            <span class="featured-badge">Plugin</span>
+                        </div>
+                        <h3 class="font-display text-lg font-bold mb-2 group-hover:text-accent transition-colors">security-toolkit</h3>
+                        <p class="text-sm text-mist leading-relaxed">Four defensive security skills plus <code class="text-xs">/security-toolkit:hotpatch</code>: OWASP audit checklists, secure auth (hashing, JWT, OAuth, passkeys), API hardening, and npm/bun supply-chain hardening.</p>
+                        <div class="flex flex-wrap gap-2 mt-3">
+                            <span class="text-[8px] bg-accent/10 text-accent px-2 py-1 rounded font-semibold">OWASP</span>
+                            <span class="text-[8px] bg-accent/10 text-accent px-2 py-1 rounded font-semibold">Auth</span>
+                            <span class="text-[8px] bg-accent/10 text-accent px-2 py-1 rounded font-semibold">Supply chain</span>
+                        </div>
+                    </a>
+
+                    <a href="visual-explainer/" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
+                        <div class="flex items-start justify-between mb-3">
+                            <i data-lucide="bar-chart-3" class="w-5 h-5 text-accent"></i>
+                            <span class="featured-badge">Plugin</span>
+                        </div>
+                        <h3 class="font-display text-lg font-bold mb-2 group-hover:text-accent transition-colors">visual-explainer</h3>
+                        <p class="text-sm text-mist leading-relaxed">HTML diagrams, data tables, architecture views, slide decks, and KPI dashboards with journalism, newsroom, and academic design sensibilities.</p>
+                        <div class="flex flex-wrap gap-2 mt-3">
+                            <span class="text-[8px] bg-accent/10 text-accent px-2 py-1 rounded font-semibold">Diagrams</span>
+                            <span class="text-[8px] bg-accent/10 text-accent px-2 py-1 rounded font-semibold">Tables</span>
+                            <span class="text-[8px] bg-accent/10 text-accent px-2 py-1 rounded font-semibold">Dashboards</span>
+                        </div>
+                    </a>
                 </div>
             </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -446,7 +446,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         </div>
                     </a>
 
-                    <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
+                    <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
                         <div class="flex items-start justify-between mb-3">
                             <i data-lucide="newspaper" class="w-5 h-5 text-accent"></i>
                             <span class="featured-badge">Plugin</span>
@@ -460,7 +460,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         </div>
                     </a>
 
-                    <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/research-toolkit" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
+                    <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism/tree/master/research-toolkit" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
                         <div class="flex items-start justify-between mb-3">
                             <i data-lucide="graduation-cap" class="w-5 h-5 text-accent"></i>
                             <span class="featured-badge">Plugin</span>
@@ -474,7 +474,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         </div>
                     </a>
 
-                    <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
+                    <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
                         <div class="flex items-start justify-between mb-3">
                             <i data-lucide="code" class="w-5 h-5 text-accent"></i>
                             <span class="featured-badge">Plugin</span>
@@ -488,7 +488,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         </div>
                     </a>
 
-                    <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/project-templates-toolkit" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
+                    <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism/tree/master/project-templates-toolkit" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
                         <div class="flex items-start justify-between mb-3">
                             <i data-lucide="files" class="w-5 h-5 text-accent"></i>
                             <span class="featured-badge">Plugin</span>
@@ -502,7 +502,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         </div>
                     </a>
 
-                    <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/security-toolkit" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
+                    <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism/tree/master/security-toolkit" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
                         <div class="flex items-start justify-between mb-3">
                             <i data-lucide="shield-check" class="w-5 h-5 text-accent"></i>
                             <span class="featured-badge">Plugin</span>


### PR DESCRIPTION
Tackles the documentation drift across the open issues plus a README gap Joe flagged.

## Changes

### README
- **Add the multi-agent workflows guide** to the top Guides table — a top-level guide (neither plugin nor skill, like persistent-sessions) that the docs landing page already featured but the README omitted.
- **#87 — standardize install syntax.** Lines 28-29 used the bare-CLI `claude plugin marketplace add <URL>` form while the rest of the README and the docs site use the `/plugin` slash-command form. Switched to the slash form and corrected the "in your terminal" instruction (slash commands run inside a Claude Code session).
- **#90 — reciprocal cross-link.** Added autopunk-media-skills to Related resources. It already links here and is a genuine, high-quality, complementary project (broadcast/TV/podcast production vs this repo's investigative focus). The entry flags that the free library is paired with a paid product, for reader transparency.

### docs/index.html
- **#88 — complete the Plugins grid.** The section labeled "10 Plugins" but rendered only 4 cards. Added the 6 missing plugin cards (journalism-core, research-toolkit, dev-toolkit, project-templates-toolkit, security-toolkit, visual-explainer), matching marketplace.json. Per the chosen **hybrid** model: Plugins section is now complete and truthful at 10; skill category sections stay a curated selection; llms.txt remains the full 53-skill catalog backing the hero count.

## Doc-accuracy audit
Cross-checked every headline count after the edits — all consistent:
- **Plugins = 10**: marketplace.json, README table, docs hero, Plugins section cards
- **Hooks = 14**: hooks/ dir, README table, docs hero, hooks section
- **Skills = 53**: docs hero and llms.txt (5+6+6+2+10+4+3+3+14, incl. 14 superjawn workflow patterns)

New guide links resolve (docs/workflows/, docs/persistent-sessions/). Plugins-section `<a>`/`</a>` balanced (10/10). visual-explainer links to its docs page; the 5 plugins without a docs page link to their GitHub tree.

## Related issues
- Closes #87
- Closes #88
- Closes #90
- #86 was already fixed by the merged PR #95 (README line 158); closed separately.