### PR TITLE
Add a cost estimator for the autonomy kit

### DIFF
--- a/docs/autonomy/kit/COSTS.md
+++ b/docs/autonomy/kit/COSTS.md
@@ -64,6 +64,24 @@ If you're on metered billing and want a firm ceiling, the practical budget is
 cadence × effort × timeout: fewer runs, lower effort, and a shorter cap each
 multiply down the worst case.
 
+## Estimate it
+
+To turn those dials into a number before you arm the loop:
+
+```
+python3 estimate_cost.py config.yaml          # reads your config
+python3 estimate_cost.py --cron "*/15 7-19 * * *" --work-effort high
+```
+
+It prints estimated runs per day, runs per month, and a monthly cost range for
+subscription vs. metered billing side by side, so the gap is concrete. The same
+math runs in the browser at `cost-estimator.html` — no setup. The price
+assumptions live in one editable block at the top of `estimate_cost.py`. The
+subscription defaults assume the common plan tiers — a $100/mo worker plan and a
+$20/mo reviewer plan — so swap in whichever tier ($20, $100, $200) you're
+actually on, and replace the metered figures with your observed per-session
+token use.
+
 ## A change worth watching
 
 Around mid-2026, two billing shifts are relevant to a loop like this. Check the

--- a/docs/autonomy/kit/README.md
+++ b/docs/autonomy/kit/README.md
@@ -56,6 +56,10 @@ widen one ring at a time as you trust it.
   starter standards file.
 - `COSTS.md` — read this before you raise the cadence. Subscription vs. metered
   billing, and what changes around June 1, 2026.
+- `estimate_cost.py` + `cost-estimator.html` — put a number on it before you arm
+  the loop. Both turn the cadence, effort, and timeout dials into estimated
+  runs/day and a monthly cost range, subscription vs. metered. The script reads
+  your `config.yaml` (or flags); the HTML page is the same math in the browser.
 
 ## Aiming it (this is the feature)
 
@@ -88,7 +92,8 @@ confidence grows.
   per-OS choices live.
 - **Cost:** the loop is cheap only if your CLIs are logged into a subscription
   rather than billing an API key, and only if you keep the cadence sane. Read
-  `COSTS.md` first.
+  `COSTS.md` first, then run `python3 estimate_cost.py config.yaml` (or open
+  `cost-estimator.html`) to put a number on your settings.
 - **Auth:** GitHub access comes from the `gh` CLI (`gh auth login`). The only
   other credential you might set is a notifier token, if you want phone alerts.
 

