### PR TITLE
Ignore local-only autocontext cache and pre-pr-linter tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,14 @@ Thumbs.db
 .superpowers
 .superpowers/
 
+# autocontext plugin runtime cache (pending-lessons.json, created when autocontext runs here)
+.autocontext
+.autocontext/
+
+# Local-only pre-PR linter tooling (not distributed via this repo)
+pre-pr-linter
+pre-pr-linter/
+
 # Python
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Adds two machine-local directories to `.gitignore` so they stop showing up as untracked and can't be committed by accident:

- `.autocontext/` — the autocontext plugin's runtime cache (`cache/pending-lessons.json`). Pure local artifact, alongside the existing `.codex/` and `.superpowers/` ignores.
- `pre-pr-linter/` — local pre-PR linting tooling (plugin.json, hooks, scripts) that isn't distributed through this skills repo.

Note: `pre-pr-linter/` is authored tooling, not a throwaway artifact. If it's meant to live in this repo as a plugin instead of staying local, say so and I'll drop it from the ignore list and commit the tooling instead.