### PR TITLE
Fix WCAG color-contrast on autonomy and workflows docs pages

### DIFF
--- a/docs/autonomy/index.html
+++ b/docs/autonomy/index.html
@@ -65,6 +65,7 @@
       --border-bright: rgba(0,0,0,0.34);
       --accent: #e4002b;          /* Swiss red */
       --accent-dim: rgba(228,0,43,0.07);
+      --accent-strong: #c00020;   /* darker red: title text on the light warn bg (>=4.5:1) */
       --neutral: #8a8a8a;         /* diagram "a step" */
 
       --font-body: 'Archivo', system-ui, -apple-system, sans-serif;
@@ -76,14 +77,14 @@
         --bg: #0e0e0e; --surface: #161616; --surface-2: #1e1e1e;
         --ink: #f2f2f2; --text: #ececec; --text-bright: #ffffff; --text-dim: #9a9a9a;
         --border: rgba(255,255,255,0.16); --border-bright: rgba(255,255,255,0.34);
-        --accent: #ff3355; --accent-dim: rgba(255,51,85,0.12); --neutral: #8f8f8f;
+        --accent: #ff3355; --accent-dim: rgba(255,51,85,0.12); --neutral: #8f8f8f; --accent-strong: #ff3355;
       }
     }
     [data-theme="dark"] {
       --bg: #0e0e0e; --surface: #161616; --surface-2: #1e1e1e;
       --ink: #f2f2f2; --text: #ececec; --text-bright: #ffffff; --text-dim: #9a9a9a;
       --border: rgba(255,255,255,0.16); --border-bright: rgba(255,255,255,0.34);
-      --accent: #ff3355; --accent-dim: rgba(255,51,85,0.12); --neutral: #8f8f8f;
+      --accent: #ff3355; --accent-dim: rgba(255,51,85,0.12); --neutral: #8f8f8f; --accent-strong: #ff3355;
     }
 
     /* ---------- Reset & base ---------- */
@@ -279,7 +280,7 @@
     .callout { padding: 18px 20px; border: 1px solid var(--border); background: var(--surface); margin: 24px 0; }
     .callout__title { font-family: var(--font-body); font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.12em; margin-bottom: 9px; color: var(--callt, var(--text-bright)); }
     .callout p { font-size: 14px; }
-    .callout--warn { background: var(--accent-dim); border-color: var(--accent); --callt: var(--accent); }
+    .callout--warn { background: var(--accent-dim); border-color: var(--accent); --callt: var(--accent-strong); }
     .callout--ok   { --callt: var(--text-bright); }
     .callout--info { --callt: var(--accent); }
 

--- a/docs/workflows/index.html
+++ b/docs/workflows/index.html
@@ -271,7 +271,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         <h4 class="font-semibold m-0">Panama &amp; Pandora Papers + Datashare</h4>
                         <span class="bg-accent/10 text-ink text-[11px] font-semibold px-2 py-1 rounded whitespace-nowrap">Fan-out + verify</span>
                     </div>
-                    <p class="text-xs text-clay/60 mb-2">ICIJ &middot; 2016&ndash;2021</p>
+                    <p class="text-xs text-clay/70 mb-2">ICIJ &middot; 2016&ndash;2021</p>
                     <p class="text-sm text-clay/70 mb-2">ICIJ ran OCR and named-entity recognition over roughly 11.5M (Panama) and 11.9M (Pandora) leaked files with its open-source Datashare tool to auto-detect people, organizations, and places, then mapped the relationships in a graph database.</p>
                     <p class="text-sm text-clay/70 mb-2"><strong>The shape:</strong> millions of documents split for parallel extraction; reporters in dozens of countries confirm entities against public records before publishing; the graph is the merge step that links per-document findings into one deduplicated network.</p>
                     <a href="https://www.icij.org/inside-icij/2019/11/what-is-datashare-frequently-asked-questions-about-our-document-analysis-software/" target="_blank" rel="noopener noreferrer" class="text-accentDark text-sm underline underline-offset-2">ICIJ on Datashare &rarr;</a>
@@ -281,7 +281,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         <h4 class="font-semibold m-0">Hidden Spy Planes</h4>
                         <span class="bg-accent/10 text-ink text-[11px] font-semibold px-2 py-1 rounded whitespace-nowrap">Fan-out + verify</span>
                     </div>