--- a/docs/autonomy/kit/cost-estimator.html
+++ b/docs/autonomy/kit/cost-estimator.html
@@ -1,0 +1,335 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Autonomy loop cost estimator</title>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%23fff'/%3E%3Cpath d='M9 9 L24 16 L11 24' stroke='%23111' stroke-width='1.5' fill='none'/%3E%3Ccircle cx='9' cy='9' r='3.4' fill='%23e4002b'/%3E%3Ccircle cx='24' cy='16' r='3.4' fill='%23111'/%3E%3Ccircle cx='11' cy='24' r='3.4' fill='%23111'/%3E%3C/svg%3E">
+  <meta name="description" content="Size the autonomous issue-workhorse loop before you arm it: turn the cadence, effort, and timeout dials into a monthly cost range for subscription vs metered API billing.">
+  <meta property="og:title" content="Autonomy loop cost estimator">
+  <meta property="og:description" content="Turn the autonomy kit's dials into a number: estimated runs per day and a monthly cost range, subscription vs metered.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://skills.amditis.tech/autonomy/kit/cost-estimator.html">
+  <meta property="og:image" content="https://skills.amditis.tech/autonomy/og-image.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Autonomy loop cost estimator">
+  <meta name="twitter:description" content="Turn the autonomy kit's dials into a number: estimated runs per day and a monthly cost range, subscription vs metered.">
+  <meta name="twitter:image" content="https://skills.amditis.tech/autonomy/og-image.png">
+  <style>
+    :root {
+      --bg: #ffffff; --surface: #f4f4f1; --ink: #111111; --text: #1a1a1a;
+      --text-dim: #6a6a6a; --border: rgba(0,0,0,0.16); --accent: #e4002b;
+      --font-body: 'Archivo', system-ui, -apple-system, sans-serif;
+      --font-mono: 'IBM Plex Mono', 'SF Mono', Consolas, monospace;
+    }
+    * { box-sizing: border-box; }
+    body {
+      font-family: var(--font-body); background: var(--bg); color: var(--text);
+      margin: 0; line-height: 1.5; -webkit-font-smoothing: antialiased;
+    }
+    .wrap { max-width: 920px; margin: 0 auto; padding: 40px 20px 80px; }
+    a { color: var(--accent); }
+    h1 { font-size: 28px; line-height: 1.15; margin: 0 0 10px; letter-spacing: -0.01em; }
+    .intro { color: var(--text-dim); max-width: 64ch; margin: 0 0 8px; }
+    .intro code { font-family: var(--font-mono); font-size: 0.85em; background: var(--surface); padding: 1px 5px; }
+    .meta { font-family: var(--font-mono); font-size: 12px; color: var(--text-dim); margin: 22px 0 0; }
+    .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 22px; margin-top: 28px; align-items: start; }
+    @media (max-width: 720px) { .grid { grid-template-columns: 1fr; } }
+    .panel { border: 1px solid var(--ink); background: var(--bg); }
+    .panel__head {
+      font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.14em;
+      color: var(--accent); padding: 12px 16px; border-bottom: 1px solid var(--border);
+    }
+    .panel__body { padding: 14px 16px 18px; }
+    .row { display: grid; grid-template-columns: 1fr auto; gap: 10px; align-items: center; margin: 0 0 12px; }
+    .row label { font-size: 14px; }
+    .row .hint { display: block; font-size: 11.5px; color: var(--text-dim); font-family: var(--font-mono); margin-top: 2px; }
+    .row .hint code { background: var(--surface); padding: 0 3px; }
+    input, select {
+      font-family: var(--font-mono); font-size: 13px; padding: 6px 8px;
+      border: 1px solid var(--border); background: var(--bg); color: var(--text); width: 100%;
+    }
+    input:focus, select:focus { outline: 2px solid var(--accent); outline-offset: -1px; }
+    .num { width: 110px; text-align: right; }
+    .row--full { grid-template-columns: 1fr; }
+    .result { border: 1px solid var(--ink); }
+    .result__head {
+      font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.14em;
+      color: var(--accent); padding: 12px 16px; border-bottom: 1px solid var(--border);
+    }
+    .result__body { padding: 4px 0 8px; }
+    .line { display: flex; justify-content: space-between; align-items: baseline; gap: 14px; padding: 11px 16px; border-bottom: 1px solid var(--border); }
+    .line:last-child { border-bottom: 0; }
+    .line .k { font-size: 13px; color: var(--text-dim); }
+    .line .v { font-family: var(--font-mono); font-size: 15px; font-weight: 600; color: var(--ink); text-align: right; }
+    .line--big .v { font-size: 21px; }
+    .line--accent .v { color: var(--accent); }
+    .sub { font-size: 11.5px; color: var(--text-dim); font-family: var(--font-mono); }
+    details.assumptions { margin-top: 22px; border: 1px solid var(--border); }
+    details.assumptions > summary {
+      cursor: pointer; padding: 11px 16px; font-size: 11px; font-weight: 700;
+      text-transform: uppercase; letter-spacing: 0.14em; color: var(--accent); list-style: none;
+    }
+    details.assumptions > summary::-webkit-details-marker { display: none; }
+    details.assumptions > summary::after { content: " +"; }
+    details.assumptions[open] > summary::after { content: " \2212"; }
+    .assume-grid { padding: 4px 16px 18px; display: grid; grid-template-columns: 1fr 1fr; gap: 12px 18px; }
+    @media (max-width: 720px) { .assume-grid { grid-template-columns: 1fr; } }
+    .assume-grid label { font-size: 12.5px; display: block; margin-bottom: 4px; }
+    .assume-grid .hint { font-size: 11px; color: var(--text-dim); font-family: var(--font-mono); }
+    .assume-grid .hint code { background: var(--surface); padding: 0 3px; }
+    .caveat { font-size: 12.5px; color: var(--text-dim); margin-top: 18px; border-top: 1px solid var(--border); padding-top: 14px; max-width: 70ch; }
+    .err { color: var(--accent); font-family: var(--font-mono); font-size: 12.5px; padding: 11px 16px; }
+    .span-2 { grid-column: 1 / -1; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>Autonomy loop cost estimator</h1>
+    <p class="intro">
+      Size the <a href="README.md">issue-workhorse loop</a> before you arm it. This turns the dials from
+      <a href="COSTS.md">COSTS.md</a> into a number: how many sessions a day your cadence fires, and a monthly
+      cost range for a flat subscription vs a metered API key. Defaults match the kit's
+      <code>config.example.yaml</code>. The prices under the fold are editable &mdash; replace them with your own
+      plans and observed per-session token use.
+    </p>
+
+    <div class="grid">
+      <div class="panel">
+        <div class="panel__head">The dials</div>
+        <div class="panel__body">
+          <div class="row row--full">
+            <label for="cron">Cadence (cron)
+              <span class="hint">minute hour dom month dow &mdash; e.g. <code>5 7-19 * * *</code></span>
+            </label>
+            <input id="cron" type="text" value="5 7-19 * * *" spellcheck="false">
+          </div>
+          <div class="row">
+            <label for="work">Work effort</label>
+            <select class="num" id="work">
+              <option>low</option><option>medium</option><option selected>high</option>
+              <option>xhigh</option><option>max</option>
+            </select>
+          </div>
+          <div class="row">
+            <label for="review">Review effort</label>
+            <select class="num" id="review">
+              <option selected>low</option><option>medium</option><option>high</option>
+              <option>xhigh</option><option>max</option>
+            </select>
+          </div>
+          <div class="row">
+            <label for="session">Avg session
+              <span class="hint">minutes; hard cap is the timeout</span>
+            </label>
+            <input class="num" id="session" type="number" min="1" step="1" value="30">
+          </div>
+          <div class="row">
+            <label for="passes">Review passes</label>
+            <input class="num" id="passes" type="number" min="1" step="1" value="3">
+          </div>
+          <div class="row">
+            <label for="days">Days / month</label>
+            <input class="num" id="days" type="number" min="1" step="0.1" value="30.4">
+          </div>
+        </div>
+      </div>
+
+      <div class="result">
+        <div class="result__head">Estimate</div>
+        <div class="result__body" id="resultBody"><!-- filled by JS --></div>
+      </div>
+    </div>
+
+    <details class="assumptions">
+      <summary>Price assumptions (USD) &mdash; edit to fit your plans</summary>
+      <div class="assume-grid">
+        <div>
+          <label for="subWorker">Subscription / mo &mdash; worker</label>
+          <input class="num" id="subWorker" type="number" min="0" step="1" value="100">
+          <span class="hint">flat plan for the coding agent</span>
+        </div>
+        <div>
+          <label for="subReviewer">Subscription / mo &mdash; reviewer</label>
+          <input class="num" id="subReviewer" type="number" min="0" step="1" value="20">
+          <span class="hint">flat plan for the reviewer (Codex/ChatGPT)</span>
+        </div>
+        <div>
+          <label for="mtokWorker">Metered $/Mtok &mdash; worker</label>
+          <input class="num" id="mtokWorker" type="number" min="0" step="0.5" value="12">
+          <span class="hint">blended input+output, Opus-class</span>
+        </div>
+        <div>
+          <label for="mtokReviewer">Metered $/Mtok &mdash; reviewer</label>
+          <input class="num" id="mtokReviewer" type="number" min="0" step="0.5" value="5">
+          <span class="hint">blended input+output, review-class</span>
+        </div>
+        <div class="span-2">
+          <span class="hint">Worker tokens billed per active minute scale with work effort (low&hellip;max):
+          3k&ndash;9k / 5k&ndash;14k / 8k&ndash;22k / 12k&ndash;30k / 18k&ndash;42k. Reviewer: 15k&ndash;60k per pass,
+          scaled by review effort. These mirror <code>estimate_cost.py</code> &mdash; keep the two in sync.</span>
+        </div>
+      </div>
+    </details>
+
+    <p class="caveat">
+      These are rough, order-of-magnitude assumptions, not a quote. Subscription runs cost nothing extra until you
+      hit the plan's limits; metered runs bill per token, and real token use swings widely with prompt caching and
+      how much each session actually does. Plans and prices move &mdash; calibrate with your own numbers before you
+      raise the cadence.
+    </p>
+    <p class="meta">Part of the autonomy issue-workhorse kit &middot; mirrors estimate_cost.py</p>
+  </div>
+
+  <script>
+    // ===== price assumptions that aren't editable inputs (mirror estimate_cost.py) =====
+    const WORKER_TOKENS_PER_MIN = {
+      low: [3000, 9000], medium: [5000, 14000], high: [8000, 22000],
+      xhigh: [12000, 30000], max: [18000, 42000],
+    };
+    const REVIEW_TOKENS_PER_PASS = [15000, 60000];
+    const REVIEW_EFFORT_MULTIPLIER = { low: 1.0, medium: 1.4, high: 2.0, xhigh: 2.6, max: 3.2 };
+    const EN = "–"; // en dash for ranges
+
+    // ===== cron cadence -> runs per day (mirrors parse_cron_field / cron_runs_per_active_day) =====
+    function parseField(text, lo, hi) {
+      const values = new Set();
+      for (let part of text.split(",")) {
+        part = part.trim();
+        if (!part) continue;
+        let step = 1, base = part;
+        if (part.includes("/")) {
+          const bits = part.split("/");
+          step = parseInt(bits[1], 10);
+          if (!(step > 0)) throw new Error('bad step in "' + part + '"');
+          base = bits[0];
+        }
+        let start, end;
+        if (base === "*") { start = lo; end = hi; }
+        else if (base.includes("-")) {
+          const r = base.split("-"); start = parseInt(r[0], 10); end = parseInt(r[1], 10);
+        } else { start = end = parseInt(base, 10); }
+        if (!Number.isFinite(start) || !Number.isFinite(end)) throw new Error('bad field "' + text + '"');
+        if (start < lo || end > hi || start > end) throw new Error('field "' + text + '" out of range [' + lo + "," + hi + "]");
+        for (let v = start; v <= end; v += step) values.add(v);
+      }
+      if (values.size === 0) throw new Error('field matched nothing: "' + text + '"');
+      return values;
+    }
+    function cronRunsPerActiveDay(expr) {
+      const f = expr.trim().split(/\s+/);
+      if (f.length !== 5) throw new Error("expected 5 cron fields, got " + f.length);
+      return parseField(f[0], 0, 59).size * parseField(f[1], 0, 23).size;
+    }
+    function cronActiveDaysPerWeek(expr) {
+      const dow = expr.trim().split(/\s+/)[4];
+      if (dow === "*") return 7;
+      // Parse against 0-7 (cron allows 0 and 7 for Sunday), then fold 7 -> 0.
+      // Normalizing the text first (dow.replace) would corrupt ranges like "1-7".
+      const days = new Set([...parseField(dow, 0, 7)].map(d => d % 7));
+      return days.size;
+    }
+    function cronRestrictions(expr) {
+      const f = expr.trim().split(/\s+/);
+      const notes = [];
+      if (f[2] !== "*") notes.push('day-of-month is "' + f[2] + '"');
+      if (f[3] !== "*") notes.push('month is "' + f[3] + '"');
+      return notes;
+    }
+
+    // ===== cost model (mirrors metered_cost_per_run) =====
+    function meteredPerRun(p) {
+      const w = WORKER_TOKENS_PER_MIN[p.work];
+      const workerLo = w[0] * p.session, workerHi = w[1] * p.session;
+      const wPrice = p.mtokWorker / 1e6;
+      const r = REVIEW_TOKENS_PER_PASS, mult = REVIEW_EFFORT_MULTIPLIER[p.review];
+      const reviewLo = r[0] * mult * p.passes, reviewHi = r[1] * mult * p.passes;
+      const rPrice = p.mtokReviewer / 1e6;
+      return [workerLo * wPrice + reviewLo * rPrice, workerHi * wPrice + reviewHi * rPrice];
+    }
+
+    function money(v) {
+      if (v >= 100) return "$" + Math.round(v).toLocaleString("en-US");
+      return "$" + v.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    }
+    function intc(v) { return Math.round(v).toLocaleString("en-US"); }
+    const $ = id => document.getElementById(id);
+
+    // DOM builders — no innerHTML, so user-typed cron text is never parsed as markup.
+    function el(tag, cls, text) {
+      const n = document.createElement(tag);
+      if (cls) n.className = cls;
+      if (text != null) n.textContent = text;
+      return n;
+    }
+    function line(kText, vNode, opts) {
+      opts = opts || {};
+      const row = el("div", "line" + (opts.big ? " line--big" : "") + (opts.accent ? " line--accent" : ""));
+      const k = el("span", "k", kText);
+      if (opts.kSub) { k.appendChild(document.createElement("br")); k.appendChild(el("span", "sub", opts.kSub)); }
+      const v = el("span", "v");
+      if (typeof vNode === "string") v.textContent = vNode; else v.appendChild(vNode);
+      if (opts.vSub) { v.appendChild(document.createTextNode(" ")); v.appendChild(el("span", "sub", opts.vSub)); }
+      row.append(k, v);
+      return row;
+    }
+
+    function compute() {
+      const body = $("resultBody");
+      let perDay, activeDays;
+      try {
+        const cron = $("cron").value;
+        // day-of-month / month aren't modelled. Refuse rather than show a
+        // monthly total off by an order of magnitude (mirrors estimate_cost.py).
+        const restrictions = cronRestrictions(cron);
+        if (restrictions.length) {
+          body.replaceChildren(el("div", "err",
+            "cron restricts " + restrictions.join(" and ") +
+            ". This estimator reads cadence from minute, hour, and day-of-week only, " +
+            "so its monthly total would be wrong here. Estimate one without a " +
+            "day-of-month or month restriction, or work it out by hand."));
+          return;
+        }
+        perDay = cronRunsPerActiveDay(cron);
+        activeDays = cronActiveDaysPerWeek(cron);
+      } catch (e) {
+        body.replaceChildren(el("div", "err", "cadence error: " + e.message));
+        return;
+      }
+      const p = {
+        work: $("work").value, review: $("review").value,
+        session: Math.max(0.1, parseFloat($("session").value) || 0),
+        passes: Math.max(1, parseInt($("passes").value, 10) || 1),
+        days: Math.max(1, parseFloat($("days").value) || 30.4),
+        mtokWorker: Math.max(0, parseFloat($("mtokWorker").value) || 0),
+        mtokReviewer: Math.max(0, parseFloat($("mtokReviewer").value) || 0),
+      };
+      const runsPerMonth = perDay * (activeDays / 7) * p.days;
+      const subscription = (parseFloat($("subWorker").value) || 0) + (parseFloat($("subReviewer").value) || 0);
+      const run = meteredPerRun(p);
+      const moLo = run[0] * runsPerMonth, moHi = run[1] * runsPerMonth;
+      const gapLo = subscription ? moLo / subscription : 0;
+      const gapHi = subscription ? moHi / subscription : 0;
+
+      body.replaceChildren();
+      body.append(line("Runs / active day", String(perDay), {
+        big: true, vSub: activeDays === 7 ? null : "(" + activeDays + " days/wk)",
+      }));
+      body.append(line("Runs / month", intc(runsPerMonth)));
+      body.append(line("Subscription / mo", money(subscription), { kSub: "flat, ~$0 per run until limits" }));
+      body.append(line("Metered / mo", money(moLo) + EN + money(moHi), {
+        accent: true, kSub: money(run[0]) + EN + money(run[1]) + " per run",
+      }));
+      body.append(line("Gap at this cadence", intc(gapLo) + "x" + EN + intc(gapHi) + "x"));
+    }
+
+    document.querySelectorAll("input, select").forEach(elm => {
+      elm.addEventListener("input", compute);
+      elm.addEventListener("change", compute);
+    });
+    compute();
+  </script>
+</body>
+</html>

--- a/docs/autonomy/kit/cost-estimator.html
+++ b/docs/autonomy/kit/cost-estimator.html
@@ -53,6 +53,7 @@
     }
     input:focus, select:focus { outline: 2px solid var(--accent); outline-offset: -1px; }
     .num { width: 110px; text-align: right; }
