### PR TITLE
Cost estimator: named-weekday cron and wake.enabled: false

### DIFF
--- a/docs/autonomy/kit/cost-estimator.html
+++ b/docs/autonomy/kit/cost-estimator.html
@@ -208,7 +208,17 @@
       if (!/^\d+$/.test(t)) throw new Error('"' + t + '" is not a whole number');
       return parseInt(t, 10);
     }
-    function parseField(text, lo, hi) {
+    // crontab(5) day-of-week names (case-insensitive). Day-of-week is the only
+    // field expanded here, so only it gets a name table (mirrors estimate_cost.py).
+    const CRON_DOW_NAMES = { SUN: 0, MON: 1, TUE: 2, WED: 3, THU: 4, FRI: 5, SAT: 6 };
+    function parseField(text, lo, hi, names) {
+      const tok = (s) => {
+        const t = String(s).trim();
+        if (names && Object.prototype.hasOwnProperty.call(names, t.toUpperCase()))
+          return names[t.toUpperCase()];
+        if (!/^\d+$/.test(t)) throw new Error('"' + t + '" is not a recognized cron value');
+        return parseInt(t, 10);
+      };
       const values = new Set();
       for (let part of text.split(",")) {
         part = part.trim();
@@ -223,8 +233,13 @@
         let start, end;
         if (base === "*") { start = lo; end = hi; }
         else if (base.includes("-")) {
-          const r = base.split("-"); start = toInt(r[0]); end = toInt(r[1]);
-        } else { start = end = toInt(base); }
+          const r = base.split("-"); start = tok(r[0]); end = tok(r[1]);
+          // Sunday has two encodings (0 and 7). A range ending in Sunday
+          // (FRI-SUN -> 5-0, or numeric 5-0) reads as start > end; lift the end
+          // to hi so it folds to {5,6,0} like the numeric "5-7". Only the
+          // day-of-week field passes a names map and its caller folds 7 -> 0.
+          if (names && start > end && end === lo) end = hi;
+        } else { start = end = tok(base); }
         if (start < lo || end > hi || start > end) throw new Error('field "' + text + '" out of range [' + lo + "," + hi + "]");
         for (let v = start; v <= end; v += step) values.add(v);
       }
@@ -241,7 +256,7 @@
       if (dow === "*") return 7;
       // Parse against 0-7 (cron allows 0 and 7 for Sunday), then fold 7 -> 0.
       // Normalizing the text first (dow.replace) would corrupt ranges like "1-7".
-      const days = new Set([...parseField(dow, 0, 7)].map(d => d % 7));
+      const days = new Set([...parseField(dow, 0, 7, CRON_DOW_NAMES)].map(d => d % 7));
       return days.size;
     }
     function cronRestrictions(expr) {

--- a/docs/autonomy/kit/estimate_cost.py
+++ b/docs/autonomy/kit/estimate_cost.py
@@ -81,12 +81,43 @@ VALID_EFFORTS = tuple(WORKER_TOKENS_PER_MIN.keys())
 # Cron cadence  ->  runs per day
 # ===========================================================================
 
+# crontab(5) accepts three-letter names in the day-of-week field (SUN..SAT,
+# case-insensitive). Only the day-of-week field is expanded here — the month
+# field is never parsed (cron_unsupported_restrictions refuses any month
+# restriction, named or numeric, because the estimator doesn't model it), so a
+# month-name table would be unreachable.
+CRON_DOW_NAMES = {
+    "SUN": 0,
+    "MON": 1,
+    "TUE": 2,
+    "WED": 3,
+    "THU": 4,
+    "FRI": 5,
+    "SAT": 6,
+}
 
-def parse_cron_field(field_text: str, lo: int, hi: int) -> set[int]:
+
+def parse_cron_field(
+    field_text: str, lo: int, hi: int, names: dict[str, int] | None = None
+) -> set[int]:
     """Expand one cron field into the set of values it matches within [lo, hi].
 
-    Handles "*", lists ("a,b"), ranges ("a-b"), and steps ("*/n", "a-b/n").
+    Handles "*", lists ("a,b"), ranges ("a-b"), and steps ("*/n", "a-b/n"). When
+    a names map is given (e.g. SUN..SAT for day-of-week), named tokens resolve
+    through it, case-insensitively, on either side of a range.
     """
+
+    def to_int(token: str) -> int:
+        token = token.strip()
+        if names and token.upper() in names:
+            return names[token.upper()]
+        try:
+            return int(token)
+        except ValueError:
+            raise ValueError(
+                f"cron field {field_text!r} has an unrecognized value: {token!r}"
+            ) from None
+
     values: set[int] = set()
     for part in field_text.split(","):
         part = part.strip()
@@ -105,9 +136,18 @@ def parse_cron_field(field_text: str, lo: int, hi: int) -> set[int]:
             start, end = lo, hi
         elif "-" in base:
             start_text, end_text = base.split("-", 1)
-            start, end = int(start_text), int(end_text)
+            start, end = to_int(start_text), to_int(end_text)
+            # In the day-of-week field Sunday has two encodings, 0 and 7. The
+            # names map resolves SUN -> 0, so a range ending in Sunday (e.g.
+            # FRI-SUN -> 5-0, or numeric 5-0) reads as start > end. cron lets
+            # Sunday also be the high alias 7, so lift the end to hi to keep the
+            # range ordered — "FRI-SUN" then folds to {5,6,0} exactly like the
+            # numeric "5-7". Only the day-of-week field passes a names map, and
+            # its caller folds 7 -> 0, so this stays scoped to that field.
+            if names and start > end and end == lo:
+                end = hi
         else:
-            start = end = int(base)
+            start = end = to_int(base)
 
         if start < lo or end > hi or start > end:
             raise ValueError(f"cron field {field_text!r} out of range [{lo},{hi}]")
@@ -143,7 +183,7 @@ def cron_active_days_per_week(expr: str) -> int:
     # Parse against 0-7 (cron allows both 0 and 7 for Sunday), then fold 7 -> 0
     # on the integer set. Normalizing before the parse — dow.replace("7", "0") —
     # would corrupt ranges like "1-7" into the invalid "1-0".
-    days = {d % 7 for d in parse_cron_field(dow, 0, 7)}
+    days = {d % 7 for d in parse_cron_field(dow, 0, 7, CRON_DOW_NAMES)}
     return len(days)
 
 
@@ -172,6 +212,7 @@ class Inputs:
     max_passes: int
     days_per_month: float = DAYS_PER_MONTH
     review_enabled: bool = True
+    wake_enabled: bool = True
 
 
 @dataclass
@@ -222,6 +263,21 @@ def estimate(inputs: Inputs) -> Estimate:
         raise ValueError("max_passes must be positive when review is enabled")
     if inputs.days_per_month <= 0:
         raise ValueError("days_per_month must be positive")
+
+    # schedule.wake.enabled: false means the loop never fires, so it runs zero
+    # times and bills zero metered tokens. Short-circuit before reading cadence —
+    # a disabled schedule's cron is moot. The per-run figure stays informational
+    # ("if you turned it on..."); the subscription line is left to issue #110
+    # (a plan you hold whether or not this loop uses it).
+    if not inputs.wake_enabled:
+        return Estimate(
+            runs_per_active_day=0,
+            active_days_per_week=0,
+            runs_per_month=0.0,
+            subscription_monthly_usd=sum(SUBSCRIPTION_PLANS_USD.values()),
+            metered_per_run_usd=metered_cost_per_run(inputs),
+            metered_monthly_usd=(0.0, 0.0),
+        )
 
     per_active_day = cron_runs_per_active_day(inputs.cron)
     active_days = cron_active_days_per_week(inputs.cron)
@@ -292,6 +348,10 @@ def inputs_from_config(cfg: dict) -> dict:
     # validation in estimate(), exactly the trap the CLI path also had.
     if wake.get("cron") is not None:
         out["cron"] = wake["cron"]
+    # schedule.wake.enabled: false turns the whole loop off -> zero runs, $0
+    # metered. Presence check so an absent key defaults on downstream.
+    if wake.get("enabled") is not None:
+        out["wake_enabled"] = bool(wake["enabled"])
     if model.get("work_effort") is not None:
         out["work_effort"] = model["work_effort"]
     if model.get("review_effort") is not None:
@@ -332,10 +392,11 @@ def format_report(inputs: Inputs, est: Estimate, *, source: str) -> str:
         if inputs.review_enabled
         else "review disabled"
     )
