### PR TITLE
one-way-door: document the stateful, safelisted hook (best of both machines)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **`one-way-door` hook is now stateful** (this PR): the check (`PreToolUse:Write`) gained a session-scoped approval ledger, and a companion `one-way-door-approve.sh` (`PostToolUse:AskUserQuestion`) promotes pending files to approved once the user answers an `AskUserQuestion`. The old stateless check re-blocked the same file on the retry, so its own "ask, then retry" instruction never terminated. The retried write now passes; every other unapproved one-way-door file still blocks. The ledger lives in `~/.claude/hooks/state/one-way-door/` (`<session_id>.pending` / `.approved`), and a new session starts clean.
+- **`one-way-door` check gained a false-positive safelist and tighter auth matching** (this PR): the documented script is now the best-of-both version running locally — it early-exits an explicit safelist (test files by convention, `tests/`/`__tests__/`/`fixtures/`/`mocks/` directories, all Markdown, and `*.txt`/`*.rst` under `plans`/`docs`/`notes`/`superpowers`) before any pattern check, and the auth/security patterns are extension-qualified (`security.{ts,js,py,json,rules,yaml,yml}`, `rbac.{ts,js,py,json}`, `permissions.{ts,js,py,json}`) so a file that merely contains a keyword no longer trips. Updated `dev-toolkit/skills/one-way-door/SKILL.md`, `hooks/one-way-door-check.md`, and `docs/one-way-door/index.html` to document both hooks, the safelist, and the new `settings.json` wiring.
+
 ## [2.1.0] - 2026-05-12
 
 The security-toolkit supply-chain release. Marketplace bumped 2.0.0 → 2.1.0 to roll up PR #77 (security-toolkit 1.1.0) and the docs-surface follow-up.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`one-way-door` Windows (PowerShell) port** (this PR): `dev-toolkit/skills/one-way-door/one-way-door-check.ps1` and `one-way-door-approve.ps1`, behavior-matched to the shell hooks for Windows, where Claude Code runs hooks through PowerShell and `tool_input.file_path` can arrive with backslashes (which `basename` does not split on, so the shell safelist would misfire). The ports share the same session ledger (`%USERPROFILE%\.claude\hooks\state\one-way-door\`), early-exit safelist, and one-way-door categories; filename and directory splitting goes through `[System.IO.Path]` and directory patterns are matched after normalizing `\` to `/`, so the check is correct for backslash and forward-slash paths alike. Verified against a block / safelist / stateful-approve test matrix. Documented with the PowerShell `settings.json` wiring in `SKILL.md`, `hooks/one-way-door-check.md`, and `docs/one-way-door/index.html`.
+
 ### Changed
 
 - **`one-way-door` hook is now stateful** (this PR): the check (`PreToolUse:Write`) gained a session-scoped approval ledger, and a companion `one-way-door-approve.sh` (`PostToolUse:AskUserQuestion`) promotes pending files to approved once the user answers an `AskUserQuestion`. The old stateless check re-blocked the same file on the retry, so its own "ask, then retry" instruction never terminated. The retried write now passes; every other unapproved one-way-door file still blocks. The ledger lives in `~/.claude/hooks/state/one-way-door/` (`<session_id>.pending` / `.approved`), and a new session starts clean.

--- a/dev-toolkit/skills/one-way-door/SKILL.md
+++ b/dev-toolkit/skills/one-way-door/SKILL.md
@@ -142,9 +142,9 @@ The automated version is two hooks that share a session-scoped approval ledger:
 - **`one-way-door-check.sh`** runs on `PreToolUse:Write`. It blocks the first write to a one-way-door file and records that file as pending.
 - **`one-way-door-approve.sh`** runs on `PostToolUse:AskUserQuestion`. When you answer any `AskUserQuestion` — normally the one the check told Claude to ask — it promotes every pending file to approved, so Claude's retried write passes.
 
-Without the ledger the check would be stateless and re-block the same file on every retry — the "use `AskUserQuestion`, then retry" instruction would loop forever. The ledger makes the loop terminate: answer once, and that file stays open for the rest of the session. Every other unapproved one-way-door file still blocks.
+Without the ledger the check would be stateless and re-block the same file on every retry — the "use `AskUserQuestion`, then retry" instruction would loop forever. The ledger makes the loop terminate: answer once, and every file currently pending — usually just the one the check told Claude to ask about — stays open for the rest of the session. A one-way-door file you have not tried to write yet is not pending, so it still blocks the first time Claude attempts it.
 
-The promoter keys on the `AskUserQuestion` event itself, not on which question was answered. If Claude asks an unrelated question while a one-way-door file is pending, that file is approved too. The block-then-discuss prompt is the real guardrail; the ledger only keeps an already-discussed file from re-blocking.
+The promoter keys on the `AskUserQuestion` event itself, not on which question was answered: it approves the whole pending set at once, so if two one-way-door files are blocked before Claude asks — or it asks an unrelated question while a file is pending — they are all approved together. The block-then-discuss prompt is the real guardrail; the ledger only keeps an already-discussed file from re-blocking.
 
 Add both hooks to your Claude Code `settings.json`:
 
@@ -365,7 +365,7 @@ exit 0
 
 **State:**
 
-The ledger lives in `~/.claude/hooks/state/one-way-door/`, one pair of files per session: `<session_id>.pending` and `<session_id>.approved`. Approval is per file path, per session — a new session starts with an empty ledger, so the same decision is surfaced again rather than silently inherited from a past session.
+The ledger lives in `~/.claude/hooks/state/one-way-door/`, one pair of files per session: `<session_id>.pending` and `<session_id>.approved`. Approval is per file path, per session — a new session starts with an empty ledger, so the same decision is surfaced again rather than silently inherited from a past session. The key is the file path as Claude Code delivers it, which is normally absolute. If one session writes identically-named files through relative paths in different directories, the path key can collide and approve the second without its own discussion; wiring on absolute paths avoids that.
 
 **Exit codes:**
 - `0` — Allow (two-way door, or a path already approved this session)

--- a/dev-toolkit/skills/one-way-door/SKILL.md
+++ b/dev-toolkit/skills/one-way-door/SKILL.md
@@ -37,7 +37,9 @@ Infrastructure choices constrain everything built on top of them. Switching from
 
 ### Authentication and authorization
 
-Files matching: `auth.ts`, `auth.js`, `auth.py`, `firestore.rules`, `storage.rules`, `*.rules`, `rbac*`, `permissions*`, `security*`
+Files matching: `auth.{ts,js,py}`, `firestore.rules`, `storage.rules`, `*.rules`, `security.{ts,js,py,json,rules,yaml,yml}`, `rbac.{ts,js,py,json}`, `permissions.{ts,js,py,json}`
+
+These patterns are extension-qualified on purpose: an unrelated file that merely contains the word `security` or `permissions` (a note, a doc, a test) does not trip the check.
 
 Auth boundaries are load-bearing walls. Session vs JWT, role-based vs attribute-based, single-tenant vs multi-tenant — each choice shapes your security model, user experience, and compliance posture.
 
@@ -113,6 +115,15 @@ These file types are safe to decide quickly and change later:
 - **Configuration files** — `.env`, feature flags, app config
 - **Static assets** — Images, fonts, icons
 
+### Enforced safelist (the hook)
+
+The CLAUDE.md rule leans on judgement, but the automated hook hard-codes an early-exit safelist that runs before any pattern check. These classes always pass, even when the filename contains a keyword like `auth` or `security`, because they're the common false positives:
+
+- Test files by naming convention — `test_*.py`, `*_test.py`, `*.test.{ts,tsx,js,jsx}`, `*.spec.{ts,tsx,js,jsx}`
+- Anything under a `tests/`, `__tests__/`, `fixtures/`, `mocks/`, or `__mocks__/` directory
+- All Markdown (`*.md`)
+- `*.txt` / `*.rst` under a `plans/`, `docs/`, `notes/`, or `superpowers` directory
+
 ## How to implement
 
 ### Option 1: CLAUDE.md rule
@@ -126,7 +137,16 @@ Before creating new files that represent architectural decisions, ask: "Which of
 
 ### Option 2: PreToolUse hook (automated enforcement)
 