+    input[type="checkbox"] { width: auto; justify-self: end; accent-color: var(--accent); }
     .row--full { grid-template-columns: 1fr; }
     .result { border: 1px solid var(--ink); }
     .result__head {
@@ -131,6 +132,12 @@
             <input class="num" id="passes" type="number" min="1" step="1" value="3">
           </div>
           <div class="row">
+            <label for="reviewOn">Review enabled
+              <span class="hint">off models <code>review.enabled: false</code> &mdash; no review cost</span>
+            </label>
+            <input id="reviewOn" type="checkbox" checked>
+          </div>
+          <div class="row">
             <label for="days">Days / month</label>
             <input class="num" id="days" type="number" min="1" step="0.1" value="30.4">
           </div>
@@ -194,6 +201,13 @@
     const EN = "–"; // en dash for ranges
 
     // ===== cron cadence -> runs per day (mirrors parse_cron_field / cron_runs_per_active_day) =====
+    // Strict: the whole token must be digits. parseInt("5x") returns 5, which
+    // would silently accept malformed cron the Python estimator rejects.
+    function toInt(s) {
+      const t = String(s).trim();
+      if (!/^\d+$/.test(t)) throw new Error('"' + t + '" is not a whole number');
+      return parseInt(t, 10);
+    }
     function parseField(text, lo, hi) {
       const values = new Set();
       for (let part of text.split(",")) {
@@ -202,16 +216,15 @@
         let step = 1, base = part;
         if (part.includes("/")) {
           const bits = part.split("/");
-          step = parseInt(bits[1], 10);
+          step = toInt(bits[1]);
           if (!(step > 0)) throw new Error('bad step in "' + part + '"');
           base = bits[0];
         }
         let start, end;
         if (base === "*") { start = lo; end = hi; }
         else if (base.includes("-")) {
-          const r = base.split("-"); start = parseInt(r[0], 10); end = parseInt(r[1], 10);
-        } else { start = end = parseInt(base, 10); }
-        if (!Number.isFinite(start) || !Number.isFinite(end)) throw new Error('bad field "' + text + '"');
+          const r = base.split("-"); start = toInt(r[0]); end = toInt(r[1]);
+        } else { start = end = toInt(base); }
         if (start < lo || end > hi || start > end) throw new Error('field "' + text + '" out of range [' + lo + "," + hi + "]");
         for (let v = start; v <= end; v += step) values.add(v);
       }
@@ -245,7 +258,8 @@
       const workerLo = w[0] * p.session, workerHi = w[1] * p.session;
       const wPrice = p.mtokWorker / 1e6;
       const r = REVIEW_TOKENS_PER_PASS, mult = REVIEW_EFFORT_MULTIPLIER[p.review];
-      const reviewLo = r[0] * mult * p.passes, reviewHi = r[1] * mult * p.passes;
+      const passes = p.reviewOn ? p.passes : 0;  // review.enabled: false bills nothing
+      const reviewLo = r[0] * mult * passes, reviewHi = r[1] * mult * passes;
       const rPrice = p.mtokReviewer / 1e6;
       return [workerLo * wPrice + reviewLo * rPrice, workerHi * wPrice + reviewHi * rPrice];
     }
