### PR TITLE
docs: sync skill/plugin counts with the actual codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,17 +107,58 @@ claude-skills-journalism/
 │       ├── project-retrospective/      # LESSONS.md generation, 4 project type templates
 │       └── template-selector/          # Decision tree for picking the right template
 │
-└── # Plugin: security-toolkit (4 skills, /security-toolkit:hotpatch command) — registered in marketplace.json
+├── # Plugin: security-toolkit (4 skills, /security-toolkit:hotpatch command) — registered in marketplace.json
+├── security-toolkit/
+│   ├── .claude-plugin/plugin.json
+│   ├── README.md
+│   ├── commands/hotpatch.md            # Slash command: sandboxed pre-install scan + cooldown bypass
+│   ├── scripts/hotpatch.example.sh     # Reference Linux/bwrap implementation
+│   ├── test-fixtures/                  # Synthetic malicious tarballs for self-test
+│   └── skills/
+│       ├── api-hardening/              # Rate limiting, CORS, request throttling, defense-in-depth
+│       ├── secure-auth/                # Password hashing, sessions, JWT, OAuth, passkeys
+│       ├── security-checklist/         # Pre-deployment OWASP audit
+│       └── supply-chain-hardening/     # npm/bun install-time cooldown + sandboxed bypass scan
+│
+├── # Plugin: autocontext (no skills — hooks/commands/agents) — registered in marketplace.json
+├── autocontext/                 # Cross-session knowledge persistence with skill evolution
+│   ├── .claude-plugin/plugin.json
+│   ├── agents/                  # Lesson-review and evolution agents
+│   ├── commands/                # /autocontext:setup, :init, :review, :status, :evolve
+│   ├── hooks/                   # Capture, validate, and surface lessons across sessions
+│   ├── scripts/skill-evolution/ # Fold accumulated lessons back into skill files
+│   ├── templates/              # Lesson and archive templates
+│   └── tests/
+│
+├── # Plugin: pdf-playground (8 commands, v1.3.1) — registered in marketplace.json
+├── pdf-playground/              # Interactive proposal/report/slide builder with live control panel
+│   ├── .claude-plugin/plugin.json
+│   ├── brands/                  # Brand presets
+│   ├── commands/                # /proposal, /report, /onepager, /newsletter, /slides, /event, /preview, /update
+│   ├── controls/template-maps/  # Live design-editing control wiring
+│   ├── hooks/
+│   ├── templates/               # Document templates
+│   └── skills/                  # document-design/ + playground.md (user-invocable entry skill)
+│
+└── # Plugin: superjawn (14 skills, v1.0.0) — registered in marketplace.json
+    ├── # Research-augmented fork of obra/superpowers; standalone, no upstream dependency
     ├── .claude-plugin/plugin.json
     ├── README.md
-    ├── commands/hotpatch.md            # Slash command: sandboxed pre-install scan + cooldown bypass
-    ├── scripts/hotpatch.example.sh     # Reference Linux/bwrap implementation
-    ├── test-fixtures/                  # Synthetic malicious tarballs for self-test
     └── skills/