-Add this to your Claude Code `settings.json`:
+The automated version is two hooks that share a session-scoped approval ledger:
+
+- **`one-way-door-check.sh`** runs on `PreToolUse:Write`. It blocks the first write to a one-way-door file and records that file as pending.
+- **`one-way-door-approve.sh`** runs on `PostToolUse:AskUserQuestion`. When you answer any `AskUserQuestion` — normally the one the check told Claude to ask — it promotes every pending file to approved, so Claude's retried write passes.
+
+Without the ledger the check would be stateless and re-block the same file on every retry — the "use `AskUserQuestion`, then retry" instruction would loop forever. The ledger makes the loop terminate: answer once, and that file stays open for the rest of the session. Every other unapproved one-way-door file still blocks.
+
+The promoter keys on the `AskUserQuestion` event itself, not on which question was answered. If Claude asks an unrelated question while a one-way-door file is pending, that file is approved too. The block-then-discuss prompt is the real guardrail; the ledger only keeps an already-discussed file from re-blocking.
+
+Add both hooks to your Claude Code `settings.json`:
 
 ```json
 {
@@ -141,17 +161,29 @@ Add this to your Claude Code `settings.json`:
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/path/to/one-way-door-approve.sh"
+          }
+        ]
+      }
     ]
   }
 }
 ```
 
-### The hook script
+### The check hook (`one-way-door-check.sh`)
 
 ```bash
 #!/bin/sh
 # One-way door check hook (PreToolUse:Write)
 # Flags architectural decisions that are hard to reverse.
+# The most expensive mistakes aren't bugs — they're irreversible decisions.
 
 INPUT=$(cat)
 [ -z "$INPUT" ] && exit 0
@@ -160,12 +192,59 @@ INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | grep -oP '"file_path"\s*:\s*"[^"]*"' | head -1 | sed 's/.*"file_path"\s*:\s*"//;s/"//')
 [ -z "$FILE_PATH" ] && exit 0
 
+# Session-scoped approval ledger. Once the user approves a one-way-door file
+# via the required AskUserQuestion, the PostToolUse:AskUserQuestion hook
+# promotes it to approved, and subsequent writes to that same file proceed.
+SESSION_ID=$(echo "$INPUT" | grep -oP '"session_id"\s*:\s*"[^"]*"' | head -1 | sed 's/.*"session_id"\s*:\s*"//;s/"//')
+[ -z "$SESSION_ID" ] && SESSION_ID="default"
+
+STATE_DIR="$HOME/.claude/hooks/state/one-way-door"
+mkdir -p "$STATE_DIR"
+APPROVED_FILE="$STATE_DIR/$SESSION_ID.approved"
+PENDING_FILE="$STATE_DIR/$SESSION_ID.pending"
+
+# Already approved this session: allow without re-blocking.
+if [ -f "$APPROVED_FILE" ] && grep -Fxq "$FILE_PATH" "$APPROVED_FILE"; then
+    echo "one-way-door: proceeding with previously-approved $(basename "$FILE_PATH")" >&2
+    exit 0
+fi
+
 FILENAME=$(basename "$FILE_PATH")
 FILENAME_LOWER=$(echo "$FILENAME" | tr "[:upper:]" "[:lower:]")
+FILE_PATH_LOWER=$(echo "$FILE_PATH" | tr "[:upper:]" "[:lower:]")
 DIR=$(dirname "$FILE_PATH")
+
+# ---------------------------------------------------------------------------
+# Early-exit safelist: clearly-additive, reversible file classes that should
+# never trip a one-way-door check even if the filename contains a keyword like
+# "auth" or "security". Tests and docs are the common false-positives.
+# ---------------------------------------------------------------------------
+
+# Test files (pytest, jest, vitest, go test conventions)
+if echo "$FILENAME_LOWER" | grep -qE "^test_.*\.py$|_test\.py$|\.test\.(ts|tsx|js|jsx)$|\.spec\.(ts|tsx|js|jsx)$"; then
+    exit 0
+fi
+
+# Test / fixture / mock directories anywhere in the path
+if echo "$FILE_PATH_LOWER" | grep -qE "/tests?/|/__tests__/|/fixtures?/|/mocks?/|/__mocks__/"; then
+    exit 0
+fi
+
+# Markdown is always reversible (broader than the later docs-only check, which
+# required a docs/ parent dir and missed ad-hoc notes).
+if echo "$FILENAME_LOWER" | grep -qE "\.md$"; then
+    exit 0
+fi
 
 ONE_WAY=0
 REASON=""
+
+# Documentation and plan files are always reversible - skip all checks
+if echo "$FILENAME_LOWER" | grep -qE "\.txt$|\.rst$"; then
+    if echo "$DIR" | grep -qE "plans?|docs?|notes?|superpowers"; then
+        exit 0
+    fi
+fi
 
 # Database schemas and migrations
 if echo "$FILENAME_LOWER" | grep -qE "schema\.(prisma|graphql|sql)|migration|\.sql$|models?\.(py|ts|js)$|entities?\.(py|ts|js)$"; then
@@ -179,8 +258,8 @@ if echo "$FILENAME_LOWER" | grep -qE "^(docker-compose|dockerfile|terraform|pulu
     REASON="infrastructure / deployment config"
 fi
 
-# Authentication and authorization
-if echo "$FILENAME_LOWER" | grep -qE "auth\.(ts|js|py)|firestore\.rules|storage\.rules|security|\.rules$|rbac|permissions"; then
+# Authentication and authorization (code/config files only - not docs)
+if echo "$FILENAME_LOWER" | grep -qE "auth\.(ts|js|py)|firestore\.rules|storage\.rules|security\.(ts|js|py|json|rules|yaml|yml)|\.rules$|rbac\.(ts|js|py|json)|permissions\.(ts|js|py|json)"; then
     ONE_WAY=1
     REASON="auth / security rules"
 fi
@@ -216,6 +295,10 @@ if echo "$DIR" | grep -qE "\.(github|gitlab|circleci)" || echo "$FILENAME_LOWER"
 fi
 
 if [ "$ONE_WAY" = "1" ]; then
+    # Record this file as pending approval for the session (deduped).
+    if [ ! -f "$PENDING_FILE" ] || ! grep -Fxq "$FILE_PATH" "$PENDING_FILE"; then
+        printf '%s\n' "$FILE_PATH" >> "$PENDING_FILE"
+    fi
     cat >&2 <<HOOK_MSG
 ONE_WAY_DOOR: You tried to create $FILENAME ($REASON). This write has been blocked because it is a one-way door -- a decision that becomes hard to reverse once other code, data, or users depend on it.
 
@@ -226,7 +309,7 @@ REQUIRED ACTION: You MUST use the AskUserQuestion tool before retrying this writ
 
 Frame the question around the specific architectural decision, not just "should I create this file?" The user needs to understand what they are committing to.
 
-After the user responds, proceed according to their choice.
+After the user answers the AskUserQuestion, retry the same write -- it will proceed automatically, because answering the question promotes this file to approved for the rest of the session. (Other unapproved one-way-door files still block.)
 HOOK_MSG
     exit 2
 fi
@@ -234,17 +317,59 @@ fi
 exit 0
 ```
 
+### The approval hook (`one-way-door-approve.sh`)
+
+```bash
+#!/bin/sh
+# One-way door approval promoter (PostToolUse:AskUserQuestion)
+# When the user answers any AskUserQuestion, promote every one-way-door file
+# that the PreToolUse:Write hook recorded as pending into the approved ledger
+# for this session. The retried Write then passes instead of re-blocking.
+# Never blocks: PostToolUse hooks must not interrupt the flow.
+
+INPUT=$(cat)
+[ -z "$INPUT" ] && exit 0
+
+SESSION_ID=$(echo "$INPUT" | grep -oP '"session_id"\s*:\s*"[^"]*"' | head -1 | sed 's/.*"session_id"\s*:\s*"//;s/"//')
+[ -z "$SESSION_ID" ] && SESSION_ID="default"
+
+STATE_DIR="$HOME/.claude/hooks/state/one-way-door"
+mkdir -p "$STATE_DIR"
+APPROVED_FILE="$STATE_DIR/$SESSION_ID.approved"
+PENDING_FILE="$STATE_DIR/$SESSION_ID.pending"
+
+# Nothing pending: nothing to promote.
+[ -s "$PENDING_FILE" ] || exit 0
+
+# Promote each pending path into approved, deduped.
+while IFS= read -r path; do
+    [ -z "$path" ] && continue
+    if [ ! -f "$APPROVED_FILE" ] || ! grep -Fxq "$path" "$APPROVED_FILE"; then
+        printf '%s\n' "$path" >> "$APPROVED_FILE"
+    fi
+done < "$PENDING_FILE"
+
+# Empty the pending list now that everything is approved.
+: > "$PENDING_FILE"
+
+exit 0
+```
+
 **How it works:**
 