@@ -300,6 +314,7 @@
       }
       const p = {
         work: $("work").value, review: $("review").value,
+        reviewOn: $("reviewOn").checked,
         session: Math.max(0.1, parseFloat($("session").value) || 0),
         passes: Math.max(1, parseInt($("passes").value, 10) || 1),
         days: Math.max(1, parseFloat($("days").value) || 30.4),

--- a/docs/autonomy/kit/estimate_cost.py
+++ b/docs/autonomy/kit/estimate_cost.py
@@ -273,6 +273,11 @@ def load_config(path: str) -> dict:
         return yaml.safe_load(handle) or {}
 
 
+def _switch_on(value: object) -> bool:
+    """A config switch defaults on; only an explicit falsey value turns it off."""
+    return value is None or bool(value)
+
+
 def inputs_from_config(cfg: dict) -> dict:
     """Pull the dials this estimator cares about out of a parsed config dict."""
     schedule = cfg.get("schedule") or {}
@@ -280,6 +285,7 @@ def inputs_from_config(cfg: dict) -> dict:
     timeouts = schedule.get("timeouts") or {}
     model = cfg.get("model") or {}
     review = cfg.get("review") or {}
+    nudges = cfg.get("nudges") or {}
     out = {}
     # Test "is not None" (key present), not truthiness — else an explicit
     # review.max_passes: 0 reads as absent and the bad value never reaches the
@@ -292,8 +298,14 @@ def inputs_from_config(cfg: dict) -> dict:
         out["review_effort"] = model["review_effort"]
     if review.get("max_passes") is not None:
         out["max_passes"] = int(review["max_passes"])
-    if review.get("enabled") is not None:
-        out["review_enabled"] = bool(review["enabled"])
+    # Review actually runs only when BOTH switches are on: review.enabled gates
+    # the machinery, and nudges.review gates whether the wake prompt even asks
+    # for it (reference/wake.reference.py appends the review block only when
+    # nudges.review is truthy). Either one off means no review tokens are billed.
+    review_on = review.get("enabled")
+    nudge_on = nudges.get("review")
+    if review_on is not None or nudge_on is not None:
+        out["review_enabled"] = _switch_on(review_on) and _switch_on(nudge_on)
     # hard_minutes is a ceiling on session length, not the average. It caps the
     # assumed average when it's tighter than the default (see resolve_inputs).
     if timeouts.get("hard_minutes") is not None:

--- a/docs/autonomy/kit/estimate_cost.py
+++ b/docs/autonomy/kit/estimate_cost.py
@@ -171,6 +171,7 @@ class Inputs:
     avg_session_minutes: float
     max_passes: int
     days_per_month: float = DAYS_PER_MONTH
+    review_enabled: bool = True
 
 
 @dataclass
@@ -199,10 +200,12 @@ def metered_cost_per_run(inputs: Inputs) -> tuple[float, float]:
     worker_tokens_hi = work_hi * inputs.avg_session_minutes
     worker_price = METERED_BLENDED_USD_PER_MTOK["worker"] / 1_000_000
 
+    # review.enabled: false means the review pass doesn't run, so it bills nothing.
+    passes = inputs.max_passes if inputs.review_enabled else 0
     pass_lo, pass_hi = REVIEW_TOKENS_PER_PASS
     mult = REVIEW_EFFORT_MULTIPLIER[inputs.review_effort]
-    review_tokens_lo = pass_lo * mult * inputs.max_passes
-    review_tokens_hi = pass_hi * mult * inputs.max_passes
+    review_tokens_lo = pass_lo * mult * passes
+    review_tokens_hi = pass_hi * mult * passes
     review_price = METERED_BLENDED_USD_PER_MTOK["reviewer"] / 1_000_000
 
     low = worker_tokens_lo * worker_price + review_tokens_lo * review_price
@@ -215,8 +218,8 @@ def estimate(inputs: Inputs) -> Estimate:
     inputs.review_effort = _validate_effort("review_effort", inputs.review_effort)
     if inputs.avg_session_minutes <= 0:
         raise ValueError("avg_session_minutes must be positive")
-    if inputs.max_passes <= 0:
-        raise ValueError("max_passes must be positive")
+    if inputs.review_enabled and inputs.max_passes <= 0:
+        raise ValueError("max_passes must be positive when review is enabled")
     if inputs.days_per_month <= 0:
         raise ValueError("days_per_month must be positive")
 
@@ -278,17 +281,22 @@ def inputs_from_config(cfg: dict) -> dict:
     model = cfg.get("model") or {}
     review = cfg.get("review") or {}
     out = {}
-    if wake.get("cron"):
+    # Test "is not None" (key present), not truthiness — else an explicit
+    # review.max_passes: 0 reads as absent and the bad value never reaches the
+    # validation in estimate(), exactly the trap the CLI path also had.
+    if wake.get("cron") is not None:
         out["cron"] = wake["cron"]
-    if model.get("work_effort"):
+    if model.get("work_effort") is not None:
         out["work_effort"] = model["work_effort"]
-    if model.get("review_effort"):
+    if model.get("review_effort") is not None:
         out["review_effort"] = model["review_effort"]
-    if review.get("max_passes"):
+    if review.get("max_passes") is not None:
         out["max_passes"] = int(review["max_passes"])
+    if review.get("enabled") is not None:
+        out["review_enabled"] = bool(review["enabled"])
     # hard_minutes is a ceiling on session length, not the average. It caps the
     # assumed average when it's tighter than the default (see resolve_inputs).
-    if timeouts.get("hard_minutes"):
+    if timeouts.get("hard_minutes") is not None:
         out["hard_minutes"] = int(timeouts["hard_minutes"])
     return out
 
@@ -307,13 +315,17 @@ def format_report(inputs: Inputs, est: Estimate, *, source: str) -> str:
         if est.active_days_per_week == 7
         else f"  ({est.active_days_per_week} days/week)"
     )
+    review_note = (
+        f"review up to {inputs.max_passes} passes"
+        if inputs.review_enabled
+        else "review disabled"
+    )
     lines = [
         "Autonomy loop cost estimate",
         f"  source            {source}",
         f"  cadence (cron)    {inputs.cron}",
         f"  work / review     {inputs.work_effort} / {inputs.review_effort} effort",
-        f"  avg session       {inputs.avg_session_minutes:g} min"
-        f"   (review up to {inputs.max_passes} passes)",
+        f"  avg session       {inputs.avg_session_minutes:g} min   ({review_note})",
         "",
         f"  runs/active day   {est.runs_per_active_day}{active_note}",
         f"  runs/month        {est.runs_per_month:,.0f}",
@@ -418,6 +430,7 @@ def resolve_inputs(args: argparse.Namespace) -> tuple[Inputs, str]:
         avg_session_minutes=avg_session_minutes,
         max_passes=values.get("max_passes", DEFAULT_MAX_PASSES),
         days_per_month=args.days_per_month,
+        review_enabled=values.get("review_enabled", True),
     )
     return inputs, source
 