+    cadence_note = "" if inputs.wake_enabled else "   (schedule disabled — 0 runs)"
     lines = [
         "Autonomy loop cost estimate",
         f"  source            {source}",
-        f"  cadence (cron)    {inputs.cron}",
+        f"  cadence (cron)    {inputs.cron}{cadence_note}",
         f"  work / review     {inputs.work_effort} / {inputs.review_effort} effort",
         f"  avg session       {inputs.avg_session_minutes:g} min   ({review_note})",
         "",
@@ -423,9 +484,15 @@ def resolve_inputs(args: argparse.Namespace) -> tuple[Inputs, str]:
         values["avg_session_minutes"] = args.avg_session_minutes
 
     if "cron" not in values:
-        raise SystemExit(
-            "no cadence given. Pass a config.yaml with schedule.wake.cron, or --cron."
-        )
+        # A disabled schedule never fires, so its cadence is moot — fill a
+        # placeholder so estimate() can short-circuit to 0 runs instead of
+        # demanding a cron the user rightly left out. Only an ENABLED loop with
+        # no cadence is an error.
+        if values.get("wake_enabled", True):
+            raise SystemExit(
+                "no cadence given. Pass a config.yaml with schedule.wake.cron, or --cron."
+            )
+        values["cron"] = "(disabled)"
     # An explicit average always wins. Otherwise start from the default and let a
     # hard timeout pull it down when the timeout is tighter than that default —
     # a 15-minute cap can't average 30 minutes a session.
@@ -443,6 +510,7 @@ def resolve_inputs(args: argparse.Namespace) -> tuple[Inputs, str]:
         max_passes=values.get("max_passes", DEFAULT_MAX_PASSES),
         days_per_month=args.days_per_month,
         review_enabled=values.get("review_enabled", True),
+        wake_enabled=values.get("wake_enabled", True),
     )
     return inputs, source
 