-        ├── api-hardening/              # Rate limiting, CORS, request throttling, defense-in-depth
-        ├── secure-auth/                # Password hashing, sessions, JWT, OAuth, passkeys
-        ├── security-checklist/         # Pre-deployment OWASP audit
-        └── supply-chain-hardening/     # npm/bun install-time cooldown + sandboxed bypass scan
+        ├── brainstorming/                 # Research phase: ideation before creative work
+        ├── dispatching-parallel-agents/   # Independent tasks across 2+ agents
+        ├── executing-plans/               # Run a written implementation plan
+        ├── finishing-a-development-branch/ # Decide how to land completed work
+        ├── receiving-code-review/         # Handle review feedback
+        ├── requesting-code-review/        # Verify completed work before merging
+        ├── subagent-driven-development/   # Parallel task execution in one session
+        ├── systematic-debugging/          # Research phase: triage before proposing fixes
+        ├── test-driven-development/        # TDD before implementation code
+        ├── using-git-worktrees/           # Isolate feature work
+        ├── using-superjawn/               # How to find and use skills
+        ├── verification-before-completion/ # Confirm work is complete before committing
+        ├── writing-plans/                 # Multi-step planning before touching code
+        └── writing-skills/                # Research phase: creating or editing skills
 ```
 
 ## Skill format

--- a/docs/data-journalism/index.html
+++ b/docs/data-journalism/index.html
@@ -351,7 +351,7 @@ print(f"${salary_2010:,} in 2010 = ${salary_2024_dollars:,.0f} in 2024")
                         </h3>
                         <pre tabindex="0"><code>/plugin marketplace add jamditis/claude-skills-journalism
 /plugin install journalism-core@claude-skills-journalism</code></pre>
-                        <p class="text-sm text-white/70 mt-3">Ships with twelve sibling skills covering AP-style writing, FOIA, fact-checking, interview workflows, and more.</p>
+                        <p class="text-sm text-white/70 mt-3">Ships with thirteen sibling skills covering AP-style writing, FOIA, fact-checking, interview workflows, and more.</p>
                     </div>
 
                     <div class="bg-white/5 p-6 rounded-xl">

--- a/docs/foia-requests/index.html
+++ b/docs/foia-requests/index.html
@@ -535,7 +535,7 @@ format as they become available.</code></pre>
                         </div>
                         <pre tabindex="0"><code>/plugin marketplace add jamditis/claude-skills-journalism
 /plugin install journalism-core@claude-skills-journalism</code></pre>
-                        <p class="text-mist text-sm mt-3">Ships with twelve sibling skills covering AP-style writing, source verification, fact-checking, interview workflows, and more.</p>
+                        <p class="text-mist text-sm mt-3">Ships with thirteen sibling skills covering AP-style writing, source verification, fact-checking, interview workflows, and more.</p>
                     </div>
 
                     <div class="feature-card p-8 rounded-xl">

--- a/docs/index.html
+++ b/docs/index.html
@@ -260,7 +260,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Claude skills for journalism">
-    <meta property="og:description" content="53 skills and 14 hooks for journalists, researchers, academics, and media professionals.">
+    <meta property="og:description" content="54 skills and 14 hooks for journalists, researchers, academics, and media professionals.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/">
     <meta property="og:image" content="https://skills.amditis.tech/og-image.png">
@@ -270,7 +270,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Claude skills for journalism">
-    <meta name="twitter:description" content="53 skills and 14 hooks for journalists, researchers, academics, and media professionals.">
+    <meta name="twitter:description" content="54 skills and 14 hooks for journalists, researchers, academics, and media professionals.">
     <meta name="twitter:image" content="https://skills.amditis.tech/og-image.png">
 <script src="ask-ai.js" defer></script>
 
@@ -335,7 +335,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <!-- Hero -->
             <header class="mb-32 md:mb-44 animate-page-in">
                 <div class="inline-block px-4 py-1 border border-ink/10 mb-6">
-                    <span class="text-[9px] font-bold tracking-[0.4em] uppercase opacity-50">53 Skills // 10 Plugins // 14 Hooks</span>
+                    <span class="text-[9px] font-bold tracking-[0.4em] uppercase opacity-50">54 Skills // 10 Plugins // 14 Hooks</span>
                 </div>
                 <h1 class="font-display fluid-title text-[11vw] md:text-[8.5vw] font-light leading-[0.85] tracking-tight mb-12 text-ink">
                     Skills for <br> <span class="italic font-black">journalism.</span>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -125,7 +125,7 @@ Skills above are distributed as Claude Code plugins. Install via:
 
 Restart your Claude Code session after installing or updating a plugin so the new skills and commands register.
 
-Plugins: `journalism-core` (14 skills), `research-toolkit` (6), `dev-toolkit` (10), `security-toolkit` (4 skills + /hotpatch command), `project-templates-toolkit` (3), `pdf-design` (1), `pdf-playground` (1), `visual-explainer` (1), `superjawn` (14).
+Plugins (10): `journalism-core` (14 skills), `research-toolkit` (6), `dev-toolkit` (10), `security-toolkit` (4 skills + /hotpatch command), `project-templates-toolkit` (3), `pdf-design` (1), `pdf-playground` (1), `visual-explainer` (1), `superjawn` (14), `autocontext` (cross-session knowledge persistence — hooks, commands, and agents rather than skills).
 
 ## Alternate installation
 

--- a/docs/source-verification/index.html
+++ b/docs/source-verification/index.html
@@ -428,7 +428,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         </h3>
                         <pre tabindex="0"><code>/plugin marketplace add jamditis/claude-skills-journalism
 /plugin install journalism-core@claude-skills-journalism</code></pre>
-                        <p class="text-sm text-white/70 mt-3">Ships with twelve sibling skills covering AP-style writing, FOIA, fact-checking, interview workflows, and more.</p>
+                        <p class="text-sm text-white/70 mt-3">Ships with thirteen sibling skills covering AP-style writing, FOIA, fact-checking, interview workflows, and more.</p>
                     </div>
 
                     <div class="bg-white/5 p-6 rounded-xl">


### PR DESCRIPTION
## What this does

Audited the repo's real structure against the documentation and fixed every count/claim that had drifted. Ground truth verified from the codebase:

- **54** skills (`SKILL.md` files), matching `llms.txt`'s own enumeration
- **10** plugins (registered in `.claude-plugin/marketplace.json`)
- **14** hooks
- Per-plugin: journalism-core **14**, dev-toolkit **10**, research-toolkit **6**, security-toolkit **4**, project-templates-toolkit **3**, superjawn **14**, pdf-design **1**, pdf-playground **1** skill / 8 commands, visual-explainer **1**, autocontext (hooks/commands/agents, no skills)

## Changes

| File | Fix |
|------|-----|
| `docs/index.html` | Hero badge + OpenGraph/Twitter meta: `53 Skills` → `54 Skills` |
| `docs/data-journalism`, `docs/source-verification`, `docs/foia-requests` | "Ships with **twelve** sibling skills" → "**thirteen**" (journalism-core grew to 14 when photo-metadata was added → 13 siblings each) |
| `docs/llms.txt` | Plugins line was missing **autocontext** — now lists all 10 |
| `CLAUDE.md` | Directory tree only documented 7 of 10 plugins; added **autocontext**, **pdf-playground**, and **superjawn**, and corrected pdf-playground's command list |

## Verified already-correct (no change needed)

- `README.md` — all plugin tables, skill lists, and the 14-hooks table are accurate
- `docs/llms.txt` — already said "54 total" and enumerates exactly 54
- `docs/sitemap.xml` — matches the 47 published pages exactly
- Homepage thematic section labels (e.g. "11 Skills", "10 Skills") — each matches its rendered card count

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015xwhymujPrQNtycNFvMarC)_