--- a/docs/autonomy/kit/estimate_cost.py
+++ b/docs/autonomy/kit/estimate_cost.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""Estimate what the autonomous issue-workhorse loop costs before you arm it.
+
+It turns the dials in COSTS.md into numbers: it reads the cadence, effort, and
+timeout from a config.yaml (or flags), works out how many sessions a day that
+fires, and prints a monthly cost range for subscription billing vs a metered
+API key — so the gap COSTS.md describes comes out as a concrete number.
+
+  python3 estimate_cost.py config.yaml
+  python3 estimate_cost.py --cron "*/15 7-19 * * *" --work-effort high
+  python3 estimate_cost.py --config config.example.yaml --avg-session-minutes 25
+
+The numbers below the divider are ASSUMPTIONS, not a quote. Plans and token
+prices move, and real token use swings widely with prompt caching and how much
+each session actually does. Edit the PRICES table to match your own plans and
+your observed per-session token use. The same table lives in cost-estimator.html;
+keep the two in sync.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+
+# ===========================================================================
+# PRICE ASSUMPTIONS  --  edit these to match your own plans and usage.
+# Checked roughly 2026-06. Treat as a starting point to verify, not a quote.
+# The HTML calculator (cost-estimator.html) carries the same numbers.
+# ===========================================================================
+
+# Flat monthly subscription fees, in USD. A subscription run costs nothing extra
+# until you hit the plan's limits, so these are fixed regardless of cadence.
+SUBSCRIPTION_PLANS_USD = {
+    "worker": 100.0,  # the coding agent on a flat plan (e.g. a Claude plan)
+    "reviewer": 20.0,  # the reviewer via a ChatGPT login (Codex)
+}
+
+# Metered token price, USD per 1,000,000 tokens, blended across input + output.
+# Output is pricier than input and prompt caching makes input far cheaper, so
+# these are deliberately rough mid-points. Lower them if you rely on caching.
+METERED_BLENDED_USD_PER_MTOK = {
+    "worker": 12.0,  # an Opus-class coding model
+    "reviewer": 5.0,  # a cheaper review-class model
+}
+
+# Tokens the WORKER bills per active minute, as a (low, high) band per effort
+# tier. This is the softest assumption in the file — an agent streams tool
+# results, file reads, and reasoning, so per-minute volume varies a lot. These
+# are order-of-magnitude envelopes; replace them with what you actually observe.
+WORKER_TOKENS_PER_MIN = {
+    "low": (3_000, 9_000),
+    "medium": (5_000, 14_000),
+    "high": (8_000, 22_000),
+    "xhigh": (12_000, 30_000),
+    "max": (18_000, 42_000),
+}
+
+# Tokens the REVIEWER bills per pass, as a (low, high) band, before the effort
+# multiplier below. A pass reads the diff plus surrounding context.
+REVIEW_TOKENS_PER_PASS = (15_000, 60_000)
+
+# How much each effort tier scales the reviewer's per-pass token use.
+REVIEW_EFFORT_MULTIPLIER = {
+    "low": 1.0,
+    "medium": 1.4,
+    "high": 2.0,
+    "xhigh": 2.6,
+    "max": 3.2,
+}
+
+# Calendar assumption: average days in a month.
+DAYS_PER_MONTH = 30.4
+
+# Defaults for dials that are not in config.yaml.
+DEFAULT_AVG_SESSION_MINUTES = 30.0
+DEFAULT_MAX_PASSES = 3
+VALID_EFFORTS = tuple(WORKER_TOKENS_PER_MIN.keys())
+
+# ===========================================================================
+# Cron cadence  ->  runs per day
+# ===========================================================================
+
+
+def parse_cron_field(field_text: str, lo: int, hi: int) -> set[int]:
+    """Expand one cron field into the set of values it matches within [lo, hi].
+
+    Handles "*", lists ("a,b"), ranges ("a-b"), and steps ("*/n", "a-b/n").
+    """
+    values: set[int] = set()
+    for part in field_text.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        step = 1
+        if "/" in part:
+            base, step_text = part.split("/", 1)
+            step = int(step_text)
+            if step <= 0:
+                raise ValueError(f"cron step must be positive: {part!r}")
+        else:
+            base = part
+
+        if base == "*":
+            start, end = lo, hi
+        elif "-" in base:
+            start_text, end_text = base.split("-", 1)
+            start, end = int(start_text), int(end_text)
+        else:
+            start = end = int(base)
+
+        if start < lo or end > hi or start > end:
+            raise ValueError(f"cron field {field_text!r} out of range [{lo},{hi}]")
+        values.update(range(start, end + 1, step))
+    if not values:
+        raise ValueError(f"cron field matched nothing: {field_text!r}")
+    return values
+
+
+def cron_runs_per_active_day(expr: str) -> int:
+    """Sessions fired on a day the schedule is active: minute count x hour count."""
+    fields = expr.split()
+    if len(fields) != 5:
+        raise ValueError(
+            f"expected a 5-field cron expression, got {len(fields)}: {expr!r}"
+        )
+    minute, hour = fields[0], fields[1]
+    minutes = parse_cron_field(minute, 0, 59)
+    hours = parse_cron_field(hour, 0, 23)
+    return len(minutes) * len(hours)
+
+
+def cron_active_days_per_week(expr: str) -> int:
+    """How many days a week the schedule runs, read from the day-of-week field.
+
+    cron day-of-week is 0-6 with 0 = Sunday; 7 is also Sunday. "*" means daily.
+    Only this field is read for weekday gating; day-of-month/month are assumed
+    unrestricted (a warning is printed elsewhere if they are not).
+    """
+    dow = expr.split()[4]
+    if dow.strip() == "*":
+        return 7
+    # Parse against 0-7 (cron allows both 0 and 7 for Sunday), then fold 7 -> 0
+    # on the integer set. Normalizing before the parse — dow.replace("7", "0") —
+    # would corrupt ranges like "1-7" into the invalid "1-0".
+    days = {d % 7 for d in parse_cron_field(dow, 0, 7)}
+    return len(days)
+
+
+def cron_unsupported_restrictions(expr: str) -> list[str]:
+    """Day-of-month / month restrictions this estimator does not model."""
+    fields = expr.split()
+    notes = []
+    if fields[2].strip() != "*":
+        notes.append(f"day-of-month is {fields[2]!r}")
+    if fields[3].strip() != "*":
+        notes.append(f"month is {fields[3]!r}")
+    return notes
+
+
+# ===========================================================================
+# Cost model
+# ===========================================================================
+
+
+@dataclass
+class Inputs:
+    cron: str
+    work_effort: str
+    review_effort: str
+    avg_session_minutes: float
+    max_passes: int
+    days_per_month: float = DAYS_PER_MONTH
+
+
+@dataclass
+class Estimate:
+    runs_per_active_day: int
+    active_days_per_week: int
+    runs_per_month: float
+    subscription_monthly_usd: float
+    metered_per_run_usd: tuple[float, float]
+    metered_monthly_usd: tuple[float, float]
+
+
+def _validate_effort(name: str, value: str) -> str:
+    value = (value or "").lower()
+    if value not in VALID_EFFORTS:
+        raise ValueError(
+            f"{name} must be one of {', '.join(VALID_EFFORTS)}; got {value!r}"
+        )
+    return value
+
+
+def metered_cost_per_run(inputs: Inputs) -> tuple[float, float]:
+    """(low, high) USD for one session billed against a metered API key."""
+    work_lo, work_hi = WORKER_TOKENS_PER_MIN[inputs.work_effort]
+    worker_tokens_lo = work_lo * inputs.avg_session_minutes
+    worker_tokens_hi = work_hi * inputs.avg_session_minutes
+    worker_price = METERED_BLENDED_USD_PER_MTOK["worker"] / 1_000_000
+
+    pass_lo, pass_hi = REVIEW_TOKENS_PER_PASS
+    mult = REVIEW_EFFORT_MULTIPLIER[inputs.review_effort]
+    review_tokens_lo = pass_lo * mult * inputs.max_passes
+    review_tokens_hi = pass_hi * mult * inputs.max_passes
+    review_price = METERED_BLENDED_USD_PER_MTOK["reviewer"] / 1_000_000
+
+    low = worker_tokens_lo * worker_price + review_tokens_lo * review_price
+    high = worker_tokens_hi * worker_price + review_tokens_hi * review_price
+    return low, high
+
+
+def estimate(inputs: Inputs) -> Estimate:
+    inputs.work_effort = _validate_effort("work_effort", inputs.work_effort)
+    inputs.review_effort = _validate_effort("review_effort", inputs.review_effort)
+    if inputs.avg_session_minutes <= 0:
+        raise ValueError("avg_session_minutes must be positive")
+    if inputs.max_passes <= 0:
+        raise ValueError("max_passes must be positive")
+
+    per_active_day = cron_runs_per_active_day(inputs.cron)
+    active_days = cron_active_days_per_week(inputs.cron)
+
+    # day-of-month and month aren't modelled. Rather than report a monthly total
+    # that's off by an order of magnitude — "0 9 1 * *" runs once a month, but
+    # minute x hour x day-of-week reads it as ~30 — refuse the schedule and say
+    # why, instead of printing a confident wrong number with a footnote.
+    restrictions = cron_unsupported_restrictions(inputs.cron)
+    if restrictions:
+        raise ValueError(
+            "cron restricts " + " and ".join(restrictions) + ". This estimator "
+            "reads cadence from minute, hour, and day-of-week only, so its "
+            "monthly total would be wrong for this schedule. Estimate one "
+            "without a day-of-month or month restriction, or work it out by hand."
+        )
+
+    runs_per_month = per_active_day * (active_days / 7.0) * inputs.days_per_month
+    subscription = sum(SUBSCRIPTION_PLANS_USD.values())
+    run_lo, run_hi = metered_cost_per_run(inputs)
+    monthly = (run_lo * runs_per_month, run_hi * runs_per_month)
+
+    return Estimate(
+        runs_per_active_day=per_active_day,
+        active_days_per_week=active_days,
+        runs_per_month=runs_per_month,
+        subscription_monthly_usd=subscription,
+        metered_per_run_usd=(run_lo, run_hi),
+        metered_monthly_usd=monthly,
+    )
+
+
+# ===========================================================================
+# Config loading + CLI
+# ===========================================================================
+
+
+def load_config(path: str) -> dict:
+    """Read the kit's config.yaml. PyYAML is optional; without it, use flags."""
+    try:
+        import yaml  # type: ignore
+    except ModuleNotFoundError as exc:  # pragma: no cover - environment-specific
+        raise SystemExit(
+            "PyYAML is not installed, so --config can't be read. Either "
+            "`pip install pyyaml`, or pass the dials as flags "
+            "(--cron, --work-effort, --review-effort, --max-passes)."
+        ) from exc
+    with open(path, encoding="utf-8") as handle:
+        return yaml.safe_load(handle) or {}
+
+
+def inputs_from_config(cfg: dict) -> dict:
+    """Pull the dials this estimator cares about out of a parsed config dict."""
+    schedule = cfg.get("schedule") or {}
+    wake = schedule.get("wake") or {}
+    timeouts = schedule.get("timeouts") or {}
+    model = cfg.get("model") or {}
+    review = cfg.get("review") or {}
+    out = {}
+    if wake.get("cron"):
+        out["cron"] = wake["cron"]
+    if model.get("work_effort"):
+        out["work_effort"] = model["work_effort"]
+    if model.get("review_effort"):
+        out["review_effort"] = model["review_effort"]
+    if review.get("max_passes"):
+        out["max_passes"] = int(review["max_passes"])
+    # hard_minutes is a ceiling on session length, not the average. It caps the
+    # assumed average when it's tighter than the default (see resolve_inputs).
+    if timeouts.get("hard_minutes"):
+        out["hard_minutes"] = int(timeouts["hard_minutes"])
+    return out
+
+
+def _money(value: float) -> str:
+    return f"${value:,.0f}" if value >= 100 else f"${value:,.2f}"
+
+
+def format_report(inputs: Inputs, est: Estimate, *, source: str) -> str:
+    lo_run, hi_run = est.metered_per_run_usd
+    lo_mo, hi_mo = est.metered_monthly_usd
+    gap_lo = lo_mo / est.subscription_monthly_usd if est.subscription_monthly_usd else 0
+    gap_hi = hi_mo / est.subscription_monthly_usd if est.subscription_monthly_usd else 0
+    active_note = (
+        ""
+        if est.active_days_per_week == 7
+        else f"  ({est.active_days_per_week} days/week)"
+    )
+    lines = [
+        "Autonomy loop cost estimate",
+        f"  source            {source}",
+        f"  cadence (cron)    {inputs.cron}",
+        f"  work / review     {inputs.work_effort} / {inputs.review_effort} effort",
+        f"  avg session       {inputs.avg_session_minutes:g} min"
+        f"   (review up to {inputs.max_passes} passes)",
+        "",
+        f"  runs/active day   {est.runs_per_active_day}{active_note}",
+        f"  runs/month        {est.runs_per_month:,.0f}",
+        "",
+        "Subscription billing (flat plans)",
+        f"  monthly           {_money(est.subscription_monthly_usd)}"
+        "   (until plan limits; ~$0 marginal per run)",
+        "",
+        "Metered API billing (pay per token)",
+        f"  per run           {_money(lo_run)} – {_money(hi_run)}",
+        f"  monthly           {_money(lo_mo)} – {_money(hi_mo)}",
+        "",
+        f"Gap: metered runs about {gap_lo:,.0f}x – {gap_hi:,.0f}x the flat plans "
+        "at this cadence.",
+    ]
+    lines += [
+        "",
+        "Price assumptions (USD) — edit at the top of estimate_cost.py to fit your plans:",
+        f"  subscription/mo   worker {_money(SUBSCRIPTION_PLANS_USD['worker'])}, "
+        f"reviewer {_money(SUBSCRIPTION_PLANS_USD['reviewer'])}",
+        f"  metered $/Mtok    worker {METERED_BLENDED_USD_PER_MTOK['worker']:g}, "
+        f"reviewer {METERED_BLENDED_USD_PER_MTOK['reviewer']:g} (blended in+out)",
+        f"  worker tokens/min ({inputs.work_effort}) "
+        f"{WORKER_TOKENS_PER_MIN[inputs.work_effort][0]:,}"
+        f"–{WORKER_TOKENS_PER_MIN[inputs.work_effort][1]:,}",
+        "",
+        "These are rough order-of-magnitude assumptions, not a quote. Plans and "
+        "token prices move,",
+        "and real token use swings with prompt caching and task size. Calibrate "
+        "with your own numbers.",
+    ]
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Estimate the autonomy loop's monthly cost: subscription vs metered.",
+    )
+    parser.add_argument(
+        "config",
+        nargs="?",
+        help="path to config.yaml (positional shorthand for --config)",
+    )
+    parser.add_argument("--config", dest="config_opt", help="path to config.yaml")
+    parser.add_argument("--cron", help="cron cadence, overrides the config")
+    parser.add_argument("--work-effort", help=f"one of {', '.join(VALID_EFFORTS)}")
+    parser.add_argument("--review-effort", help=f"one of {', '.join(VALID_EFFORTS)}")
+    parser.add_argument(
+        "--avg-session-minutes",
+        type=float,
+        help=f"average minutes a session runs (default {DEFAULT_AVG_SESSION_MINUTES:g})",
+    )
+    parser.add_argument("--max-passes", type=int, help="review passes per session")
+    parser.add_argument(
+        "--days-per-month",
+        type=float,
+        default=DAYS_PER_MONTH,
+        help=f"days in a month (default {DAYS_PER_MONTH})",
+    )
+    return parser
+
+
+def resolve_inputs(args: argparse.Namespace) -> tuple[Inputs, str]:
+    cfg_path = args.config_opt or args.config
+    values: dict = {}
+    source = "flags"
+    if cfg_path:
+        values.update(inputs_from_config(load_config(cfg_path)))
+        source = cfg_path
+    # Flag overrides win over the config file.
+    if args.cron:
+        values["cron"] = args.cron
+    if args.work_effort:
+        values["work_effort"] = args.work_effort
+    if args.review_effort:
+        values["review_effort"] = args.review_effort
+    if args.max_passes:
+        values["max_passes"] = args.max_passes
+    if args.avg_session_minutes:
+        values["avg_session_minutes"] = args.avg_session_minutes
+
+    if "cron" not in values:
+        raise SystemExit(
+            "no cadence given. Pass a config.yaml with schedule.wake.cron, or --cron."
+        )
+    # An explicit average always wins. Otherwise start from the default and let a
+    # hard timeout pull it down when the timeout is tighter than that default —
+    # a 15-minute cap can't average 30 minutes a session.
+    if "avg_session_minutes" in values:
+        avg_session_minutes = values["avg_session_minutes"]
+    else:
+        avg_session_minutes = DEFAULT_AVG_SESSION_MINUTES
+        if "hard_minutes" in values:
+            avg_session_minutes = min(avg_session_minutes, values["hard_minutes"])
+    inputs = Inputs(
+        cron=values["cron"],
+        work_effort=values.get("work_effort", "high"),
+        review_effort=values.get("review_effort", "low"),
+        avg_session_minutes=avg_session_minutes,
+        max_passes=values.get("max_passes", DEFAULT_MAX_PASSES),
+        days_per_month=args.days_per_month,
+    )
+    return inputs, source
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        inputs, source = resolve_inputs(args)
+        est = estimate(inputs)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(format_report(inputs, est, source=source))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/autonomy/kit/estimate_cost.py
+++ b/docs/autonomy/kit/estimate_cost.py
@@ -217,6 +217,8 @@ def estimate(inputs: Inputs) -> Estimate:
         raise ValueError("avg_session_minutes must be positive")
     if inputs.max_passes <= 0:
         raise ValueError("max_passes must be positive")
