### PR TITLE
Make WSL the recommended Windows path; harden the native Task Scheduler template

### DIFF
--- a/docs/autonomy/kit/BUILD-WITH-YOUR-AGENT.md
+++ b/docs/autonomy/kit/BUILD-WITH-YOUR-AGENT.md
@@ -149,7 +149,11 @@ Two warnings that have actually bitten people:
   `templates/task-scheduler.ps1.example` registers the schedule with the
   documented `Register-ScheduledTask -Xml` form and shows a PowerShell
   job-plus-kill-timer wrapper so the wake script bounds itself. If you can run
-  WSL, do; only reach for the native path if you genuinely can't.
+  WSL, do; only reach for the native path if you genuinely can't. One WSL setup
+  step is easy to miss: the distro's VM stops when idle and cron doesn't
+  auto-start, so a crontab alone won't survive a reboot — enable cron under
+  systemd and add a Windows logon task to boot the distro. The header of
+  `templates/task-scheduler.ps1.example` spells out both one-time steps.
 
 - **The Notifier is the one primitive that's identical everywhere** because it's
   just an HTTPS call. To keep a first build trivial, set `notify.channel: stdout`

--- a/docs/autonomy/kit/BUILD-WITH-YOUR-AGENT.md
+++ b/docs/autonomy/kit/BUILD-WITH-YOUR-AGENT.md
@@ -111,9 +111,9 @@ pick the right column. Nothing else in the build should branch on OS.
 
 | Primitive | What it does | Linux | macOS | Windows |
 |---|---|---|---|---|
-| **Scheduler** | fires the wake on a cadence | `cron` | `launchd` (a `.plist` in `~/Library/LaunchAgents`) or `cron` | Task Scheduler, or `cron` inside WSL |
-| **Timeout wrapper** | kills a hung session *without* killing it before output flushes | `timeout --foreground` (GNU or uutils coreutils) | `gtimeout --foreground` (`brew install coreutils`) | a PowerShell job with a kill timer, or run the loop in WSL with GNU `timeout` |
-| **Session host** | keeps the long session alive and captures its output | `tmux` (or a detached process to a log) | `tmux` | Windows Terminal / a background `Start-Process`, or `tmux` in WSL |
+| **Scheduler** | fires the wake on a cadence | `cron` | `launchd` (a `.plist` in `~/Library/LaunchAgents`) or `cron` | `cron` inside WSL (recommended), or native Task Scheduler |
+| **Timeout wrapper** | kills a hung session *without* killing it before output flushes | `timeout --foreground` (GNU or uutils coreutils) | `gtimeout --foreground` (`brew install coreutils`) | GNU `timeout --foreground` inside WSL (recommended), or a native PowerShell job with a kill timer |
+| **Session host** | keeps the long session alive and captures its output | `tmux` (or a detached process to a log) | `tmux` | `tmux` inside WSL (recommended), or Windows Terminal / a background `Start-Process` |
 | **Secret store** | resolves the `*_ref` names to real values | `pass`, or env | Keychain, `pass`, or env | Credential Manager, `1password` CLI, or env |
 | **Notifier** | delivers the session summary | Telegram bot (HTTPS), or stdout | same | same |
 