-                    <p class="text-xs text-clay/60 mb-2">BuzzFeed News (Peter Aldhous) &middot; 2017</p>
+                    <p class="text-xs text-clay/70 mb-2">BuzzFeed News (Peter Aldhous) &middot; 2017</p>
                     <p class="text-sm text-clay/70 mb-2">A machine-learning classifier trained on the flight patterns of known FBI and DHS planes scored about 20,000 aircraft from four months of flight data, flagging roughly 69 candidate surveillance planes. The code and data were open-sourced.</p>
                     <p class="text-sm text-clay/70 mb-2"><strong>The shape:</strong> the model scores every plane independently; reporters then cross-check FAA registration, shell-company ownership, and flight behavior to confirm each hit before naming it.</p>
                     <a href="https://www.buzzfeednews.com/article/peteraldhous/hidden-spy-planes" target="_blank" rel="noopener noreferrer" class="text-accentDark text-sm underline underline-offset-2">BuzzFeed News &rarr;</a>
@@ -291,7 +291,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         <h4 class="font-semibold m-0">Algorithm audits (Citizen Browser, Allstate)</h4>
                         <span class="bg-accent/10 text-ink text-[11px] font-semibold px-2 py-1 rounded whitespace-nowrap">Fan-out + verify</span>
                     </div>
-                    <p class="text-xs text-clay/60 mb-2">The Markup (Allstate work with Consumer Reports) &middot; 2020&ndash;2021</p>
+                    <p class="text-xs text-clay/70 mb-2">The Markup (Allstate work with Consumer Reports) &middot; 2020&ndash;2021</p>
                     <p class="text-sm text-clay/70 mb-2">The Markup analyzed feed data from a paid panel of 1,000+ Facebook users to see what different demographics were shown, and separately analyzed pricing for about 93,000 Allstate policyholders in Maryland to expose a discriminatory pricing scheme.</p>
                     <p class="text-sm text-clay/70 mb-2"><strong>The shape:</strong> automated analysis across many sampled units, then a rigorous verify stage &mdash; published methodology, independent re-runs by data scientists, and outside-expert review before publication.</p>
                     <a href="https://themarkup.org/citizen-browser" target="_blank" rel="noopener noreferrer" class="text-accentDark text-sm underline underline-offset-2">The Markup &rarr;</a>
@@ -305,7 +305,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         <h4 class="font-semibold m-0">Automated earnings and sports coverage</h4>
                         <span class="bg-accent/10 text-ink text-[11px] font-semibold px-2 py-1 rounded whitespace-nowrap">Fan-out</span>
                     </div>
-                    <p class="text-xs text-clay/60 mb-2">Associated Press (with Automated Insights) &middot; 2014&ndash;2016</p>
+                    <p class="text-xs text-clay/70 mb-2">Associated Press (with Automated Insights) &middot; 2014&ndash;2016</p>
                     <p class="text-sm text-clay/70 mb-2">AP used natural-language generation to turn structured earnings data into stories, scaling quarterly coverage roughly tenfold &mdash; from about 300 to several thousand stories per quarter &mdash; and later extended it to minor-league baseball recaps.</p>
                     <p class="text-sm text-clay/70 mb-2"><strong>The shape:</strong> one generation step produces a draft per item (each filing, each box score) in parallel; verification is built in as templates plus source-data validation, with editors spot-checking and a disclosure line as the audit trail. The pattern works even when the per-item agent is template generation, not a chatbot.</p>
                     <a href="https://www.poynter.org/reporting-editing/2015/robot-writing-increased-aps-earnings-stories-by-tenfold/" target="_blank" rel="noopener noreferrer" class="text-accentDark text-sm underline underline-offset-2">Poynter &rarr;</a>
@@ -319,7 +319,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         <h4 class="font-semibold m-0">AI claim detection and matching</h4>
                         <span class="bg-accent/10 text-ink text-[11px] font-semibold px-2 py-1 rounded whitespace-nowrap">Fan-out + human verify</span>
                     </div>