+    if inputs.days_per_month <= 0:
+        raise ValueError("days_per_month must be positive")
 
     per_active_day = cron_runs_per_active_day(inputs.cron)
     active_days = cron_active_days_per_week(inputs.cron)
@@ -381,16 +383,19 @@ def resolve_inputs(args: argparse.Namespace) -> tuple[Inputs, str]:
     if cfg_path:
         values.update(inputs_from_config(load_config(cfg_path)))
         source = cfg_path
-    # Flag overrides win over the config file.
-    if args.cron:
+    # Flag overrides win over the config file. Test "is not None" (was the flag
+    # passed?), not truthiness — otherwise an explicit --max-passes 0 or
+    # --avg-session-minutes 0 is falsy, gets silently dropped for the default,
+    # and the positive-value checks in estimate() never see the bad value.
+    if args.cron is not None:
         values["cron"] = args.cron
-    if args.work_effort:
+    if args.work_effort is not None:
         values["work_effort"] = args.work_effort
-    if args.review_effort:
+    if args.review_effort is not None:
         values["review_effort"] = args.review_effort
-    if args.max_passes:
+    if args.max_passes is not None:
         values["max_passes"] = args.max_passes
-    if args.avg_session_minutes:
+    if args.avg_session_minutes is not None:
         values["avg_session_minutes"] = args.avg_session_minutes
 
     if "cron" not in values:

--- a/docs/autonomy/kit/test_estimate_cost.py
+++ b/docs/autonomy/kit/test_estimate_cost.py
@@ -234,6 +234,27 @@ def test_inputs_from_config_reads_review_enabled():
     assert "review_enabled" not in ec.inputs_from_config({"review": {}})
 
 
+def test_inputs_from_config_nudge_off_disables_review():
+    # nudges.review gates whether the wake prompt asks for review at all, so it
+    # disables review the same way review.enabled does — even with enabled true.
+    assert (
+        ec.inputs_from_config({"nudges": {"review": False}})["review_enabled"] is False
+    )
+    assert (
+        ec.inputs_from_config(
+            {"review": {"enabled": True}, "nudges": {"review": False}}
+        )["review_enabled"]
+        is False
+    )
+    # Both switches explicitly on -> review on.
+    assert (
+        ec.inputs_from_config(
+            {"review": {"enabled": True}, "nudges": {"review": True}}
+        )["review_enabled"]
+        is True
+    )
+
+
 def test_disabled_review_zeroes_review_cost():
     on = ec.metered_cost_per_run(_inputs(review_enabled=True))
     off = ec.metered_cost_per_run(_inputs(review_enabled=False))

--- a/docs/autonomy/kit/test_estimate_cost.py
+++ b/docs/autonomy/kit/test_estimate_cost.py
@@ -217,6 +217,47 @@ def test_inputs_from_config_tolerates_missing_sections():
     assert ec.inputs_from_config({}) == {}
 
 
+def test_inputs_from_config_preserves_explicit_zero_max_passes():
+    # review.max_passes: 0 must survive as 0, not be dropped by a truthiness
+    # check the way the CLI path used to drop --max-passes 0.
+    assert ec.inputs_from_config({"review": {"max_passes": 0}})["max_passes"] == 0
+
+
+def test_inputs_from_config_reads_review_enabled():
+    assert (
+        ec.inputs_from_config({"review": {"enabled": False}})["review_enabled"] is False
+    )
+    assert (
+        ec.inputs_from_config({"review": {"enabled": True}})["review_enabled"] is True
+    )
+    # Absent enabled key defaults to on (handled downstream), so it's not emitted.
+    assert "review_enabled" not in ec.inputs_from_config({"review": {}})
+
+
+def test_disabled_review_zeroes_review_cost():
+    on = ec.metered_cost_per_run(_inputs(review_enabled=True))
+    off = ec.metered_cost_per_run(_inputs(review_enabled=False))
+    assert off[0] < on[0]
+    assert off[1] < on[1]
+    # With review off, max_passes is irrelevant — it bills no review tokens.
+    assert ec.metered_cost_per_run(_inputs(review_enabled=False, max_passes=99)) == off
+
+
+def test_disabled_review_allows_zero_max_passes():
+    # max_passes 0 is moot when review is off, so estimate() accepts it; it's
+    # rejected only when review is enabled.
+    est = ec.estimate(_inputs(review_enabled=False, max_passes=0))
+    assert est.metered_per_run_usd[0] > 0  # worker cost still present
+    with pytest.raises(ValueError, match="max_passes"):
+        ec.estimate(_inputs(review_enabled=True, max_passes=0))
+
+
+def test_format_report_notes_disabled_review():
+    inputs = _inputs(review_enabled=False)
+    report = ec.format_report(inputs, ec.estimate(inputs), source="flags")
+    assert "review disabled" in report
+
+
 def test_example_config_round_trips_through_estimate():
     here = os.path.dirname(__file__)
     path = os.path.join(here, "config.example.yaml")