--- a/docs/autonomy/kit/test_estimate_cost.py
+++ b/docs/autonomy/kit/test_estimate_cost.py
@@ -53,6 +53,44 @@ def test_dow_ranges_containing_seven():
     assert ec.cron_active_days_per_week("0 9 * * 6-7") == 2
 
 
+def test_dow_named_weekdays():
+    # crontab(5) accepts SUN..SAT names in the day-of-week field.
+    assert ec.cron_active_days_per_week("5 7-19 * * MON-FRI") == 5
+    assert ec.cron_active_days_per_week("0 9 * * SAT,SUN") == 2
+    assert ec.cron_active_days_per_week("0 9 * * SUN") == 1  # SUN = 0
+    # Case-insensitive, and a named range folds the same way numbers do.
+    assert ec.cron_active_days_per_week("0 9 * * mon-fri") == 5
+
+
+def test_dow_named_range_ending_in_sunday():
+    # SUN resolves to 0, so a range ending in Sunday (FRI-SUN) reads as 5-0.
+    # cron lets Sunday also be 7, so it must fold like the numeric "5-7" rather
+    # than raise. FRI-SUN = Fri, Sat, Sun = 3 days.
+    assert ec.cron_active_days_per_week("0 9 * * FRI-SUN") == 3
+    # MON-SUN spans the whole week = 7 days.
+    assert ec.cron_active_days_per_week("0 9 * * MON-SUN") == 7
+    # SAT-SUN (and its numeric twin 6-0) is the weekend = 2 days.
+    assert ec.cron_active_days_per_week("0 9 * * SAT-SUN") == 2
+    assert ec.cron_active_days_per_week("0 9 * * 6-0") == 2
+    # SUN-SAT is the forward whole-week range and stays 7 days (no lift needed).
+    assert ec.cron_active_days_per_week("0 9 * * SUN-SAT") == 7
+    # A genuinely backwards range that does not end in Sunday still raises.
+    with pytest.raises(ValueError, match=r"out of range"):
+        ec.cron_active_days_per_week("0 9 * * WED-MON")
+
+
+def test_dow_unknown_name_rejected():
+    with pytest.raises(ValueError, match="unrecognized value"):
+        ec.cron_active_days_per_week("0 9 * * FUNDAY")
+
+
+def test_names_only_apply_where_passed():
+    # Minute/hour fields get no names map, so a name there is still rejected.
+    with pytest.raises(ValueError):
+        ec.parse_cron_field("MON", 0, 59)
+    assert ec.parse_cron_field("MON-FRI", 0, 7, ec.CRON_DOW_NAMES) == {1, 2, 3, 4, 5}
+
+
 @pytest.mark.parametrize(
     "field, lo, hi, expected",
     [
@@ -255,6 +293,40 @@ def test_inputs_from_config_nudge_off_disables_review():
     )
 
 
+def test_inputs_from_config_reads_wake_enabled():
+    cfg = {"schedule": {"wake": {"cron": "5 7-19 * * *", "enabled": False}}}
+    got = ec.inputs_from_config(cfg)
+    assert got["wake_enabled"] is False
+    assert got["cron"] == "5 7-19 * * *"
+    # Absent enabled key defaults to on downstream, so it's not emitted.
+    assert "wake_enabled" not in ec.inputs_from_config(
+        {"schedule": {"wake": {"cron": "5 7-19 * * *"}}}
+    )
+
+
+def test_disabled_wake_zeroes_runs_and_monthly():
+    on = ec.estimate(_inputs(wake_enabled=True))
+    off = ec.estimate(_inputs(wake_enabled=False))
+    assert on.runs_per_month > 0
+    assert off.runs_per_month == 0
+    assert off.metered_monthly_usd == (0.0, 0.0)
+    # Per-run stays informational ("if you turned it on..."), so it's unchanged.
+    assert off.metered_per_run_usd == on.metered_per_run_usd
+
+
+def test_disabled_wake_skips_cron_restriction_refusal():
+    # A disabled loop's cadence is moot, so an otherwise-unsupported cron does not
+    # raise — it just reports zero runs.
+    est = ec.estimate(_inputs(cron="0 9 1 * *", wake_enabled=False))
+    assert est.runs_per_month == 0
+
+
+def test_format_report_notes_disabled_schedule():
+    inputs = _inputs(wake_enabled=False)
+    report = ec.format_report(inputs, ec.estimate(inputs), source="flags")
+    assert "schedule disabled" in report
+
+
 def test_disabled_review_zeroes_review_cost():
     on = ec.metered_cost_per_run(_inputs(review_enabled=True))
     off = ec.metered_cost_per_run(_inputs(review_enabled=False))
@@ -332,6 +404,24 @@ def test_config_review_disabled_lowers_cost(tmp_path):
     assert (
         ec.estimate(off).metered_per_run_usd[0] < ec.estimate(on).metered_per_run_usd[0]
     )
+
+
+def test_disabled_wake_without_cron_reports_zero(tmp_path):
+    # wake.enabled: false with no cron must NOT fail "no cadence given" — the
+    # cadence is moot when the loop is off, so it estimates 0 runs.
+    path = _write_config(tmp_path, {"schedule": {"wake": {"enabled": False}}})
+    inputs, _ = ec.resolve_inputs(ec.build_parser().parse_args([path]))
+    assert inputs.wake_enabled is False
+    assert ec.estimate(inputs).runs_per_month == 0
+    assert ec.main([path]) == 0  # prints a report, doesn't error
+
+
+def test_enabled_wake_without_cron_still_errors(tmp_path):
+    # An ENABLED loop with no cadence is still an error — the placeholder only
+    # applies when the schedule is off.
+    path = _write_config(tmp_path, {"schedule": {"wake": {"enabled": True}}})
+    with pytest.raises(SystemExit):
+        ec.resolve_inputs(ec.build_parser().parse_args([path]))
 
 
 def test_hard_timeout_caps_average_session(tmp_path):


### PR DESCRIPTION
Two inputs a real config can hold were being rejected by the estimator. This makes both produce a sensible estimate instead of an error.

## Named day-of-week cron (refs #111)
`parse_cron_field` now resolves `SUN..SAT` names case-insensitively in the day-of-week field, so cadences like `MON-FRI` or `FRI-SUN` parse the way crontab(5) and hand-written `config.yaml` schedules use them.

Sunday has two encodings (0 and 7). A range ending in Sunday — `FRI-SUN`, i.e. `5-0` — read as `start > end` and tripped the range guard. It now lifts the end to the `7` alias so it folds to `{5,6,0}`, exactly like the numeric `5-7` already did. A genuinely backwards range that does not end in Sunday (`WED-MON`) still raises.

**Partial on #111:** only weekday names ship. The issue also lists month names (`JAN-DEC`), but the month field is never parsed — `cron_unsupported_restrictions` refuses any month-restricted cron because the estimator doesn't model "only in January," so a month-name table would be unreachable. Left `Refs` rather than `Closes` so #111 stays open for that call; comment to follow.

## Honor `schedule.wake.enabled: false` (closes #112)
A disabled loop never fires. `estimate()` now short-circuits to zero runs and zero metered cost before reading cadence, and `resolve_inputs` no longer demands a `--cron` when the schedule is off (an *enabled* loop with no cadence still errors). The report adds a `(schedule disabled — 0 runs)` note on the cadence line. The per-run figure stays informational ("if you turned it on…"); the subscription line is left to #110.

## Parity and tests
The `cost-estimator.html` calculator mirrors the same parsing and Sunday-wrap, browser-verified to return identical numbers across all cases (`FRI-SUN`→3, `MON-SUN`→7, `SAT-SUN`→2, `SUN-SAT`→7, `WED-MON`/`FUNDAY`→errors). 67 Python tests pass, ruff clean.

#110 is untouched and stays open.