-1. The hook intercepts every `Write` tool call (new file creation)
-2. It extracts the file path and checks it against known one-way-door patterns
-3. If the file matches, the hook exits with code 2 (block) and sends a message to stderr
-4. Claude receives the block message and must use `AskUserQuestion` to discuss the decision with the user
-5. Two-way door files pass through silently (exit 0)
+1. `one-way-door-check.sh` intercepts every `Write` (new file creation) and reads the `file_path` and `session_id` from the tool input.
+2. If that path is already in the session's `.approved` ledger, the write proceeds — the decision was already discussed this session. (The hook logs a one-line `one-way-door: proceeding with previously-approved <file>` note to stderr; it is not silent.)
+3. Otherwise the hook checks the filename against the one-way-door patterns. On a match it records the path in the session's `.pending` list, exits with code 2 (block), and tells Claude to use `AskUserQuestion` and then retry.
+4. When the user answers any `AskUserQuestion`, `one-way-door-approve.sh` (PostToolUse:AskUserQuestion) promotes every pending path into `.approved` and clears the pending list. It never blocks — PostToolUse hooks must not interrupt the flow.
+5. Claude retries the same write. The path is now approved, so it proceeds. Two-way door files pass through silently the whole time (exit 0, no output).
+
+**State:**
+
+The ledger lives in `~/.claude/hooks/state/one-way-door/`, one pair of files per session: `<session_id>.pending` and `<session_id>.approved`. Approval is per file path, per session — a new session starts with an empty ledger, so the same decision is surfaced again rather than silently inherited from a past session.
 
 **Exit codes:**
-- `0` — Allow (two-way door, proceed normally)
-- `2` — Block (one-way door, requires discussion)
+- `0` — Allow (two-way door, or a path already approved this session)
+- `2` — Block (one-way door not yet approved — requires discussion)
 
 ## The three questions
 

--- a/dev-toolkit/skills/one-way-door/SKILL.md
+++ b/dev-toolkit/skills/one-way-door/SKILL.md
@@ -371,6 +371,46 @@ The ledger lives in `~/.claude/hooks/state/one-way-door/`, one pair of files per
 - `0` — Allow (two-way door, or a path already approved this session)
 - `2` — Block (one-way door not yet approved — requires discussion)
 