@@ -244,6 +285,32 @@ def _write_config(tmp_path, cfg):
     path = tmp_path / "config.yaml"
     path.write_text(yaml.safe_dump(cfg))
     return str(path)
+
+
+def test_config_explicit_zero_max_passes_rejected(tmp_path):
+    # The config path must reject review.max_passes: 0 too, not just the CLI.
+    path = _write_config(
+        tmp_path,
+        {"schedule": {"wake": {"cron": "0 * * * *"}}, "review": {"max_passes": 0}},
+    )
+    assert ec.main([path]) == 2
+
+
+def test_config_review_disabled_lowers_cost(tmp_path):
+    # review.enabled: false flows through to a lower metered estimate.
+    yaml = pytest.importorskip("yaml")
+    base = {"schedule": {"wake": {"cron": "0 * * * *"}}}
+    on_path = tmp_path / "on.yaml"
+    on_path.write_text(yaml.safe_dump(base))
+    off_path = tmp_path / "off.yaml"
+    off_path.write_text(yaml.safe_dump({**base, "review": {"enabled": False}}))
+    on, _ = ec.resolve_inputs(ec.build_parser().parse_args([str(on_path)]))
+    off, _ = ec.resolve_inputs(ec.build_parser().parse_args([str(off_path)]))
+    assert on.review_enabled is True
+    assert off.review_enabled is False
+    assert (
+        ec.estimate(off).metered_per_run_usd[0] < ec.estimate(on).metered_per_run_usd[0]
+    )
 
 
 def test_hard_timeout_caps_average_session(tmp_path):