-                    <p class="text-xs text-clay/60 mb-2">Full Fact (UK) &middot; 2016&ndash;present</p>
+                    <p class="text-xs text-clay/70 mb-2">Full Fact (UK) &middot; 2016&ndash;present</p>
                     <p class="text-sm text-clay/70 mb-2">A classifier spots check-worthy claims across news, TV subtitles, and social media at firehose scale, and a separate model flags when an already-debunked claim resurfaces even reworded. The AI surfaces candidates; human fact-checkers write the verdict. Used by 45+ organizations across 30 countries.</p>
                     <p class="text-sm text-clay/70 mb-2"><strong>The shape:</strong> detection parallelizes across hundreds of thousands of sentences, but nothing publishes until a skeptical human confirms or refutes each flag. The mandatory human challenge is the guardrail.</p>
                     <a href="https://fullfact.org/ai/" target="_blank" rel="noopener noreferrer" class="text-accentDark text-sm underline underline-offset-2">Full Fact &rarr;</a>
@@ -329,7 +329,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         <h4 class="font-semibold m-0">Squash and Tech &amp; Check</h4>
                         <span class="bg-accent/10 text-ink text-[11px] font-semibold px-2 py-1 rounded whitespace-nowrap">Pipeline + verify</span>
                     </div>
-                    <p class="text-xs text-clay/60 mb-2">Duke Reporters' Lab &middot; 2016&ndash;present</p>
+                    <p class="text-xs text-clay/70 mb-2">Duke Reporters' Lab &middot; 2016&ndash;present</p>
                     <p class="text-sm text-clay/70 mb-2">Tech &amp; Check runs a claim-spotting model over transcripts and emails journalists a daily list of check-worthy claims. Squash transcribes live political speeches and instantly matches spoken claims against a database of published human fact-checks, displaying matches on screen.</p>
                     <p class="text-sm text-clay/70 mb-2"><strong>The shape:</strong> detection is cleanly separated from verification &mdash; a model proposes a claim, then a distinct layer must ground it in an independent corpus of human-vetted checks. It refuses to surface a verdict it cannot anchor.</p>
                     <a href="https://reporterslab.org/tech-and-check/" target="_blank" rel="noopener noreferrer" class="text-accentDark text-sm underline underline-offset-2">Duke Reporters' Lab &rarr;</a>
@@ -339,7 +339,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         <h4 class="font-semibold m-0">InVID / WeVerify Verification Plugin</h4>
                         <span class="bg-accent/10 text-ink text-[11px] font-semibold px-2 py-1 rounded whitespace-nowrap">Adversarial-verify</span>
                     </div>
-                    <p class="text-xs text-clay/60 mb-2">InVID &amp; WeVerify consortia, maintained by AFP Medialab &middot; 2017&ndash;present</p>
+                    <p class="text-xs text-clay/70 mb-2">InVID &amp; WeVerify consortia, maintained by AFP Medialab &middot; 2017&ndash;present</p>
                     <p class="text-sm text-clay/70 mb-2">A browser plugin used by 50,000+ journalists and fact-checkers weekly: keyframe extraction, reverse image search across multiple engines, metadata analysis, forensic filters, and synthetic-media detection.</p>
                     <p class="text-sm text-clay/70 mb-2"><strong>The shape:</strong> built for refutation. A journalist starts with a claim (&ldquo;this video shows event X today&rdquo;) and the tools hunt for evidence that disproves it &mdash; earlier copies, mismatched metadata, manipulation artifacts. Each check is a fresh challenge to the original claim.</p>
                     <a href="https://github.com/AFP-Medialab/verification-plugin" target="_blank" rel="noopener noreferrer" class="text-accentDark text-sm underline underline-offset-2">Verification Plugin (GitHub) &rarr;</a>
@@ -349,7 +349,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         <h4 class="font-semibold m-0">Multi-agent debate fact-checking</h4>
                         <span class="bg-accent/10 text-ink text-[11px] font-semibold px-2 py-1 rounded whitespace-nowrap">Adversarial-verify</span>
                     </div>
-                    <p class="text-xs text-clay/60 mb-2">Academic research groups (arXiv) &middot; 2025&ndash;2026</p>
+                    <p class="text-xs text-clay/70 mb-2">Academic research groups (arXiv) &middot; 2025&ndash;2026</p>
                     <p class="text-sm text-clay/70 mb-2">Research frameworks where two agents take opposing stances &mdash; one affirming, one refuting a claim &mdash; over several rounds while a moderator renders a verdict. Some add per-agent evidence retrieval. Published results show the debate setup corrects single-model errors.</p>
                     <p class="text-sm text-clay/70 mb-2"><strong>The shape:</strong> the most literal version of adversarial-verify &mdash; one agent argues a claim is true, a second is tasked specifically with refuting it, a third adjudicates. Direct evidence that a separate refuting agent reduces error, especially when it retrieves its own evidence. (Preprint; not yet peer-reviewed.)</p>
                     <a href="https://arxiv.org/abs/2507.19090" target="_blank" rel="noopener noreferrer" class="text-accentDark text-sm underline underline-offset-2">arXiv preprint &rarr;</a>
