### PR TITLE
Fix intermittent undici crash in the a11y verification gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A curated collection of Claude Code skills designed for journalists, researchers, academics, media professionals, and communications practitioners.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test \"scripts/**/*.test.mjs\"",
+    "a11y": "node scripts/verify_a11y.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/verify_a11y.mjs
+++ b/scripts/verify_a11y.mjs
@@ -3,10 +3,10 @@
 // if any page has impact >= moderate (so it doubles as a CI gate).
 
 import { spawn } from 'node:child_process';
-import { createServer } from 'node:net';
+import { createServer, connect } from 'node:net';
 import { readdirSync, statSync, writeFileSync } from 'node:fs';
 import { join, relative, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { chromium } from 'playwright';
 import { AxeBuilder } from '@axe-core/playwright';
 
@@ -43,16 +43,30 @@ function findIndexes(dir, out = []) {
   return out;
 }
 
-async function waitForServer(port, timeoutMs = 10000) {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      const r = await fetch(`http://127.0.0.1:${port}/`);
-      if (r.ok || r.status === 404) return;
-    } catch {}
-    await new Promise((r) => setTimeout(r, 100));
-  }
-  throw new Error(`server on :${port} did not start`);
+// Readiness probe via a raw TCP connect (node:net), NOT an HTTP fetch. A
+// successful connect means the listener is accepting, which is all "ready"
+// needs here. The old version used global fetch (undici) and never consumed
+// the response body, which parked the keep-alive socket in a paused state;
+// undici's later handling of that idle connection intermittently tripped
+// `assert(!this.paused)` and crashed the whole run (see issue #121). A connect
+// probe has no response body and no connection pool, so that failure class
+// cannot occur.
+export function waitForPort(port, { host = '127.0.0.1', timeoutMs = 10000, intervalMs = 100 } = {}) {
+  const probe = () => new Promise((resolve) => {
+    const sock = connect({ port, host });
+    const finish = (ok) => { sock.removeAllListeners(); sock.destroy(); resolve(ok); };
+    sock.once('connect', () => finish(true));
+    sock.once('error', () => finish(false));
+    sock.setTimeout(Math.max(250, intervalMs), () => finish(false));
+  });
+  return (async () => {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (await probe()) return;
+      await new Promise((r) => setTimeout(r, intervalMs));
+    }
+    throw new Error(`server on ${host}:${port} did not start within ${timeoutMs}ms`);
+  })();
 }
 
 function truncate(s, n) { return s && s.length > n ? s.slice(0, n) + '...' : (s || ''); }