+### Windows (PowerShell)
+
+The shell scripts above assume a POSIX shell. On Windows, Claude Code invokes hooks through PowerShell, and `tool_input.file_path` can arrive with backslashes — which `basename` does not split on, so the shell version's safelist would misfire. Behavior-matched PowerShell ports ship alongside this skill:
+
+- `one-way-door-check.ps1` — the `PreToolUse:Write` check
+- `one-way-door-approve.ps1` — the `PostToolUse:AskUserQuestion` promoter
+
+They use the same session ledger (`%USERPROFILE%\.claude\hooks\state\one-way-door\`), the same early-exit safelist, and the same one-way-door categories as the shell version. Filename and directory splitting goes through `[System.IO.Path]`, and the directory patterns are matched after normalizing `\` to `/`, so the check is correct whether a path uses backslashes or forward slashes. They mirror the shell hooks check-for-check — the same patterns in the same order — so the behavioral contract is identical; only the language differs.
+
+Copy both `.ps1` files from this skill's directory into your hooks folder (for example `%USERPROFILE%\.claude\hooks\`), then wire them with the PowerShell launcher. Update the `command` paths to match where you saved them (replace `<you>` with your username):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell -ExecutionPolicy Bypass -File C:/Users/<you>/.claude/hooks/one-way-door-check.ps1"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell -ExecutionPolicy Bypass -File C:/Users/<you>/.claude/hooks/one-way-door-approve.ps1"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
 ## The three questions
 
 Before committing to any one-way door, ask:

--- a/dev-toolkit/skills/one-way-door/one-way-door-approve.ps1
+++ b/dev-toolkit/skills/one-way-door/one-way-door-approve.ps1
@@ -1,0 +1,37 @@
+# One-way door approval promoter (PostToolUse:AskUserQuestion) - PowerShell port for legion2025.
+# Behavior-matched to ~/.claude/hooks/one-way-door-approve.sh on officejawn/houseofjawn.
+# When the user answers any AskUserQuestion, promote every one-way-door file
+# that the PreToolUse:Write hook recorded as pending into the approved ledger
+# for this session. The retried Write then passes instead of re-blocking.
+# Never blocks: PostToolUse hooks must not interrupt the flow.
+param()
+
+$raw = [Console]::In.ReadToEnd()
+if ([string]::IsNullOrEmpty($raw)) { exit 0 }
+
+try { $data = $raw | ConvertFrom-Json } catch { exit 0 }
+
+$SESSION_ID = $data.session_id
+if ([string]::IsNullOrEmpty($SESSION_ID)) { $SESSION_ID = "default" }
+
+$STATE_DIR = "$env:USERPROFILE\.claude\hooks\state\one-way-door"
+if (-not (Test-Path $STATE_DIR)) { New-Item -ItemType Directory -Force -Path $STATE_DIR | Out-Null }
+$APPROVED_FILE = Join-Path $STATE_DIR "$SESSION_ID.approved"
+$PENDING_FILE  = Join-Path $STATE_DIR "$SESSION_ID.pending"
+
+# Nothing pending: nothing to promote.
+if (-not (Test-Path $PENDING_FILE)) { exit 0 }
+$pending = @(Get-Content -LiteralPath $PENDING_FILE -Encoding UTF8 -ErrorAction SilentlyContinue) | Where-Object { $_ -ne "" }
+if (-not $pending) { exit 0 }
+
+# Promote each pending path into approved, deduped.
+$approved = if (Test-Path $APPROVED_FILE) { @(Get-Content -LiteralPath $APPROVED_FILE -Encoding UTF8 -ErrorAction SilentlyContinue) } else { @() }
+foreach ($path in $pending) {
+    if ($approved -notcontains $path) { $approved += $path }
+}
+Set-Content -LiteralPath $APPROVED_FILE -Value $approved -Encoding UTF8
+
+# Empty the pending list now that everything is approved.
+Clear-Content -LiteralPath $PENDING_FILE
+
+exit 0

--- a/dev-toolkit/skills/one-way-door/one-way-door-check.ps1
+++ b/dev-toolkit/skills/one-way-door/one-way-door-check.ps1
@@ -1,0 +1,138 @@
+# One-way door check hook (PreToolUse:Write) - PowerShell port for legion2025 (Windows).
+# Behavior-matched to ~/.claude/hooks/one-way-door-check.sh on officejawn/houseofjawn.
+# Flags architectural decisions that are hard to reverse.
+# The most expensive mistakes aren't bugs - they're irreversible decisions.
+param()
+
+$raw = [Console]::In.ReadToEnd()
+if ([string]::IsNullOrEmpty($raw)) { exit 0 }
+
+# Fail open: a malformed payload must never brick the user's ability to write.
+try { $data = $raw | ConvertFrom-Json } catch { exit 0 }
+
+$FILE_PATH = $data.tool_input.file_path
+if ([string]::IsNullOrEmpty($FILE_PATH)) { exit 0 }
+
+# Canonical ledger key: normalize separators so approval is keyed on one form.
+# Without this, a block recorded as C:\a\b.sql and a retry arriving as C:/a/b.sql
+# would miss in the ledger and re-block the same file. Comparisons are also
+# case-insensitive (PowerShell -contains), matching Windows path semantics.
+$FILE_KEY = $FILE_PATH -replace '\\','/'
+
+# Session-scoped approval ledger. Once the user approves a one-way-door file
+# via the required AskUserQuestion, the PostToolUse:AskUserQuestion hook
+# promotes it to approved, and subsequent writes to that same file proceed.
+$SESSION_ID = $data.session_id
+if ([string]::IsNullOrEmpty($SESSION_ID)) { $SESSION_ID = "default" }
+
+$STATE_DIR = "$env:USERPROFILE\.claude\hooks\state\one-way-door"
+if (-not (Test-Path $STATE_DIR)) { New-Item -ItemType Directory -Force -Path $STATE_DIR | Out-Null }
+$APPROVED_FILE = Join-Path $STATE_DIR "$SESSION_ID.approved"
+$PENDING_FILE  = Join-Path $STATE_DIR "$SESSION_ID.pending"
+
+# Already approved this session: allow without re-blocking.
+if (Test-Path $APPROVED_FILE) {
+    $approved = @(Get-Content -LiteralPath $APPROVED_FILE -Encoding UTF8 -ErrorAction SilentlyContinue)
+    if ($approved -contains $FILE_KEY) {
+        [Console]::Error.WriteLine("one-way-door: proceeding with previously-approved $([System.IO.Path]::GetFileName($FILE_PATH))")
+        exit 0
+    }
+}
+
+$FILENAME = [System.IO.Path]::GetFileName($FILE_PATH)
+$FILENAME_LOWER = $FILENAME.ToLower()
+$DIR = [System.IO.Path]::GetDirectoryName($FILE_PATH)
+if ($null -eq $DIR) { $DIR = "" }
+
+# Normalize separators to forward slashes for path/dir regex checks, so the
+# same patterns match whether Claude Code delivers C:\a\b or C:/a/b. .NET's
+# GetFileName/GetDirectoryName already split on both separators on Windows.
+$FILE_PATH_LOWER_FWD = ($FILE_PATH.ToLower()) -replace '\\','/'
+$DIR_LOWER_FWD = ($DIR.ToLower()) -replace '\\','/'
+
+# ---------------------------------------------------------------------------
+# Early-exit safelist: clearly-additive, reversible file classes that should
+# never trip a one-way-door check even if the filename contains a keyword like
+# "auth" or "security". Tests and docs are the common false-positives.
+# ---------------------------------------------------------------------------
+
+# Test files (pytest, jest, vitest, go test conventions)
+if ($FILENAME_LOWER -match '^test_.*\.py$|_test\.py$|\.test\.(ts|tsx|js|jsx)$|\.spec\.(ts|tsx|js|jsx)$') { exit 0 }
+
+# Test / fixture / mock directories anywhere in the path
+if ($FILE_PATH_LOWER_FWD -match '/tests?/|/__tests__/|/fixtures?/|/mocks?/|/__mocks__/') { exit 0 }
+
+# Markdown is always reversible (broader than the later docs-only check, which
+# required a docs/ parent dir and missed ad-hoc notes).
+if ($FILENAME_LOWER -match '\.md$') { exit 0 }
+
+$ONE_WAY = $false
+$REASON = ""
+
+# Documentation and plan files are always reversible - skip all checks
+if ($FILENAME_LOWER -match '\.txt$|\.rst$') {
+    if ($DIR_LOWER_FWD -match 'plans?|docs?|notes?|superpowers') { exit 0 }
+}
+
+# Database schemas and migrations
+if ($FILENAME_LOWER -match 'schema\.(prisma|graphql|sql)|migration|\.sql$|models?\.(py|ts|js)$|entities?\.(py|ts|js)$') {
+    $ONE_WAY = $true; $REASON = "data model / database schema"
+}
+
+# Infrastructure and deployment configs
+if ($FILENAME_LOWER -match '^(docker-compose|dockerfile|terraform|pulumi|cdk)|\.tf$|cloudformation|k8s|kubernetes|helm') {
+    $ONE_WAY = $true; $REASON = "infrastructure / deployment config"
+}
+
+# Authentication and authorization (code/config files only - not docs)
+if ($FILENAME_LOWER -match 'auth\.(ts|js|py)|firestore\.rules|storage\.rules|security\.(ts|js|py|json|rules|yaml|yml)|\.rules$|rbac\.(ts|js|py|json)|permissions\.(ts|js|py|json)') {
+    $ONE_WAY = $true; $REASON = "auth / security rules"
+}
+
+# API contracts and service interfaces
+if ($FILENAME_LOWER -match 'openapi|swagger|\.proto$|\.graphql$|api-schema|routes\.(ts|js|py)$') {
+    $ONE_WAY = $true; $REASON = "API contract / service interface"
+}
+
+# Event systems and message queues
+if ($FILENAME_LOWER -match 'event(s|bus|emitter|handler)\.(ts|js|py)$|pubsub|queue|kafka|rabbit') {
+    $ONE_WAY = $true; $REASON = "event system / message bus"
+}
+
+# Package manager configs (dependency choices)
+if ($FILENAME_LOWER -match '^(package\.json|cargo\.toml|go\.mod|requirements\.txt|pyproject\.toml|gemfile)$') {
+    $ONE_WAY = $true; $REASON = "dependency / package config"
+}
+
+# Firebase and cloud service configs
+if ($FILENAME_LOWER -match '^firebase\.json$|^\.firebaserc$|firestore\.indexes') {
+    $ONE_WAY = $true; $REASON = "cloud service config (Firebase)"
+}
+
+# CI/CD pipelines
+if (($DIR_LOWER_FWD -match '\.(github|gitlab|circleci)') -or ($FILENAME_LOWER -match '^(jenkinsfile|\.travis\.yml|cloudbuild)')) {
+    $ONE_WAY = $true; $REASON = "CI/CD pipeline"
+}
+
+if ($ONE_WAY) {
+    # Record this file as pending approval for the session (deduped).
+    $pending = if (Test-Path $PENDING_FILE) { @(Get-Content -LiteralPath $PENDING_FILE -Encoding UTF8 -ErrorAction SilentlyContinue) } else { @() }
+    if ($pending -notcontains $FILE_KEY) { Add-Content -LiteralPath $PENDING_FILE -Value $FILE_KEY -Encoding UTF8 }
+
+    $msg = @"
+ONE_WAY_DOOR: You tried to create $FILENAME ($REASON). This write has been blocked because it is a one-way door -- a decision that becomes hard to reverse once other code, data, or users depend on it.
+
+REQUIRED ACTION: You MUST use the AskUserQuestion tool before retrying this write. Present the user with:
+1. What this file does and why it is a one-way door
+2. At least 2 alternative approaches (if any exist) with their trade-offs
+3. An option to proceed as planned
+
+Frame the question around the specific architectural decision, not just "should I create this file?" The user needs to understand what they are committing to.
+
+After the user answers the AskUserQuestion, retry the same write -- it will proceed automatically, because answering the question promotes this file to approved for the rest of the session. (Other unapproved one-way-door files still block.)
+"@
+    [Console]::Error.WriteLine($msg)
+    exit 2
+}
+
+exit 0

--- a/docs/one-way-door/index.html
+++ b/docs/one-way-door/index.html
@@ -528,6 +528,28 @@ committing.</code></pre>
   }
 }</code></pre>
                     </div>
+                    <h4 class="font-semibold mb-2 mt-6">Windows (PowerShell)</h4>
+                    <p class="text-sm text-clay/70 mb-3">On Windows, hooks run through PowerShell and file paths can use backslashes. Behavior-matched ports — <code class="bg-ink/5 px-1.5 py-0.5 rounded text-xs">one-way-door-check.ps1</code> and <code class="bg-ink/5 px-1.5 py-0.5 rounded text-xs">one-way-door-approve.ps1</code> — ship in the skill directory and use the same session ledger, safelist, and categories. Copy both into your hooks folder (for example <code class="bg-ink/5 px-1.5 py-0.5 rounded text-xs">%USERPROFILE%\.claude\hooks\</code>), then wire them with the PowerShell launcher — update the paths to match where you saved them (replace <code class="bg-ink/5 px-1.5 py-0.5 rounded text-xs">&lt;you&gt;</code>):</p>
+                    <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
+                        <pre tabindex="0" class="text-white"><code>{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Write",
+      "hooks": [{
+        "type": "command",
+        "command": "powershell -ExecutionPolicy Bypass -File C:/Users/&lt;you&gt;/.claude/hooks/one-way-door-check.ps1"
+      }]
+    }],
+    "PostToolUse": [{
+      "matcher": "AskUserQuestion",
+      "hooks": [{
+        "type": "command",
+        "command": "powershell -ExecutionPolicy Bypass -File C:/Users/&lt;you&gt;/.claude/hooks/one-way-door-approve.ps1"
+      }]
+    }]
+  }
+}</code></pre>
+                    </div>
                 </div>
             </div>
 

--- a/docs/one-way-door/index.html
+++ b/docs/one-way-door/index.html
@@ -299,7 +299,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         <span class="bg-red-100 text-red-800 text-xs font-semibold px-2.5 py-1 rounded">Block</span>
                         <div>
                             <h3 class="font-semibold">One-way door detected</h3>
-                            <p class="text-sm text-clay/70 mt-1">If the file matches a one-way-door pattern, the hook exits with code 2 (block) and sends a message to stderr explaining what was caught and why.</p>
+                            <p class="text-sm text-clay/70 mt-1">If the file matches a one-way-door pattern and isn't already approved this session, the hook records it as pending, exits with code 2 (block), and sends a message to stderr explaining what was caught and why.</p>
                         </div>
                     </div>
                 </div>
@@ -316,8 +316,8 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                     <div class="flex items-start gap-4">
                         <span class="bg-green-100 text-green-800 text-xs font-semibold px-2.5 py-1 rounded">Proceed</span>
                         <div>
-                            <h3 class="font-semibold">Write with confidence</h3>
-                            <p class="text-sm text-clay/70 mt-1">After the user makes an informed choice, Claude retries the write. Two-way door files always pass through silently with no interruption.</p>
+                            <h3 class="font-semibold">Approve, then write with confidence</h3>
+                            <p class="text-sm text-clay/70 mt-1">When the user answers, a companion hook (PostToolUse:AskUserQuestion) promotes the file to approved for the session, so Claude's retried write passes instead of re-blocking. Two-way door files always pass through silently, and a new session starts with a clean slate.</p>
                         </div>
                     </div>
                 </div>
@@ -326,8 +326,8 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
         <!-- Hook script -->
         <section class="mb-16">
-            <h2 class="font-display text-2xl font-semibold mb-4">The hook script</h2>
-            <p class="text-clay/80 mb-4">A shell script that runs on every <code class="bg-ink/5 px-1.5 py-0.5 rounded text-xs">Write</code> tool call. It pattern-matches the filename and blocks with exit code 2 if the file is a one-way door.</p>
+            <h2 class="font-display text-2xl font-semibold mb-4">The hook scripts</h2>
+            <p class="text-clay/80 mb-4">Two shell scripts that share a session-scoped approval ledger. The check runs on every <code class="bg-ink/5 px-1.5 py-0.5 rounded text-xs">Write</code>: it pattern-matches the filename and blocks with exit code 2 if the file is a one-way door it hasn't already seen approved this session.</p>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
                 <pre tabindex="0" class="text-white"><code>#!/bin/sh
 INPUT=$(cat)
@@ -337,9 +337,39 @@ FILE_PATH=$(echo "$INPUT" | grep -oP '"file_path"\s*:\s*"[^"]*"' \
   | head -1 | sed 's/.*"file_path"\s*:\s*"//;s/"//')
 [ -z "$FILE_PATH" ] && exit 0
 
+# Session-scoped approval ledger
+SESSION_ID=$(echo "$INPUT" | grep -oP '"session_id"\s*:\s*"[^"]*"' \
+  | head -1 | sed 's/.*"session_id"\s*:\s*"//;s/"//')
+[ -z "$SESSION_ID" ] && SESSION_ID="default"
+STATE_DIR="$HOME/.claude/hooks/state/one-way-door"; mkdir -p "$STATE_DIR"
+APPROVED_FILE="$STATE_DIR/$SESSION_ID.approved"
+PENDING_FILE="$STATE_DIR/$SESSION_ID.pending"
+
+# Already approved this session: note it and allow
+if [ -f "$APPROVED_FILE" ] && grep -Fxq "$FILE_PATH" "$APPROVED_FILE"; then
+    echo "one-way-door: proceeding with previously-approved $(basename "$FILE_PATH")" >&2
+    exit 0
+fi
+
 FILENAME=$(basename "$FILE_PATH")
 FILENAME_LOWER=$(echo "$FILENAME" | tr "[:upper:]" "[:lower:]")
+FILE_PATH_LOWER=$(echo "$FILE_PATH" | tr "[:upper:]" "[:lower:]")
 DIR=$(dirname "$FILE_PATH")
+
+# Early-exit safelist: always-reversible classes pass even if the name
+# contains a keyword like "auth" (tests, fixtures/mocks, markdown, docs)
+if echo "$FILENAME_LOWER" | grep -qE \
+  "^test_.*\.py$|_test\.py$|\.test\.(ts|tsx|js|jsx)$|\.spec\.(ts|tsx|js|jsx)$"; then
+    exit 0
+fi
+if echo "$FILE_PATH_LOWER" | grep -qE \
+  "/tests?/|/__tests__/|/fixtures?/|/mocks?/|/__mocks__/"; then
+    exit 0
+fi
+if echo "$FILENAME_LOWER" | grep -qE "\.md$"; then exit 0; fi
+if echo "$FILENAME_LOWER" | grep -qE "\.txt$|\.rst$"; then
+    echo "$DIR" | grep -qE "plans?|docs?|notes?|superpowers" && exit 0
+fi
 
 ONE_WAY=0
 REASON=""
@@ -356,22 +386,49 @@ if echo "$FILENAME_LOWER" | grep -qE \
 fi
 
 if echo "$FILENAME_LOWER" | grep -qE \
-  "auth\.(ts|js|py)|\.rules$|rbac|permissions"; then
+  "auth\.(ts|js|py)|\.rules$|security\.(ts|js|py|json|rules|yaml|yml)|rbac\.(ts|js|py|json)|permissions\.(ts|js|py|json)"; then
     ONE_WAY=1; REASON="auth / security rules"
 fi
 
 # ... (8 categories total)
 
 if [ "$ONE_WAY" = "1" ]; then
+    grep -Fxq "$FILE_PATH" "$PENDING_FILE" 2>/dev/null \
+      || printf '%s\n' "$FILE_PATH" >> "$PENDING_FILE"  # record as pending
     echo "ONE_WAY_DOOR: $FILENAME ($REASON)" >&2
-    echo "Blocked. Discuss trade-offs first." >&2
+    echo "Blocked. Use AskUserQuestion, then retry." >&2
     exit 2  # Block the write
 fi
 
 exit 0  # Allow two-way doors</code></pre>
             </div>
+            <p class="text-clay/80 mt-5 mb-3">A second hook runs on <code class="bg-ink/5 px-1.5 py-0.5 rounded text-xs">PostToolUse:AskUserQuestion</code>. When the user answers any <code class="bg-ink/5 px-1.5 py-0.5 rounded text-xs">AskUserQuestion</code>, it promotes every pending path to approved so the retried write passes. It never blocks. It keys on the event, not the specific question — so an unrelated question answered while a file is pending approves it too. The block-then-discuss prompt is the guardrail; the ledger just stops an already-discussed file from re-blocking.</p>
+            <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
+                <pre tabindex="0" class="text-white"><code>#!/bin/sh
+# one-way-door-approve.sh (PostToolUse:AskUserQuestion)
+INPUT=$(cat); [ -z "$INPUT" ] && exit 0
+
+SESSION_ID=$(echo "$INPUT" | grep -oP '"session_id"\s*:\s*"[^"]*"' \
+  | head -1 | sed 's/.*"session_id"\s*:\s*"//;s/"//')
+[ -z "$SESSION_ID" ] && SESSION_ID="default"
+STATE_DIR="$HOME/.claude/hooks/state/one-way-door"; mkdir -p "$STATE_DIR"
+APPROVED_FILE="$STATE_DIR/$SESSION_ID.approved"
+PENDING_FILE="$STATE_DIR/$SESSION_ID.pending"
+
+[ -s "$PENDING_FILE" ] || exit 0  # nothing pending
+
+# Promote each pending path into approved, deduped
+while IFS= read -r path; do
+    [ -z "$path" ] && continue
+    grep -Fxq "$path" "$APPROVED_FILE" 2>/dev/null \
+      || printf '%s\n' "$path" >> "$APPROVED_FILE"
+done < "$PENDING_FILE"
+
+: > "$PENDING_FILE"  # clear pending now that it's approved
+exit 0</code></pre>
+            </div>
             <p class="text-sm text-clay/80 mt-3">
-                Full script with all 8 categories available in the
+                Full check script with all 8 categories, plus the approval hook, in the
                 <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/one-way-door" class="text-accentDark hover:text-accentDark underline underline-offset-2" target="_blank" rel="noopener noreferrer">skill directory</a>.
             </p>
         </section>
@@ -379,7 +436,7 @@ exit 0  # Allow two-way doors</code></pre>
         <!-- Two-way doors -->
         <section class="mb-16">
             <h2 class="font-display text-2xl font-semibold mb-4">Two-way doors</h2>
-            <p class="text-clay/80 mb-4">These file types pass through the hook silently. They're safe to decide quickly and change later.</p>
+            <p class="text-clay/80 mb-4">These file types pass through the hook silently. They're safe to decide quickly and change later. Test files, Markdown, and docs/plans text files are enforced by an early-exit safelist, so they pass even when the name contains a keyword like "auth".</p>
             <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
                 <div class="bg-green-50 border border-green-200 rounded-lg p-3 text-center">
                     <i data-lucide="layout" class="w-5 h-5 text-green-700 mx-auto mb-1"></i>
@@ -449,8 +506,8 @@ committing.</code></pre>
                 </div>
 
                 <div>
-                    <h3 class="font-semibold mb-3">Option 3: Add the automated hook</h3>
-                    <p class="text-sm text-clay/70 mb-3">For automated enforcement, save the hook script and add this to your <code class="bg-ink/5 px-1.5 py-0.5 rounded text-xs">settings.json</code>:</p>
+                    <h3 class="font-semibold mb-3">Option 3: Add the automated hooks</h3>
+                    <p class="text-sm text-clay/70 mb-3">For automated enforcement, save both scripts and add this to your <code class="bg-ink/5 px-1.5 py-0.5 rounded text-xs">settings.json</code>. The approval hook is required — without it, the check re-blocks an approved file on every retry:</p>
                     <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
                         <pre tabindex="0" class="text-white"><code>{
   "hooks": {
@@ -459,6 +516,13 @@ committing.</code></pre>
       "hooks": [{
         "type": "command",
         "command": "/path/to/one-way-door-check.sh"
+      }]
+    }],
+    "PostToolUse": [{
+      "matcher": "AskUserQuestion",
+      "hooks": [{
+        "type": "command",
+        "command": "/path/to/one-way-door-approve.sh"
       }]
     }]
   }

--- a/hooks/one-way-door-check.md
+++ b/hooks/one-way-door-check.md
@@ -3,7 +3,7 @@ name: one-way-door-check
 event: PreToolUse
 tools:
   - Write
-description: Blocks creation of files that represent irreversible architectural decisions until the user confirms
+description: Blocks creation of files that represent irreversible architectural decisions until the user confirms. Requires the companion PostToolUse:AskUserQuestion hook (one-way-door-approve), which promotes the session's pending files to approved so the retry passes — install both, not just this check.
 ---
 
 # One-way door check
@@ -17,9 +17,9 @@ It ships as two scripts that share a session-scoped approval ledger:
 
 Behavior-matched PowerShell ports for Windows (`one-way-door-check.ps1`, `one-way-door-approve.ps1`) ship in the [`one-way-door` skill directory](../dev-toolkit/skills/one-way-door/); see [Windows (PowerShell)](#windows-powershell) below.
 
-The ledger is what makes the hook stateful. A stateless check would re-block the same file on the retry, so the "ask, then retry" instruction would loop forever. With the ledger, answering the question opens that one file for the rest of the session while every other unapproved one-way-door file still blocks.
+The ledger is what makes the hook stateful. A stateless check would re-block the same file on the retry, so the "ask, then retry" instruction would loop forever. With the ledger, answering the question promotes every file currently pending — usually just the one the check told Claude to ask about — and keeps it open for the rest of the session. A one-way-door file you have not tried to write yet is not pending, so it still blocks the first time Claude attempts it.
 
-The promoter keys on the `AskUserQuestion` event, not on which question was answered: if Claude asks an unrelated question while a file is pending, that file is approved too. The block-then-discuss prompt is the guardrail; the ledger only stops an already-discussed file from re-blocking.
+The promoter keys on the `AskUserQuestion` event, not on which question was answered: it approves the whole pending set at once, so if two one-way-door files are blocked before Claude asks — or it asks an unrelated question while a file is pending — they are all approved together. The block-then-discuss prompt is the guardrail; the ledger only stops an already-discussed file from re-blocking.
 
 ## When this hook fires
 
@@ -83,7 +83,7 @@ After the user answers any `AskUserQuestion`, the PostToolUse:AskUserQuestion ho
 
 ### State
 
-The ledger lives in `~/.claude/hooks/state/one-way-door/`, one pair of files per session: `<session_id>.pending` and `<session_id>.approved`. Approval is per file path, per session — a new session starts with an empty ledger, so the same decision is surfaced again rather than inherited from a past session.
+The ledger lives in `~/.claude/hooks/state/one-way-door/`, one pair of files per session: `<session_id>.pending` and `<session_id>.approved`. Approval is per file path, per session — a new session starts with an empty ledger, so the same decision is surfaced again rather than inherited from a past session. The key is the file path as Claude Code delivers it, which is normally absolute. If a single session writes identically-named files through relative paths in different directories, the path key can collide and approve the second without its own discussion; wiring on absolute paths avoids that.
 
 ## Hook scripts
 

--- a/hooks/one-way-door-check.md
+++ b/hooks/one-way-door-check.md
@@ -10,14 +10,23 @@ description: Blocks creation of files that represent irreversible architectural 
 
 This hook intercepts `Write` tool calls and checks whether the target file represents a one-way door — an architectural decision that becomes hard to reverse once other code, data, or users depend on it.
 
+It ships as two scripts that share a session-scoped approval ledger:
+
+- **`one-way-door-check.sh`** (`PreToolUse:Write`) blocks the first write to a one-way-door file and records it as pending.
+- **`one-way-door-approve.sh`** (`PostToolUse:AskUserQuestion`) promotes the pending files to approved once the user answers any `AskUserQuestion` — normally the one the check told Claude to ask.
+
+The ledger is what makes the hook stateful. A stateless check would re-block the same file on the retry, so the "ask, then retry" instruction would loop forever. With the ledger, answering the question opens that one file for the rest of the session while every other unapproved one-way-door file still blocks.
+
+The promoter keys on the `AskUserQuestion` event, not on which question was answered: if Claude asks an unrelated question while a file is pending, that file is approved too. The block-then-discuss prompt is the guardrail; the ledger only stops an already-discussed file from re-blocking.
+
 ## When this hook fires
 
-- **Event:** PreToolUse (before Claude writes a file)
-- **Tools:** Write only (not Edit — editing an existing file is a two-way door)
+- **Event:** PreToolUse (the check, before Claude writes a file) and PostToolUse:AskUserQuestion (the approval promoter)
+- **Tools:** Write only for the check (not Edit — editing an existing file is a two-way door); AskUserQuestion for the approval promoter
 
 ## Detection logic
 
-The hook extracts the file path from the tool input and checks the filename against patterns for known one-way door categories:
+Before any pattern check, the hook early-exits an explicit safelist of always-reversible file classes (test files, test/fixture/mock directories, Markdown, and docs/plans text files) so they never trip even when the name contains a keyword like `auth`. It then checks the filename against patterns for known one-way door categories:
 
 ### Patterns that trigger blocking
 
@@ -25,7 +34,7 @@ The hook extracts the file path from the tool input and checks the filename agai
 |----------|--------------|
 | Data models | `schema.prisma`, `schema.graphql`, `*.sql`, `migration*`, `models.py`, `models.ts`, `entities.py`, `entities.ts` |
 | Infrastructure | `docker-compose*`, `Dockerfile`, `*.tf`, `terraform*`, `pulumi*`, `cdk*`, `cloudformation*`, `k8s*`, `helm*` |
-| Auth / security | `auth.ts`, `auth.py`, `firestore.rules`, `storage.rules`, `*.rules`, `rbac*`, `permissions*` |
+| Auth / security | `auth.{ts,js,py}`, `firestore.rules`, `storage.rules`, `*.rules`, `security.{ts,js,py,json,rules,yaml,yml}`, `rbac.{ts,js,py,json}`, `permissions.{ts,js,py,json}` |
 | API contracts | `openapi*`, `swagger*`, `*.proto`, `*.graphql`, `api-schema*`, `routes.ts`, `routes.py` |
 | Event systems | `events.ts`, `eventbus.py`, `eventemitter.ts`, `pubsub*`, `queue*`, `kafka*`, `rabbit*` |
 | Dependencies | `package.json`, `Cargo.toml`, `go.mod`, `requirements.txt`, `pyproject.toml`, `Gemfile` |
@@ -41,40 +50,109 @@ The hook extracts the file path from the tool input and checks the filename agai
 - Static assets
 - Configuration that doesn't lock you into architecture (`.env`, feature flags)
 
+Some of these are enforced by the early-exit safelist rather than left to the absence of a match. The hook hard-codes pass-through for:
+
+- Test files by convention — `test_*.py`, `*_test.py`, `*.test.{ts,tsx,js,jsx}`, `*.spec.{ts,tsx,js,jsx}`
+- Anything under a `tests/`, `__tests__/`, `fixtures/`, `mocks/`, or `__mocks__/` directory
+- All Markdown (`*.md`)
+- `*.txt` / `*.rst` under a `plans/`, `docs/`, `notes/`, or `superpowers` directory
+
 ## Hook behavior
 
-### When it blocks (exit code 2)
+### When the check blocks (exit code 2)
 
-The hook outputs a message to stderr instructing Claude to:
+The check hook records the file path as pending for the session, then outputs a message to stderr instructing Claude to:
 
 1. Explain what the file does and why it's a one-way door
 2. Present at least 2 alternative approaches with trade-offs
 3. Offer an option to proceed as planned
 4. Use `AskUserQuestion` to get the user's decision
 
-### When it allows (exit code 0)
+### When the check allows (exit code 0)
 
-The hook exits silently when the file is a two-way door.
+The check allows the write in two cases:
 
-## Hook script
+- The file is a two-way door (no pattern match) — exits silently, no output.
+- The file path is already in the session's approved ledger — the decision was discussed earlier this session, so the write proceeds. This case is not silent: the hook logs `one-way-door: proceeding with previously-approved <file>` to stderr first.
+
+### When the approval promoter runs
+
+After the user answers any `AskUserQuestion`, the PostToolUse:AskUserQuestion hook promotes every pending path into the approved ledger and clears the pending list. It never blocks (exit 0 always) — PostToolUse hooks must not interrupt the flow. Claude's retried write then proceeds because the path is now approved.
+
+### State
+
+The ledger lives in `~/.claude/hooks/state/one-way-door/`, one pair of files per session: `<session_id>.pending` and `<session_id>.approved`. Approval is per file path, per session — a new session starts with an empty ledger, so the same decision is surfaced again rather than inherited from a past session.
+
+## Hook scripts
+
+### Check hook (`one-way-door-check.sh`)
 
 ```bash
 #!/bin/sh
 # One-way door check hook (PreToolUse:Write)
 # Flags architectural decisions that are hard to reverse.
+# The most expensive mistakes aren't bugs — they're irreversible decisions.
 
 INPUT=$(cat)
 [ -z "$INPUT" ] && exit 0
 
+# Extract the file path from tool_input
 FILE_PATH=$(echo "$INPUT" | grep -oP '"file_path"\s*:\s*"[^"]*"' | head -1 | sed 's/.*"file_path"\s*:\s*"//;s/"//')
 [ -z "$FILE_PATH" ] && exit 0
 
+# Session-scoped approval ledger. Once the user approves a one-way-door file
+# via the required AskUserQuestion, the PostToolUse:AskUserQuestion hook
+# promotes it to approved, and subsequent writes to that same file proceed.
+SESSION_ID=$(echo "$INPUT" | grep -oP '"session_id"\s*:\s*"[^"]*"' | head -1 | sed 's/.*"session_id"\s*:\s*"//;s/"//')
+[ -z "$SESSION_ID" ] && SESSION_ID="default"
+
+STATE_DIR="$HOME/.claude/hooks/state/one-way-door"
+mkdir -p "$STATE_DIR"
+APPROVED_FILE="$STATE_DIR/$SESSION_ID.approved"
+PENDING_FILE="$STATE_DIR/$SESSION_ID.pending"
+
+# Already approved this session: allow without re-blocking.
+if [ -f "$APPROVED_FILE" ] && grep -Fxq "$FILE_PATH" "$APPROVED_FILE"; then
+    echo "one-way-door: proceeding with previously-approved $(basename "$FILE_PATH")" >&2
+    exit 0
+fi
+
 FILENAME=$(basename "$FILE_PATH")
 FILENAME_LOWER=$(echo "$FILENAME" | tr "[:upper:]" "[:lower:]")
+FILE_PATH_LOWER=$(echo "$FILE_PATH" | tr "[:upper:]" "[:lower:]")
 DIR=$(dirname "$FILE_PATH")
+
+# ---------------------------------------------------------------------------
+# Early-exit safelist: clearly-additive, reversible file classes that should
+# never trip a one-way-door check even if the filename contains a keyword like
+# "auth" or "security". Tests and docs are the common false-positives.
+# ---------------------------------------------------------------------------
+
+# Test files (pytest, jest, vitest, go test conventions)
+if echo "$FILENAME_LOWER" | grep -qE "^test_.*\.py$|_test\.py$|\.test\.(ts|tsx|js|jsx)$|\.spec\.(ts|tsx|js|jsx)$"; then
+    exit 0
+fi
+
+# Test / fixture / mock directories anywhere in the path
+if echo "$FILE_PATH_LOWER" | grep -qE "/tests?/|/__tests__/|/fixtures?/|/mocks?/|/__mocks__/"; then
+    exit 0
+fi
+
+# Markdown is always reversible (broader than the later docs-only check, which
+# required a docs/ parent dir and missed ad-hoc notes).
+if echo "$FILENAME_LOWER" | grep -qE "\.md$"; then
+    exit 0
+fi
 
 ONE_WAY=0
 REASON=""
+
+# Documentation and plan files are always reversible - skip all checks
+if echo "$FILENAME_LOWER" | grep -qE "\.txt$|\.rst$"; then
+    if echo "$DIR" | grep -qE "plans?|docs?|notes?|superpowers"; then
+        exit 0
+    fi
+fi
 
 # Database schemas and migrations
 if echo "$FILENAME_LOWER" | grep -qE "schema\.(prisma|graphql|sql)|migration|\.sql$|models?\.(py|ts|js)$|entities?\.(py|ts|js)$"; then
@@ -88,8 +166,8 @@ if echo "$FILENAME_LOWER" | grep -qE "^(docker-compose|dockerfile|terraform|pulu
     REASON="infrastructure / deployment config"
 fi
 
-# Authentication and authorization
-if echo "$FILENAME_LOWER" | grep -qE "auth\.(ts|js|py)|firestore\.rules|storage\.rules|security|\.rules$|rbac|permissions"; then
+# Authentication and authorization (code/config files only - not docs)
+if echo "$FILENAME_LOWER" | grep -qE "auth\.(ts|js|py)|firestore\.rules|storage\.rules|security\.(ts|js|py|json|rules|yaml|yml)|\.rules$|rbac\.(ts|js|py|json)|permissions\.(ts|js|py|json)"; then
     ONE_WAY=1
     REASON="auth / security rules"
 fi
@@ -106,7 +184,7 @@ if echo "$FILENAME_LOWER" | grep -qE "event(s|bus|emitter|handler)\.(ts|js|py)$|
     REASON="event system / message bus"
 fi
 
-# Package manager configs
+# Package manager configs (dependency choices)
 if echo "$FILENAME_LOWER" | grep -qE "^(package\.json|cargo\.toml|go\.mod|requirements\.txt|pyproject\.toml|gemfile)$"; then
     ONE_WAY=1
     REASON="dependency / package config"
@@ -125,6 +203,10 @@ if echo "$DIR" | grep -qE "\.(github|gitlab|circleci)" || echo "$FILENAME_LOWER"
 fi
 
 if [ "$ONE_WAY" = "1" ]; then
+    # Record this file as pending approval for the session (deduped).
+    if [ ! -f "$PENDING_FILE" ] || ! grep -Fxq "$FILE_PATH" "$PENDING_FILE"; then
+        printf '%s\n' "$FILE_PATH" >> "$PENDING_FILE"
+    fi
     cat >&2 <<HOOK_MSG
 ONE_WAY_DOOR: You tried to create $FILENAME ($REASON). This write has been blocked because it is a one-way door -- a decision that becomes hard to reverse once other code, data, or users depend on it.
 
@@ -135,7 +217,7 @@ REQUIRED ACTION: You MUST use the AskUserQuestion tool before retrying this writ
 
 Frame the question around the specific architectural decision, not just "should I create this file?" The user needs to understand what they are committing to.
 
-After the user responds, proceed according to their choice.
+After the user answers the AskUserQuestion, retry the same write -- it will proceed automatically, because answering the question promotes this file to approved for the rest of the session. (Other unapproved one-way-door files still block.)
 HOOK_MSG
     exit 2
 fi
@@ -143,9 +225,47 @@ fi
 exit 0
 ```
 
+### Approval hook (`one-way-door-approve.sh`)
+
+```bash
+#!/bin/sh
+# One-way door approval promoter (PostToolUse:AskUserQuestion)
+# When the user answers any AskUserQuestion, promote every one-way-door file
+# that the PreToolUse:Write hook recorded as pending into the approved ledger
+# for this session. The retried Write then passes instead of re-blocking.
+# Never blocks: PostToolUse hooks must not interrupt the flow.
+
+INPUT=$(cat)
+[ -z "$INPUT" ] && exit 0
+
+SESSION_ID=$(echo "$INPUT" | grep -oP '"session_id"\s*:\s*"[^"]*"' | head -1 | sed 's/.*"session_id"\s*:\s*"//;s/"//')
+[ -z "$SESSION_ID" ] && SESSION_ID="default"
+
+STATE_DIR="$HOME/.claude/hooks/state/one-way-door"
+mkdir -p "$STATE_DIR"
+APPROVED_FILE="$STATE_DIR/$SESSION_ID.approved"
+PENDING_FILE="$STATE_DIR/$SESSION_ID.pending"
+
+# Nothing pending: nothing to promote.
+[ -s "$PENDING_FILE" ] || exit 0
+
+# Promote each pending path into approved, deduped.
+while IFS= read -r path; do
+    [ -z "$path" ] && continue
+    if [ ! -f "$APPROVED_FILE" ] || ! grep -Fxq "$path" "$APPROVED_FILE"; then
+        printf '%s\n' "$path" >> "$APPROVED_FILE"
+    fi
+done < "$PENDING_FILE"
+
+# Empty the pending list now that everything is approved.
+: > "$PENDING_FILE"
+
+exit 0
+```
+
 ## Configuration
 
-Add to your Claude Code `settings.json` (user or project level):
+Add both hooks to your Claude Code `settings.json` (user or project level):
 
 ```json
 {
@@ -160,12 +280,23 @@ Add to your Claude Code `settings.json` (user or project level):
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/path/to/one-way-door-approve.sh"
+          }
+        ]
+      }
     ]
   }
 }
 ```
 
-Save the script, make it executable (`chmod +x one-way-door-check.sh`), and update the path in the config.
+Save both scripts, make them executable (`chmod +x one-way-door-check.sh one-way-door-approve.sh`), and update the paths in the config. The approval hook is required: without it, the check would re-block an approved file on every retry.
 
 ## Examples
 
@@ -196,3 +327,16 @@ ONE_WAY_DOOR: You tried to create deploy.yml (CI/CD pipeline).
 ```
 
 Claude must discuss the deployment strategy before proceeding.
