### PR TITLE
Fix validator version wording and drop AI-attribution footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,3 @@ MIT License - See [LICENSE](./LICENSE) for details.
 ## Author
 
 Joe Amditis ([@jamditis](https://github.com/jamditis))
-
----
-
-*Built with Claude Code*

--- a/okf-init/scripts/validate.py
+++ b/okf-init/scripts/validate.py
@@ -222,7 +222,7 @@ def main() -> int:
                     if version != SPEC_VERSION:
                         errors.append(
                             f"index.md: okf_version {fm.get('okf_version')!r} is not supported "
-                            f"(this validator implements OKF spec v{SPEC_VERSION})")
+                            f"(this validator supports okf_version {SPEC_VERSION})")
                 extra = sorted(keys - {"okf_version"})
                 if extra:
                     errors.append(f"index.md: bundle-root index may carry only okf_version, found {extra}")


### PR DESCRIPTION
Two small fixes found during a documentation sweep of the repo after the okf-init merge.

## Changes
- **okf-init/scripts/validate.py** — the unsupported-`okf_version` error printed "OKF spec v0.1", conflating the spec name (v1) with the `okf_version` field value (0.1). It pointed a user at the wrong value to edit. Now reads "this validator supports okf_version 0.1".
- **README.md** — removed the "Built with Claude Code" footer line (and its orphaned horizontal rule). The repo's own `.github/copilot-instructions.md` bans AI-authorship notes in committed docs; the author section right above already credits the maintainer.

## Verification
- 28/28 okf-init tests pass.
- No test asserts on the old message text (the version test checks for "not supported", which is preserved).
- codex gpt-5.4/low adversarial pass: clean, no high/medium findings.

The rest of the sweep (markdown docs, the GitHub Pages site, and okf-init's internal docs) came back clean — counts consistent at 55 skills / 11 plugins / 14 hooks, all 47 live pages return 200, OG/favicon metadata complete.