### PR TITLE
Fix mobile diagrams getting cut off on the right

### DIFF
--- a/docs/autonomy/index.html
+++ b/docs/autonomy/index.html
@@ -344,7 +344,7 @@
       .lanes { grid-template-columns: 1fr; }
       .lane { border-right: none; border-bottom: 1px solid var(--border); }
       .pipeline__step { min-width: 200px; }
-      .mermaid-wrap { min-height: 300px; padding: 14px 8px; }
+      .mermaid-wrap { min-height: 180px; padding: 16px 10px; }
       .primer__row { grid-template-columns: 104px 1fr; gap: 3px 14px; }
       .theme-toggle { bottom: 14px; right: 14px; }
     }
@@ -953,12 +953,12 @@ flowchart TD
 
   async function renderAll() {
     var dark = currentDark();
-    // On phones, fitting a wide flowchart to the narrow column makes the text tiny.
-    // Render at natural size instead and let the reader pinch / drag to move around.
-    var narrow = window.matchMedia('(max-width: 1000px)').matches;
+    // Fit each diagram to the column so the whole thing is always visible (no horizontal
+    // cut-off on phones). Reading small labels on wide diagrams is handled by pinch / +-
+    // zoom and the full-size button, not by letting the diagram overflow the screen.
     mermaid.initialize({
       startOnLoad: false, theme: 'base',
-      flowchart: { curve: 'basis', padding: 14, useMaxWidth: !narrow },
+      flowchart: { curve: 'basis', padding: 14, useMaxWidth: true },
       themeVariables: themeVars(dark)
     });
     nodes.forEach(function (n, i) { n.removeAttribute('data-processed'); n.textContent = sources[i]; });
@@ -967,12 +967,6 @@ flowchart TD
 
   window.__rerenderMermaid = renderAll;
   renderAll();
-
-  // Re-render when the viewport crosses the mobile breakpoint (e.g. rotating a phone),
-  // so useMaxWidth flips and diagrams don't keep the wrong sizing mode.
-  var mq = window.matchMedia('(max-width: 1000px)');
-  if (mq.addEventListener) mq.addEventListener('change', renderAll);
-  else if (mq.addListener) mq.addListener(renderAll);
 </script>
 
 <!-- ---------- Theme toggle ---------- -->


### PR DESCRIPTION
Follow-up to #100. On phones the diagrams were rendering at natural size, which made the text readable but pushed wide diagrams off the right edge of the screen — with no discoverable way to reach the cut-off part.

## Fix
- Back to **fit-to-width** (`useMaxWidth: true`) so the whole diagram is always visible, no horizontal cut-off.
- Reading small labels on the few wide diagrams (e.g. the fan-out) is handled by the **pinch / +- zoom** added in #100, plus the full-size (⛶) button.
- Dropped the `matchMedia` breakpoint re-render — it only existed to flip `useMaxWidth`, so it's now dead code.
- Kept the touch **pinch/pan handlers** and **`touch-action: pan-y`** — those were the real fix from #100 and are unchanged.

## Verification (live preview at 390px)
- All 5 diagrams fit within the column (svg width ≤ container width) — nothing cut off. Confirmed Fig 1 shows every node, the return arrows, and the "needs changes" label.
- Two-finger pinch still zooms (`scale(2)`); one-finger leaves the diagram alone so the page scrolls; 0 console errors.

Net of #100 + this: mobile diagrams fit the screen as before, but now you can pinch/button-zoom and pan to read them — which was the original ask.