+
+### Example 4: Approved — retry after the discussion
+
+Continuing from Example 3: Claude uses `AskUserQuestion` to walk through the deployment trade-offs, and the user picks an option. The approval hook promotes `deploy.yml` to approved for the session.
+
+Claude retries: `Write .github/workflows/deploy.yml`
+
+Hook allows (exit 0) — the file is already approved this session:
+```
+one-way-door: proceeding with previously-approved deploy.yml
+```
+
+A different one-way-door file (say `schema.prisma`) still blocks until it gets its own discussion.

--- a/hooks/one-way-door-check.md
+++ b/hooks/one-way-door-check.md
@@ -15,6 +15,8 @@ It ships as two scripts that share a session-scoped approval ledger:
 - **`one-way-door-check.sh`** (`PreToolUse:Write`) blocks the first write to a one-way-door file and records it as pending.
 - **`one-way-door-approve.sh`** (`PostToolUse:AskUserQuestion`) promotes the pending files to approved once the user answers any `AskUserQuestion` — normally the one the check told Claude to ask.
 
+Behavior-matched PowerShell ports for Windows (`one-way-door-check.ps1`, `one-way-door-approve.ps1`) ship in the [`one-way-door` skill directory](../dev-toolkit/skills/one-way-door/); see [Windows (PowerShell)](#windows-powershell) below.
+
 The ledger is what makes the hook stateful. A stateless check would re-block the same file on the retry, so the "ask, then retry" instruction would loop forever. With the ledger, answering the question opens that one file for the rest of the session while every other unapproved one-way-door file still blocks.
 
 The promoter keys on the `AskUserQuestion` event, not on which question was answered: if Claude asks an unrelated question while a file is pending, that file is approved too. The block-then-discuss prompt is the guardrail; the ledger only stops an already-discussed file from re-blocking.
@@ -297,6 +299,46 @@ Add both hooks to your Claude Code `settings.json` (user or project level):
 ```
 
 Save both scripts, make them executable (`chmod +x one-way-door-check.sh one-way-door-approve.sh`), and update the paths in the config. The approval hook is required: without it, the check would re-block an approved file on every retry.
+
+### Windows (PowerShell)
+
+The shell scripts assume a POSIX shell. On Windows, Claude Code invokes hooks through PowerShell, and `tool_input.file_path` can arrive with backslashes, which `basename` does not split on — so the shell version's safelist would misfire. Behavior-matched PowerShell ports ship in the [`one-way-door` skill directory](../dev-toolkit/skills/one-way-door/):
+
+- `one-way-door-check.ps1` — the `PreToolUse:Write` check
+- `one-way-door-approve.ps1` — the `PostToolUse:AskUserQuestion` promoter
+
+They use the same session ledger (`%USERPROFILE%\.claude\hooks\state\one-way-door\`), the same early-exit safelist, and the same categories as the shell version. Filename and directory splitting goes through `[System.IO.Path]`, and the directory patterns are matched after normalizing `\` to `/`, so the check is correct for backslash and forward-slash paths alike.
+
+Copy both `.ps1` files from the skill directory into your hooks folder (for example `%USERPROFILE%\.claude\hooks\`), then wire them with the PowerShell launcher. Update the `command` paths to match where you saved them (replace `<you>` with your username):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell -ExecutionPolicy Bypass -File C:/Users/<you>/.claude/hooks/one-way-door-check.ps1"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell -ExecutionPolicy Bypass -File C:/Users/<you>/.claude/hooks/one-way-door-approve.ps1"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
 
 ## Examples
 


### PR DESCRIPTION
## What

Syncs the `one-way-door` docs to the **best-of-both** hook now running on every machine, and adds a tested Windows (PowerShell) port so the hook is cross-platform. Doc changes across three surfaces, a changelog entry, and two new `.ps1` scripts.

## Why

The hook had drifted into two variants. officejawn had a **stateful approval ledger**; houseofjawn had a **false-positive safelist + extension-qualified auth matching**. This PR documents the merged version that combines both, and that combined hook is now deployed identically on officejawn and houseofjawn.

**Statefulness.** The old stateless check re-blocked the same file on the very retry it told Claude to make, so the "use `AskUserQuestion`, then retry" loop never terminated. The check (`PreToolUse:Write`) now records a blocked file as pending, and a companion `one-way-door-approve.sh` (`PostToolUse:AskUserQuestion`) promotes pending files to approved — so the retry passes. Other unapproved one-way-door files still block; a new session starts clean.

**Fewer false positives.** Before any pattern check, the hook early-exits a safelist: test files by convention, `tests/`/`__tests__/`/`fixtures/`/`mocks/`/`__mocks__/` directories, all Markdown, and `*.txt`/`*.rst` under `plans`/`docs`/`notes`/`superpowers`. The auth/security patterns are extension-qualified (`security.{ts,js,py,json,rules,yaml,yml}`, `rbac.{ts,js,py,json}`, `permissions.{ts,js,py,json}`), so a file that merely contains a keyword no longer trips.

**Cross-platform.** The skill shipped only the bash hook, so Windows users without WSL had no way to run the check. The two new `.ps1` scripts behavior-match the canonical `.sh` on every check: same 8 categories, same safelist, same session-scoped pending/approved ledger, same block message, same exit codes (2 block, 0 allow/fail-open; the promoter never blocks). The parity target is behavioral, not byte-identity — Windows path and encoding semantics differ from POSIX shell.

## Changes

- `dev-toolkit/skills/one-way-door/SKILL.md` — both hook scripts (verbatim), the enforced safelist, tighter auth patterns, dual-hook `settings.json` wiring, updated flow + exit codes + state notes, and a new Windows (PowerShell) section.
- `hooks/one-way-door-check.md` — same, plus an approval-flow example, the safelist in the detection logic + pass-through list, and a Windows (PowerShell) section.
- `docs/one-way-door/index.html` — how-it-works steps, the embedded snippets (full safelist + auth matcher; categories abbreviated with a link), the install config now covers both hooks, and a Windows (PowerShell) block.
- `dev-toolkit/skills/one-way-door/one-way-door-check.ps1` — new. PowerShell port of the check hook.
- `dev-toolkit/skills/one-way-door/one-way-door-approve.ps1` — new. PowerShell port of the promoter.
- `CHANGELOG.md` — `[Unreleased] / Added` entry for the PowerShell port; `Changed` entries for statefulness and the safelist/precision.

## Windows port notes

- **Ledger key normalization.** The ledger is keyed on a separator-normalized path (`$FILE_KEY`, backslash to forward-slash) so a block recorded as `C:\a\b.sql` and a retry arriving as `C:/a/b.sql` resolve to the same entry instead of re-blocking.
- **Encoding.** All ledger I/O passes `-Encoding UTF8` because PowerShell 5.1's `Content` cmdlets default to the ANSI codepage, which would corrupt non-ASCII paths and silently desync the approved and pending ledgers.
- **Install.** Docs tell users to copy both `.ps1` files into their hooks folder first, then wire them in `settings.json` with Windows-style paths.
- **Tested green on Windows (legion2025):** a 13-case matrix (block, safelist pass-through, the full pending→approve→retry flow, separator-flip approval) plus a non-ASCII path round-trip, driven through the real hook invocation path.

## Accuracy notes

- The embedded full shell blocks in the two markdown docs are **byte-identical** to the deployed `~/.claude/hooks/one-way-door-check.sh` and `one-way-door-approve.sh` (verified programmatically).
- The promoter keys on the `AskUserQuestion` **event**, not on which question was answered — documented in all three docs as a real limitation, not glossed over.
- The already-approved allow path is **not silent** — it logs `one-way-door: proceeding with previously-approved <file>` to stderr. Documented.

## Review

Adversarial codex (gpt-5.4 / low) run to convergence on both the bash docs and the PowerShell port. Bash docs: four rounds of P2/medium factual-drift findings fixed (any-question approval semantics; non-silent approved path; snippet message parity; HTML safelist + auth matcher completeness). PowerShell port: three more rounds fixed (ledger separator-normalization; copy-first install clarity; UTF-8 ledger encoding), final pass clean with no high or medium findings.