--- a/docs/autonomy/kit/test_estimate_cost.py
+++ b/docs/autonomy/kit/test_estimate_cost.py
@@ -1,0 +1,288 @@
+"""Tests for estimate_cost.py.
+
+The cron cases are pinned to the reference numbers COSTS.md publishes
+("hourly during work hours is ~13 runs a day; every 15 minutes is ~50"; the
+high end is "~100 sessions a day"), so the estimator and the prose can't drift.
+
+Run:  python3 -m pytest docs/autonomy/kit/test_estimate_cost.py -q
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import estimate_cost as ec  # noqa: E402
+
+
+# --- cron cadence, anchored to COSTS.md -----------------------------------
+
+
+@pytest.mark.parametrize(
+    "expr, per_day, days_per_week",
+    [
+        ("5 7-19 * * *", 13, 7),  # COSTS.md: hourly, work hours ~= 13/day
+        ("*/15 7-19 * * *", 52, 7),  # COSTS.md: every 15 min, work hours ~= 50
+        ("*/15 * * * *", 96, 7),  # COSTS.md high end: ~100 sessions a day
+        ("0 * * * *", 24, 7),  # hourly, around the clock
+        ("0 9-17 * * 1-5", 9, 5),  # work hours, weekdays only
+        ("0 0 * * *", 1, 7),  # once a day
+        ("0,30 7-19 * * *", 26, 7),  # twice an hour, work hours
+    ],
+)
+def test_cron_reference_cadences(expr, per_day, days_per_week):
+    assert ec.cron_runs_per_active_day(expr) == per_day
+    assert ec.cron_active_days_per_week(expr) == days_per_week
+
+
+def test_dow_7_is_sunday_like_0():
+    # 0 and 7 both mean Sunday, so they collapse to one day.
+    assert ec.cron_active_days_per_week("0 9 * * 0,7") == 1
+    assert ec.cron_active_days_per_week("0 9 * * 6,0") == 2
+
+
+def test_dow_ranges_containing_seven():
+    # A range that ends at 7 must not be string-mangled into "1-0". "1-7" spans
+    # Mon..Sun, and 7 folds onto Sunday (= 0), so it's all 7 days.
+    assert ec.cron_active_days_per_week("0 9 * * 1-7") == 7
+    # "5-7" is Fri, Sat, Sun = 3 days.
+    assert ec.cron_active_days_per_week("0 9 * * 5-7") == 3
+    # "6-7" is Sat, Sun = 2 days.
+    assert ec.cron_active_days_per_week("0 9 * * 6-7") == 2
+
+
+@pytest.mark.parametrize(
+    "field, lo, hi, expected",
+    [
+        ("*", 0, 5, {0, 1, 2, 3, 4, 5}),
+        ("*/2", 0, 6, {0, 2, 4, 6}),
+        ("1-3", 0, 59, {1, 2, 3}),
+        ("0-10/5", 0, 59, {0, 5, 10}),
+        ("7,9,11", 0, 23, {7, 9, 11}),
+        ("5", 0, 59, {5}),
+    ],
+)
+def test_parse_cron_field(field, lo, hi, expected):
+    assert ec.parse_cron_field(field, lo, hi) == expected
+
+
+@pytest.mark.parametrize("bad", ["99", "7-2", "-1", "", "*/0"])
+def test_parse_cron_field_rejects_bad(bad):
+    with pytest.raises(ValueError):
+        ec.parse_cron_field(bad, 0, 23)
+
+
+def test_cron_requires_five_fields():
+    with pytest.raises(ValueError):
+        ec.cron_runs_per_active_day("0 * * *")
+
+
+def test_unsupported_restrictions_flagged():
+    assert ec.cron_unsupported_restrictions("0 9 1 * *")  # day-of-month set
+    assert ec.cron_unsupported_restrictions("0 9 * 6 *")  # month set
+    assert ec.cron_unsupported_restrictions("0 9 * * *") == []
+
+
+@pytest.mark.parametrize("cron", ["0 9 1 * *", "0 9 * 6 *", "0 9 1 6 *"])
+def test_estimate_refuses_unsupported_restrictions(cron):
+    # A day-of-month or month restriction would make the monthly total wrong, so
+    # estimate() refuses rather than print a confident wrong number.
+    with pytest.raises(ValueError, match="day-of-month|month"):
+        ec.estimate(_inputs(cron=cron))
+
+
+def test_estimate_allows_day_of_week_restriction():
+    # day-of-week IS modelled, so it must not be swept up by the refusal.
+    est = ec.estimate(_inputs(cron="0 9-17 * * 1-5"))
+    assert est.runs_per_active_day == 9
+    assert est.active_days_per_week == 5
+
+
+# --- cost model ------------------------------------------------------------
+
+
+def _inputs(**kw):
+    base = dict(
+        cron="5 7-19 * * *",
+        work_effort="high",
+        review_effort="low",
+        avg_session_minutes=30.0,
+        max_passes=3,
+    )
+    base.update(kw)
+    return ec.Inputs(**base)
+
+
+def test_subscription_is_flat_regardless_of_cadence():
+    sparse = ec.estimate(_inputs(cron="0 0 * * *"))
+    dense = ec.estimate(_inputs(cron="*/15 * * * *"))
+    assert sparse.subscription_monthly_usd == dense.subscription_monthly_usd
+    assert sparse.subscription_monthly_usd == sum(ec.SUBSCRIPTION_PLANS_USD.values())
+
+
+def test_metered_monthly_scales_with_runs():
+    sparse = ec.estimate(_inputs(cron="0 0 * * *"))  # 1/day
+    dense = ec.estimate(_inputs(cron="0 * * * *"))  # 24/day
+    assert dense.runs_per_month == pytest.approx(sparse.runs_per_month * 24)
+    assert dense.metered_monthly_usd[0] == pytest.approx(
+        sparse.metered_monthly_usd[0] * 24
+    )
+
+
+def test_higher_work_effort_costs_more_per_run():
+    low = ec.metered_cost_per_run(_inputs(work_effort="low"))
+    high = ec.metered_cost_per_run(_inputs(work_effort="max"))
+    assert high[0] > low[0]
+    assert high[1] > low[1]
+
+
+def test_more_passes_costs_more():
+    one = ec.metered_cost_per_run(_inputs(max_passes=1))
+    three = ec.metered_cost_per_run(_inputs(max_passes=3))
+    assert three[0] > one[0]
+
+
+def test_longer_session_costs_more():
+    short = ec.metered_cost_per_run(_inputs(avg_session_minutes=10))
+    long = ec.metered_cost_per_run(_inputs(avg_session_minutes=60))
+    assert long[0] > short[0]
+
+
+def test_range_low_below_high():
+    run_lo, run_hi = ec.metered_cost_per_run(_inputs())
+    assert run_lo < run_hi
+
+
+def test_weekday_gating_reduces_monthly_runs():
+    daily = ec.estimate(_inputs(cron="0 9-17 * * *"))
+    weekdays = ec.estimate(_inputs(cron="0 9-17 * * 1-5"))
+    assert weekdays.runs_per_month == pytest.approx(daily.runs_per_month * 5 / 7)
+
+
+def test_invalid_effort_rejected():
+    with pytest.raises(ValueError):
+        ec.estimate(_inputs(work_effort="turbo"))
+
+
+def test_nonpositive_session_rejected():
+    with pytest.raises(ValueError):
+        ec.estimate(_inputs(avg_session_minutes=0))
+
+
+# --- config extraction + end to end ---------------------------------------
+
+
+def test_inputs_from_config_reads_the_dials():
+    cfg = {
+        "schedule": {
+            "wake": {"cron": "5 7-19 * * *"},
+            "timeouts": {"hard_minutes": 90},
+        },
+        "model": {"work_effort": "high", "review_effort": "low"},
+        "review": {"max_passes": 2},
+    }
+    got = ec.inputs_from_config(cfg)
+    assert got["cron"] == "5 7-19 * * *"
+    assert got["work_effort"] == "high"
+    assert got["review_effort"] == "low"
+    assert got["max_passes"] == 2
+    assert got["hard_minutes"] == 90
+
+
+def test_inputs_from_config_tolerates_missing_sections():
+    assert ec.inputs_from_config({}) == {}
+
+
+def test_example_config_round_trips_through_estimate():
+    here = os.path.dirname(__file__)
+    path = os.path.join(here, "config.example.yaml")
+    if not os.path.exists(path):  # pragma: no cover
+        pytest.skip("config.example.yaml not present")
+    pytest.importorskip("yaml")
+    values = ec.inputs_from_config(ec.load_config(path))
+    inputs = ec.Inputs(
+        cron=values["cron"],
+        work_effort=values.get("work_effort", "high"),
+        review_effort=values.get("review_effort", "low"),
+        avg_session_minutes=ec.DEFAULT_AVG_SESSION_MINUTES,
+        max_passes=values.get("max_passes", ec.DEFAULT_MAX_PASSES),
+    )
+    est = ec.estimate(inputs)
+    # The example cadence is "5 7-19 * * *" -> 13/day, matching COSTS.md.
+    assert est.runs_per_active_day == 13
+    assert est.runs_per_month == pytest.approx(13 * ec.DAYS_PER_MONTH)
+    assert est.subscription_monthly_usd == sum(ec.SUBSCRIPTION_PLANS_USD.values())
+    assert est.metered_monthly_usd[1] > est.metered_monthly_usd[0] > 0
+
+
+def _write_config(tmp_path, cfg):
+    yaml = pytest.importorskip("yaml")
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(cfg))
+    return str(path)
+
+
+def test_hard_timeout_caps_average_session(tmp_path):
+    # A 10-minute hard cap is tighter than the 30-minute default average, so it
+    # pulls the assumed average down — the timeout dial has to do something.
+    path = _write_config(
+        tmp_path,
+        {"schedule": {"wake": {"cron": "0 * * * *"}, "timeouts": {"hard_minutes": 10}}},
+    )
+    args = ec.build_parser().parse_args([path])
+    inputs, _ = ec.resolve_inputs(args)
+    assert inputs.avg_session_minutes == 10
+
+
+def test_loose_hard_timeout_leaves_default_average(tmp_path):
+    # A 90-minute cap is looser than the 30-minute default, so the default stands.
+    path = _write_config(
+        tmp_path,
+        {"schedule": {"wake": {"cron": "0 * * * *"}, "timeouts": {"hard_minutes": 90}}},
+    )
+    args = ec.build_parser().parse_args([path])
+    inputs, _ = ec.resolve_inputs(args)
+    assert inputs.avg_session_minutes == ec.DEFAULT_AVG_SESSION_MINUTES
+
+
+def test_explicit_avg_flag_overrides_hard_timeout(tmp_path):
+    # An explicit --avg-session-minutes wins even over a tighter timeout.
+    path = _write_config(
+        tmp_path,
+        {"schedule": {"wake": {"cron": "0 * * * *"}, "timeouts": {"hard_minutes": 5}}},
+    )
+    args = ec.build_parser().parse_args([path, "--avg-session-minutes", "45"])
+    inputs, _ = ec.resolve_inputs(args)
+    assert inputs.avg_session_minutes == 45
+
+
+def test_tighter_timeout_lowers_metered_cost(tmp_path):
+    # The wiring should be visible in the bill, not just the inputs.
+    tight = _write_config(
+        tmp_path,
+        {"schedule": {"wake": {"cron": "0 * * * *"}, "timeouts": {"hard_minutes": 5}}},
+    )
+    tight_inputs, _ = ec.resolve_inputs(ec.build_parser().parse_args([tight]))
+    default_inputs = ec.Inputs(
+        cron="0 * * * *",
+        work_effort=tight_inputs.work_effort,
+        review_effort=tight_inputs.review_effort,
+        avg_session_minutes=ec.DEFAULT_AVG_SESSION_MINUTES,
+        max_passes=tight_inputs.max_passes,
+    )
+    tight_run = ec.metered_cost_per_run(tight_inputs)
+    default_run = ec.metered_cost_per_run(default_inputs)
+    assert tight_run[0] < default_run[0]
+    assert tight_run[1] < default_run[1]
+
+
+def test_format_report_shows_required_numbers():
+    inputs = _inputs()
+    est = ec.estimate(inputs)
+    report = ec.format_report(inputs, est, source="flags")
+    assert "runs/month" in report
+    assert "Subscription billing" in report
+    assert "Metered API billing" in report
+    assert "Price assumptions" in report

--- a/docs/autonomy/kit/test_estimate_cost.py
+++ b/docs/autonomy/kit/test_estimate_cost.py
@@ -171,6 +171,28 @@ def test_nonpositive_session_rejected():
         ec.estimate(_inputs(avg_session_minutes=0))
 
 
+@pytest.mark.parametrize("days", [0, -3])
+def test_nonpositive_days_per_month_rejected(days):
+    # A zero or negative calendar would yield zero/negative runs and cost.
+    with pytest.raises(ValueError, match="days_per_month"):
+        ec.estimate(_inputs(days_per_month=days))
+
+
+@pytest.mark.parametrize(
+    "flag, value",
+    [
+        ("--max-passes", "0"),
+        ("--avg-session-minutes", "0"),
+        ("--days-per-month", "0"),
+        ("--days-per-month", "-5"),
+    ],
+)
+def test_cli_rejects_explicit_invalid_overrides(flag, value):
+    # An explicit invalid override must be rejected (exit 2), not silently
+    # swapped for the default because 0 is falsy.
+    assert ec.main(["--cron", "0 * * * *", flag, value]) == 2
+
+
 # --- config extraction + end to end ---------------------------------------
 
 


### PR DESCRIPTION
Closes #102.

COSTS.md explains the levers but leaves the actual number to the reader. This adds a tool that turns the cadence, effort, and timeout dials into estimated runs/day, runs/month, and a monthly cost range for subscription vs. metered billing — so the gap is concrete before you arm the loop.

## What's here

- `estimate_cost.py` — reads your `config.yaml` (or flags), prints the estimate. Zero dependencies beyond optional PyYAML for the config path.
- `cost-estimator.html` — the same cost model in a self-contained browser page. No build, no network. DOM-built output (no `innerHTML`), inline SVG favicon, full OG/Twitter tags.
- `test_estimate_cost.py` — 43 tests. Cron cadences are anchored to the reference numbers in COSTS.md so the estimator and the prose can't drift.
- COSTS.md + README.md — point at both tools.

The price assumptions sit in one editable block at the top of each front end, so they're easy to swap for your own plans.

## Design choices worth a look

- **Refuses schedules it can't model.** The estimator reads cadence from minute, hour, and day-of-week only. A day-of-month or month restriction (e.g. `0 9 1 * *`) would make the monthly total off by an order of magnitude, so it refuses and says why instead of printing a confident wrong number — in both the CLI and the browser.
- **The hard timeout actually moves the number.** It caps the assumed average session length when it's tighter than the default, so the documented timeout dial isn't read and ignored.
- **Cron day-of-week 7 -> Sunday** is folded after parsing, not by rewriting the field text, so ranges like `1-7` stay valid.

## Verification

- `python3 -m pytest docs/autonomy/kit/test_estimate_cost.py -q` -> 43 passed.
- `ruff format` + `ruff check` clean.
- Browser-checked the HTML against the Python output: default cadence 13/day, $120 sub, $1,227-$3,486 metered, 10x-29x gap; weekday-only 9/day, 195/mo; both restricted crons refuse; day-of-week ranges (`1-7`->7 days, `5-7`->3 days) match. Zero console errors.