@@ -83,7 +97,7 @@ async function main() {
   process.on('SIGINT', () => { cleanup(); process.exit(130); });
 
   try {
-    await waitForServer(port);
+    await waitForPort(port);
 
     const indexFiles = findIndexes(DOCS_DIR);
     const pages = indexFiles.map((abs) => {
@@ -176,4 +190,8 @@ async function main() {
   }
 }
 
-main();
+// Only run the scan when executed directly (node verify_a11y.mjs). When the
+// module is imported — e.g. by verify_a11y.test.mjs to exercise waitForPort —
+// importing must not spawn the server or launch a browser.
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) main();

--- a/scripts/verify_a11y.test.mjs
+++ b/scripts/verify_a11y.test.mjs
@@ -1,0 +1,78 @@
+// Tests for the readiness probe in verify_a11y.mjs (run: `npm test`).
+//
+// Regression coverage for issue #121: the old readiness check used global fetch
+// (undici) and left the response body unconsumed, which intermittently crashed
+// the run with `assert(!this.paused)`. waitForPort uses a raw TCP connect — no
+// body, no connection pool — so that failure class is gone. These tests pin the
+// probe's contract and stress the path that used to crash.
+//
+// They deliberately never free a local port and reuse it: that races the OS
+// port allocator. Live cases hold their server open for the whole test; the
+// "down" case targets port 0 on loopback, which can never have a listener, so
+// connect() always fails locally with no routing and nothing to reassign.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { waitForPort } from './verify_a11y.mjs';
+
+const HOST = '127.0.0.1';
+
+function canBindLoopback() {
+  return new Promise((resolve) => {
+    const s = createServer();
+    s.once('error', () => resolve(false));
+    s.listen(0, HOST, () => s.close(() => resolve(true)));
+  });
+}
+
+// Some restricted sandboxes forbid binding a loopback listener (listen EPERM).
+// A real a11y run always has loopback (the gate serves docs/ on 127.0.0.1), but
+// `npm test` may run in such a sandbox. Mirror test_embed.py's
+// skip-when-prerequisite-missing pattern: probe once, skip the listener-based
+// tests rather than hard-failing the suite. The "down" test only connects, so
+// it still runs.
+const noBind = (await canBindLoopback()) ? false : 'loopback binding unavailable in this environment';
+
+function listenHttp() {
+  const server = createServer((req, res) => res.end('ok'));
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, HOST, () => resolve({ server, port: server.address().port }));
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+test('resolves once the server is accepting connections', { skip: noBind }, async () => {
+  const { server, port } = await listenHttp();
+  try {
+    await waitForPort(port, { timeoutMs: 2000, intervalMs: 25 });
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test('rejects when the target never accepts', async () => {
+  // Port 0 on loopback is the deterministic "always refused" target: nothing
+  // can ever listen on port 0 (listen(0) means "auto-assign", the bound port is
+  // never literally 0), so connect() fails immediately and locally with no
+  // routing involved and no port the OS could reassign. Every probe fails, so
+  // waitForPort must exhaust its deadline and throw.
+  await assert.rejects(
+    () => waitForPort(0, { host: HOST, timeoutMs: 300, intervalMs: 50 }),
+    /did not start/,
+  );
+});
+
+test('stress: 250 sequential probes never crash (undici-free readiness path)', { skip: noBind }, async () => {
+  const { server, port } = await listenHttp();
+  try {
+    for (let i = 0; i < 250; i++) {
+      await waitForPort(port, { timeoutMs: 1000, intervalMs: 25 });
+    }
+  } finally {
+    await closeServer(server);
+  }
+});


### PR DESCRIPTION
## What

Fixes #121 — `node scripts/verify_a11y.mjs` intermittently crashed with undici's `assert(!this.paused)` and exited non-zero.

## Root cause (verified from source)

The script's **only** use of Node's global `fetch` (undici) was the server-readiness poll in `waitForServer`, and it never consumed the response body. An unconsumed undici body parks the keep-alive socket in a paused state; undici's later handling of that idle connection intermittently trips the assertion. Playwright and `@axe-core/playwright` don't use undici, so the readiness poll was the sole culprit.

Because the gate uses distinct exit codes (`1` = violations, `2` = scan error), the crash made a non-zero exit ambiguous — it could mean real violations, a failed scan, **or** this race. That ambiguity is what made the flaky gate worse than a flaky page.

## Fix

- Replace the HTTP `fetch` readiness check with **`waitForPort()`**, a raw TCP-connect probe (`node:net`). A successful connect is all "ready" means here, and it removes global `fetch` **entirely** — so the assertion class can't occur (make the bad state impossible, not handled).
- Export `waitForPort` and guard `main()` behind an `isMain` check so the probe is unit-testable without spawning the server or launching a browser.

## Tests (`npm test`, via built-in `node:test` — no new deps)

- resolves once the server accepts connections
- rejects after its deadline when the target never accepts — **port 0 on loopback**, which can never have a listener, so it's deterministic with no routing dependency and no freed-port reassignment race
- survives **250 sequential probes** (the path that used to crash)
- listener-based tests **skip** when the sandbox forbids loopback binding, mirroring `test_embed.py`'s skip-when-prerequisite-missing pattern; the connect-only test still runs

## Verification

- `npm test` → 3 pass, 0 fail
- `node scripts/verify_a11y.mjs` end-to-end → **47 pages, 0 violations**, exit 0 (the new readiness probe doesn't regress the gate)
- codex gpt-5.4/low: clean after 5 rounds (rounds 2–5 hardened the test against its own flakiness)

### Honest limitation

The original crash is intermittent and undici-internal, so the stress test is a **regression guard**, not a deterministic reproduction. The real guarantee is structural: the readiness path no longer touches undici at all.

Closes #121.