@@ -363,7 +363,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         <h4 class="font-semibold m-0">Systematic literature review</h4>
                         <span class="bg-accent/10 text-ink text-[11px] font-semibold px-2 py-1 rounded whitespace-nowrap">Fan-out + verify</span>
                     </div>
-                    <p class="text-xs text-clay/60 mb-2">Elicit &middot; 2023&ndash;2026</p>
+                    <p class="text-xs text-clay/70 mb-2">Elicit &middot; 2023&ndash;2026</p>
                     <p class="text-sm text-clay/70 mb-2">An AI research assistant that runs the systematic-review pipeline end to end: takes a research question, screens large paper sets, and extracts structured data into a table, with a supporting quote and citation attached to every answer. The company reports high screening recall benchmarked against hundreds of Cochrane reviews.</p>
                     <p class="text-sm text-clay/70 mb-2"><strong>The shape:</strong> one query expands into thousands of parallel per-paper screening calls; each judgment ships with a verbatim quote and citation so a human can audit it. The quote-per-claim is the structural verification gate. (Accuracy figures are the vendor's own.)</p>
                     <a href="https://elicit.com/blog/evaluating-elicit-slr" target="_blank" rel="noopener noreferrer" class="text-accentDark text-sm underline underline-offset-2">Elicit evaluation &rarr;</a>
@@ -373,7 +373,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         <h4 class="font-semibold m-0">AI Co-Scientist</h4>
                         <span class="bg-accent/10 text-ink text-[11px] font-semibold px-2 py-1 rounded whitespace-nowrap">Fan-out + adversarial-verify</span>
                     </div>
-                    <p class="text-xs text-clay/60 mb-2">Google DeepMind &middot; 2025&ndash;2026</p>
+                    <p class="text-xs text-clay/70 mb-2">Google DeepMind &middot; 2025&ndash;2026</p>
                     <p class="text-sm text-clay/70 mb-2">A multi-agent system where specialized agents generate, debate, rank, and refine research hypotheses, spending most of the compute on verifying hypotheses rather than generating them. Validated on drug repurposing (30 candidates narrowed to 5 lab-tested) and published in Nature.</p>
                     <p class="text-sm text-clay/70 mb-2"><strong>The shape:</strong> a generation agent proposes many hypotheses in parallel; a debate agent and a ranking tournament adversarially score and eliminate weak ones; an evolution loop refines the survivors. Verification is a dedicated agent role, not an afterthought.</p>
                     <a href="https://deepmind.google/blog/co-scientist-a-multi-agent-ai-partner-to-accelerate-research/" target="_blank" rel="noopener noreferrer" class="text-accentDark text-sm underline underline-offset-2">Google DeepMind &rarr;</a>
@@ -387,7 +387,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         <h4 class="font-semibold m-0">Dead-link repair at scale</h4>
                         <span class="bg-accent/10 text-ink text-[11px] font-semibold px-2 py-1 rounded whitespace-nowrap">Loop-until-dry</span>
                     </div>
-                    <p class="text-xs text-clay/60 mb-2">InternetArchiveBot, Internet Archive + Wikimedia &middot; 2016&ndash;present</p>
+                    <p class="text-xs text-clay/70 mb-2">InternetArchiveBot, Internet Archive + Wikimedia &middot; 2016&ndash;present</p>
                     <p class="text-sm text-clay/70 mb-2">A bot scans outbound links across Wikipedia, confirms a URL is actually dead before acting, then rewrites the citation to an archived snapshot. It has fixed roughly 6 million dead references; 9M+ Wikipedia URLs now point to archived copies.</p>
                     <p class="text-sm text-clay/70 mb-2"><strong>The shape:</strong> probe each live URL; on confirmed failure, query archive providers for a usable snapshot; rewrite the citation only when a valid replacement is verified. The dead-link confirmation is a false-positive guard before the archive fallback.</p>
                     <a href="https://meta.wikimedia.org/wiki/InternetArchiveBot/How_the_bot_fixes_broken_links" target="_blank" rel="noopener noreferrer" class="text-accentDark text-sm underline underline-offset-2">How the bot works &rarr;</a>
@@ -397,7 +397,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         <h4 class="font-semibold m-0">Link rot and content drift</h4>
                         <span class="bg-accent/10 text-ink text-[11px] font-semibold px-2 py-1 rounded whitespace-nowrap">Verify at scale</span>
                     </div>
-                    <p class="text-xs text-clay/60 mb-2">Harvard Library Innovation Lab, in Columbia Journalism Review &middot; 2021</p>
+                    <p class="text-xs text-clay/70 mb-2">Harvard Library Innovation Lab, in Columbia Journalism Review &middot; 2021</p>
                     <p class="text-sm text-clay/70 mb-2">Analyzed 553,693 New York Times articles (1996&ndash;2019) containing over 2.2M outbound links, finding widespread link rot (dead pages) and content drift (pages that still load but silently changed from what was cited).</p>
                     <p class="text-sm text-clay/70 mb-2"><strong>The shape:</strong> a large automated verify pass over millions of URLs that compared current content against the original, not just HTTP status. The lesson: real verification checks whether the content still supports the claim, not just whether the link loads.</p>
                     <a href="https://www.cjr.org/analysis/linkrot-content-drift-new-york-times.php" target="_blank" rel="noopener noreferrer" class="text-accentDark text-sm underline underline-offset-2">Columbia Journalism Review &rarr;</a>
@@ -441,19 +441,19 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <div class="grid grid-cols-2 md:grid-cols-4 gap-3 my-6">
                 <div class="bg-white rounded-xl p-4 border border-mist/30 text-center">
                     <div class="font-display text-3xl font-bold text-accentDark">11</div>
-                    <div class="text-xs text-clay/60 mt-1">agents spawned</div>
+                    <div class="text-xs text-clay/70 mt-1">agents spawned</div>
                 </div>
                 <div class="bg-white rounded-xl p-4 border border-mist/30 text-center">
                     <div class="font-display text-3xl font-bold text-accentDark">~13.5</div>
-                    <div class="text-xs text-clay/60 mt-1">minutes, start to finish</div>
+                    <div class="text-xs text-clay/70 mt-1">minutes, start to finish</div>
                 </div>
                 <div class="bg-white rounded-xl p-4 border border-mist/30 text-center">
                     <div class="font-display text-3xl font-bold text-accentDark">~801K</div>
-                    <div class="text-xs text-clay/60 mt-1">tokens used</div>
+                    <div class="text-xs text-clay/70 mt-1">tokens used</div>
                 </div>
                 <div class="bg-white rounded-xl p-4 border border-mist/30 text-center">
                     <div class="font-display text-3xl font-bold text-accentDark">13</div>
-                    <div class="text-xs text-clay/60 mt-1">verified examples kept</div>
+                    <div class="text-xs text-clay/70 mt-1">verified examples kept</div>
                 </div>
             </div>
 


### PR DESCRIPTION
## What

Fixes the two serious `color-contrast` (WCAG 1.4.3) violations reported in #120.

| Page | Element | Before | After |
|------|---------|--------|-------|
| `/autonomy/` | `.callout--warn .callout__title` (brand red on light-red tint) | ~4.3:1 | **5.69:1** |
| `/workflows/` | `.text-clay/60` card captions (on canvas-tinted cards) | ~3.7:1 | **4.86:1** |

## How

- **autonomy:** new theme-aware `--accent-strong` (`#c00020` light / `#ff3355` dark) drives the warn-callout title. Scoped to that element so the global `--accent` (used by links, which already passed) is untouched. Dark mode keeps the bright red, which already clears the threshold on near-black.
- **workflows:** the failing `text-clay/60` captions are raised to `text-clay/70` — the same muted level the page's body text already uses and that axe already passed on identical backgrounds.

## Verification

`node scripts/verify_a11y.mjs` → **0 violations across all 47 pages** (was 2 serious). Both target pages confirmed at 0. Pages rendered headless to confirm no visual regression. Reviewed with codex gpt-5.4/low: clean.

Closes #120.