@@ -138,9 +138,18 @@ Two warnings that have actually bitten people:
   group — and in practice a Node-based agent CLI killed that way can leave a
   truncated or zero-byte log behind a "succeeded" status (we've hit exactly this).
   Flush timing also depends on the child's stdio buffering, so treat `--foreground`
-  as necessary, not a guarantee. Use it (or `gtimeout --foreground` on macOS); on
-  Windows, the simplest reliable path is to run the loop inside WSL and use the
-  Linux column.
+  as necessary, not a guarantee. Use it (or `gtimeout --foreground` on macOS).
+
+- **On Windows, run the loop inside WSL — that's the recommended path, not a
+  fallback.** WSL reuses the exact Linux primitives this kit was tested on (cron,
+  GNU `timeout --foreground`, tmux), so it sidesteps the two native Windows gaps:
+  there's no native `timeout --foreground` equivalent, and Task Scheduler's own
+  time limit terminates a run without letting the agent flush its log. Native
+  Task Scheduler is supported as an advanced, still-untested fallback —
+  `templates/task-scheduler.ps1.example` registers the schedule with the
+  documented `Register-ScheduledTask -Xml` form and shows a PowerShell
+  job-plus-kill-timer wrapper so the wake script bounds itself. If you can run
+  WSL, do; only reach for the native path if you genuinely can't.
 
 - **The Notifier is the one primitive that's identical everywhere** because it's
   just an HTTPS call. To keep a first build trivial, set `notify.channel: stdout`

--- a/docs/autonomy/kit/README.md
+++ b/docs/autonomy/kit/README.md
@@ -85,7 +85,9 @@ confidence grows.
   planned. If you're on either, treat that column as a solid starting point, not a
   guarantee: have your agent verify each piece on a throwaway issue before you arm
   the schedule. The primitives table in `BUILD-WITH-YOUR-AGENT.md` is where the
-  per-OS choices live.
+  per-OS choices live. On Windows specifically, the recommended path is to run the
+  loop inside WSL, which reuses the tested Linux primitives; native Task Scheduler
+  is an advanced, still-untested fallback.
 - **Cost:** the loop is cheap only if your CLIs are logged into a subscription
   rather than billing an API key, and only if you keep the cadence sane. Read
   `COSTS.md` first.

--- a/docs/autonomy/kit/templates/task-scheduler.ps1.example
+++ b/docs/autonomy/kit/templates/task-scheduler.ps1.example
@@ -4,7 +4,18 @@
 # WSL reuses the exact Linux primitives this kit was tested on — cron, GNU
 # `timeout --foreground`, tmux — so it's the lower-risk setup by a wide margin.
 # Install a WSL distro, then follow the Linux recipe (crontab.example) inside it.
-# Reach for this native script only if you can't use WSL.
+#
+# One WSL gotcha: the distro's lightweight VM shuts down when nothing is holding
+# it open, and cron does not auto-start — so a crontab alone won't survive a
+# reboot or an idle WSL shutdown. Two one-time steps fix it:
+#   1. Inside WSL, run cron under systemd:  set [boot] systemd=true in
+#      /etc/wsl.conf, `wsl --shutdown` once, then `sudo systemctl enable --now cron`.
+#   2. On Windows, add a Task Scheduler task "At log on" that boots the distro —
+#      e.g. action `wsl.exe` with arguments `-d <distro> -u root service cron start`
+#      (or `-d <distro> --exec true` just to start the VM). Without this the hourly
+#      wake won't fire until someone opens WSL by hand.
+#
+# Reach for the native script below only if you can't use WSL.
 #
 # Untested as of this version: only the Linux path has been run end to end. This
 # script is reasoned from the same design but not yet verified on Windows.
@@ -27,12 +38,25 @@
 #   param([int]$HardMinutes = 90)
 #   $python = "C:\Path\To\python.exe"
 #   $wake   = "C:\Users\YOU\autonomy\wake.py"
-#   $job = Start-Job { & $using:python $using:wake }
-#   if (Wait-Job $job -Timeout ($HardMinutes * 60)) {
-#       Receive-Job $job            # flush the run's output to the log
-#   } else {
-#       Stop-Job $job; Receive-Job $job   # kill the hung run, keep what it wrote
-#       Write-Error "wake exceeded $HardMinutes min hard timeout; killed"
+#   $job = Start-Job {
+#       & $using:python $using:wake
+#       # A job reaches 'Completed' even when the child exits non-zero, so turn a
+#       # bad exit into a terminating error the parent can re-raise — otherwise a
+#       # failed wake (bad creds, wrong path, crashed session) is logged as a
+#       # successful run and you never find out.
+#       if ($LASTEXITCODE -ne 0) { throw "wake exited $LASTEXITCODE" }
+#   }
+#   try {
+#       if (Wait-Job $job -Timeout ($HardMinutes * 60)) {
+#           Receive-Job $job -ErrorAction Stop   # flush output; re-raise a bad exit
+#       } else {
+#           Stop-Job $job; Receive-Job $job      # kill the hung run, keep its log
+#           throw "wake exceeded $HardMinutes min hard timeout; killed"
+#       }
+#   } catch {
+#       Remove-Job $job -Force
+#       Write-Error $_              # non-zero exit -> Task Scheduler records failure
+#       exit 1
 #   }
 #   Remove-Job $job -Force
 #
@@ -55,6 +79,14 @@ $taskName = "AutonomyWake"
 # been observed not to repeat. <Repetition> inside <CalendarTrigger> below is the
 # documented equivalent. The action runs powershell.exe against the wrapper, so
 # the hard timeout in step 1 actually bounds every wake.
+#
+# Element order matters: the XSD fixes the trigger sequence as Enabled,
+# StartBoundary, Repetition, then ScheduleByDay — out-of-order children make
+# Register-ScheduledTask reject the whole task. The <Principal id="Author"> has
+# to match Actions Context="Author" for the same reason (an action context that
+# names no defined principal is a validation error, not a silent default).
+# InteractiveToken runs the task while you're logged in; to run while logged out,
+# change LogonType to Password and register with `-User <you> -Password <pw>`.
 $xml = @"
 <?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
@@ -63,18 +95,24 @@ $xml = @"
   </RegistrationInfo>
   <Triggers>
     <CalendarTrigger>
-      <StartBoundary>2026-01-01T07:05:00</StartBoundary>
       <Enabled>true</Enabled>
-      <ScheduleByDay>
-        <DaysInterval>1</DaysInterval>
-      </ScheduleByDay>
+      <StartBoundary>2026-01-01T07:05:00</StartBoundary>
       <Repetition>
         <Interval>PT1H</Interval>
         <Duration>PT12H</Duration>
         <StopAtDurationEnd>true</StopAtDurationEnd>
       </Repetition>
+      <ScheduleByDay>
+        <DaysInterval>1</DaysInterval>
+      </ScheduleByDay>
     </CalendarTrigger>
   </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <LogonType>InteractiveToken</LogonType>
+      <RunLevel>LeastPrivilege</RunLevel>
+    </Principal>
+  </Principals>
   <Settings>
     <StartWhenAvailable>true</StartWhenAvailable>
     <IdleSettings>

--- a/docs/autonomy/kit/templates/task-scheduler.ps1.example
+++ b/docs/autonomy/kit/templates/task-scheduler.ps1.example
@@ -1,43 +1,94 @@
 # Task Scheduler registration for the issue workhorse (Windows, PowerShell).
 #
-# Run this script once, from an elevated PowerShell, to register an hourly task.
-# Edit the paths and hours first. Check it took with:
-#   Get-ScheduledTask -TaskName "AutonomyWake"
+# RECOMMENDED WINDOWS PATH: run the loop inside WSL, not native Task Scheduler.
+# WSL reuses the exact Linux primitives this kit was tested on — cron, GNU
+# `timeout --foreground`, tmux — so it's the lower-risk setup by a wide margin.
+# Install a WSL distro, then follow the Linux recipe (crontab.example) inside it.
+# Reach for this native script only if you can't use WSL.
 #
-# Untested as of this version: the Linux path is the one that's been run end to
-# end. This script is reasoned from the same design but not yet verified on
-# Windows. Register it against a throwaway issue and watch one wake complete
-# (including the hard-timeout kill) before you trust it.
+# Untested as of this version: only the Linux path has been run end to end. This
+# script is reasoned from the same design but not yet verified on Windows.
+# Register it against a throwaway issue and watch one wake complete — including
+# the hard-timeout kill — before you trust it.
 #
-# Two caveats for Windows:
-#  1. There is no exact equivalent of GNU `timeout --foreground`. The simplest
-#     reliable setup on Windows is to run the whole loop inside WSL and use the
-#     Linux primitives (cron + GNU timeout + tmux). Do that if you can.
-#  2. If you stay native, the wake script must enforce its own hard timeout (start
-#     the agent as a job and kill it after schedule.timeouts.hard_minutes). The
-#     trigger below only starts the run; it does not bound it.
+# Run once from an elevated PowerShell. Edit the paths and hours first. Check it
+# took with:  Get-ScheduledTask -TaskName "AutonomyWake"
 
-$python   = "C:\Path\To\python.exe"
-$wake     = "C:\Users\YOU\autonomy\wake.py"
+# --- 1. Write the timeout wrapper (the scheduled task runs THIS) -----------
+#
+# Windows has no equivalent of GNU `timeout --foreground`, and Task Scheduler's
+# own ExecutionTimeLimit is coarse (it terminates a run without giving the agent
+# a chance to flush its log). So the wake must run through a wrapper that bounds
+# it: a background job killed after schedule.timeouts.hard_minutes. Save this as
+# run-wake.ps1, edit the two paths to match your machine, and the registration
+# below points the scheduled task at it (via powershell.exe, not python.exe).
+#
+#   # run-wake.ps1
+#   param([int]$HardMinutes = 90)
+#   $python = "C:\Path\To\python.exe"
+#   $wake   = "C:\Users\YOU\autonomy\wake.py"
+#   $job = Start-Job { & $using:python $using:wake }
+#   if (Wait-Job $job -Timeout ($HardMinutes * 60)) {
+#       Receive-Job $job            # flush the run's output to the log
+#   } else {
+#       Stop-Job $job; Receive-Job $job   # kill the hung run, keep what it wrote
+#       Write-Error "wake exceeded $HardMinutes min hard timeout; killed"
+#   }
+#   Remove-Job $job -Force
+#
+# A job + Stop-Job is not a perfect process-tree kill — verify on a deliberately
+# hung session that the child python actually dies and the log isn't zero-byte
+# before you rely on it.
+
+$wrapper  = "C:\Users\YOU\autonomy\run-wake.ps1"
 $taskName = "AutonomyWake"
 
-# Hourly from 7am, repeating for 12 hours -> last run at 7pm. Match this to
-# schedule.wake.cron in your config.yaml.
+# --- 2. Register the schedule (documented XML form) ------------------------
 #
-# Heads-up: assigning .Repetition from a throwaway -Once trigger is a widely-used
-# community idiom, but Microsoft doesn't formally document it for -Daily triggers.
-# For a fully-documented, stable recipe, define the task in XML and register it
-# with `Register-ScheduledTask -Xml` instead.
-$trigger = New-ScheduledTaskTrigger -Daily -At 7:05AM
-$trigger.Repetition = (New-ScheduledTaskTrigger -Once -At 7:05AM `
-    -RepetitionInterval (New-TimeSpan -Hours 1) `
-    -RepetitionDuration (New-TimeSpan -Hours 12)).Repetition
+# Hourly from 7:05am, repeating for 12 hours -> last run at 7:05pm. Match this to
+# schedule.wake.cron in your config.yaml: edit StartBoundary (start time),
+# Interval (PT1H = every hour), and Duration (PT12H = the active window).
+#
+# This uses Register-ScheduledTask -Xml, the form Microsoft documents. The older
+# idiom — assigning .Repetition from a throwaway -Once trigger onto a -Daily
+# trigger object — is widely copied but undocumented for daily triggers and has
+# been observed not to repeat. <Repetition> inside <CalendarTrigger> below is the
+# documented equivalent. The action runs powershell.exe against the wrapper, so
+# the hard timeout in step 1 actually bounds every wake.
+$xml = @"
+<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Description>Autonomous GitHub-issue workhorse, hourly wake</Description>
+  </RegistrationInfo>
+  <Triggers>
+    <CalendarTrigger>
+      <StartBoundary>2026-01-01T07:05:00</StartBoundary>
+      <Enabled>true</Enabled>
+      <ScheduleByDay>
+        <DaysInterval>1</DaysInterval>
+      </ScheduleByDay>
+      <Repetition>
+        <Interval>PT1H</Interval>
+        <Duration>PT12H</Duration>
+        <StopAtDurationEnd>true</StopAtDurationEnd>
+      </Repetition>
+    </CalendarTrigger>
+  </Triggers>
+  <Settings>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <IdleSettings>
+      <StopOnIdleEnd>false</StopOnIdleEnd>
+    </IdleSettings>
+    <ExecutionTimeLimit>PT2H</ExecutionTimeLimit>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>powershell.exe</Command>
+      <Arguments>-NoProfile -ExecutionPolicy Bypass -File "$wrapper"</Arguments>
+    </Exec>
+  </Actions>
+</Task>
+"@
 
-$action = New-ScheduledTaskAction -Execute $python -Argument $wake
-
-# Run whether or not you're logged in; don't wake the machine just for this.
-$settings = New-ScheduledTaskSettingsSet -StartWhenAvailable `
-    -DontStopOnIdleEnd -ExecutionTimeLimit (New-TimeSpan -Hours 2)
-
-Register-ScheduledTask -TaskName $taskName -Trigger $trigger -Action $action `
-    -Settings $settings -Description "Autonomous GitHub-issue workhorse, hourly wake"
+Register-ScheduledTask -TaskName $taskName -Xml $xml


### PR DESCRIPTION
Part of #104 (does not close it).

#104 asks for two things: (1) decide the supported Windows path — native Task Scheduler vs. WSL — and (2) run one real end-to-end wake on each of macOS and Windows. This PR does (1) and hardens the native fallback. It does **not** do (2): that needs real macOS and Windows hardware, which I don't have (this was authored on a Linux ARM64 Pi). So #104 stays open for the end-to-end testing, and no "untested" label is flipped to "tested."

## The decision

WSL is the recommended Windows path; native Task Scheduler is an advanced, still-untested fallback. WSL reuses the exact Linux primitives the kit was tested on (cron, GNU `timeout --foreground`, tmux), so it's the only Windows path that inherits any of that testing. Native Windows has two real gaps WSL sidesteps: no `timeout --foreground` equivalent, and a coarse Task Scheduler time limit that kills a run before the agent can flush its log.

- Reordered the Windows column in the primitives table to lead with WSL (recommended).
- Firmed the BUILD-spec prose from a soft "do that if you can" aside into an explicit recommendation.
- Added a one-line Windows note to the README's platform section.

## Template hardening (`task-scheduler.ps1.example`)

For people who still need the native path, fixed the two weak points #104 names:

- **Repetition:** switched from assigning `.Repetition` onto a `-Daily` trigger (community lore, undocumented for daily, observed not to repeat) to the documented `Register-ScheduledTask -Xml` form, with `<Repetition>` inside `<CalendarTrigger>`.
- **Self-timeout:** the scheduled action now runs a PowerShell wrapper (`Start-Job` + `Wait-Job -Timeout` + `Stop-Job`) via `powershell.exe`, so the wake bounds itself. Scheduling `python.exe` directly would skip the timeout entirely.

## Honesty note

The PowerShell/XML here is reasoned from Microsoft's documentation, not executed — I can't run Task Scheduler on Linux. The template still carries its "untested as of this version" header and tells the user to watch one wake complete (including the hard-timeout kill) before trusting it. Local Codex review caught one P1 in an earlier draft — the registration still invoked `python.exe` against the `.ps1` wrapper, which would fail — now fixed so the action runs `powershell.exe` against the wrapper.