### PR TITLE
Add autonomy explainer to the README Guides table

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Setup and workflow guides, separate from the skills themselves:
 
 | Guide | Description |
 |-------|-------------|
+| [Autonomous and hands-on dev work](https://skills.amditis.tech/autonomy/) | A first-person account of running dev work with Claude in two modes — autonomous sessions that pull tasks off GitHub issues, and hands-on multi-agent reviews at the keyboard — held to one quality bar, with copy-able prompts to adapt the approach to your own agent |
 | [Multi-agent workflows](https://skills.amditis.tech/workflows/) | Plain-language guide to running many AI agents on one job — fan-out, pipeline, and adversarial-verify patterns, with real examples from ICIJ, The Markup, Full Fact, and Elicit, plus honest cautions |
 | [Persistent sessions](https://skills.amditis.tech/persistent-sessions/) | Keep Claude Code sessions alive through disconnects using tmux — setup, key bindings, activity notifications, and scheduler coexistence |
 


### PR DESCRIPTION
## What

Adds the new [/autonomy/](https://skills.amditis.tech/autonomy/) page to the README's **Guides** table, alongside Multi-agent workflows and Persistent sessions.

## Why

PR #97 published the autonomy page and its sitemap entry, but the README — the repo's front door — had no link to it. The Guides table is where standalone narrative pages live (the ones that aren't skills or plugins), so this is the right home for it. Placed first as the highest-level overview, since it ties together the autonomous-session and multi-agent-review threads the other two guides cover.

## Change

One row added to the Guides table. No other files touched.