### PR TITLE
Fix okf-wiki docs: card prose flow and narrow-screen table clip

### DIFF
--- a/docs/okf-wiki/index.html
+++ b/docs/okf-wiki/index.html
@@ -214,8 +214,8 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                     <span class="sm:hidden">&darr;</span><span class="hidden sm:inline">&rarr;</span>
                 </div>
                 <div class="flex-[2] bg-white rounded-xl p-4 border border-mist/30 text-sm text-clay/80 flex items-center">
-                    A project that validates itself: <code class="bg-black/5 px-1.5 py-0.5 rounded mx-1">bundle/</code>, the
-                    <code class="bg-black/5 px-1.5 py-0.5 rounded mx-1">.claude/</code> session hooks, the spec, and the validator.
+                    <p>A project that validates itself: <code class="bg-black/5 px-1.5 py-0.5 rounded">bundle/</code>, the
+                    <code class="bg-black/5 px-1.5 py-0.5 rounded">.claude/</code> session hooks, the spec, and the validator.</p>
                 </div>
             </div>
 
@@ -308,7 +308,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">The frontmatter contract</h2>
             <p class="text-clay/80 mb-4">Every concept file carries these keys. The validator fails the build if any are missing, mistyped, or shaped wrong.</p>
-            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden">
+            <div class="bg-white rounded-xl border border-mist/30 overflow-x-auto" tabindex="0" role="region" aria-label="Frontmatter contract table, scrollable">
                 <table class="w-full">
                     <thead>
                         <tr class="bg-mist/10 border-b border-mist/30">
@@ -495,7 +495,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 changes. <code class="bg-black/5 px-1.5 py-0.5 rounded">scaffold.py</code> auto-detects your OS, and
                 <code class="bg-black/5 px-1.5 py-0.5 rounded">--hooks-os posix|windows</code> overrides it.
             </p>
-            <div class="bg-white rounded-xl border border-mist/30 overflow-hidden mb-4">
+            <div class="bg-white rounded-xl border border-mist/30 overflow-x-auto mb-4" tabindex="0" role="region" aria-label="Hook settings.json entries table, scrollable">
                 <table class="w-full">
                     <thead>
                         <tr class="bg-mist/10 border-b border-mist/30">


### PR DESCRIPTION
The okf-wiki docs page had a card whose text fragmented around the inline code pills, and tables that clipped on narrow screens. Both are layout bugs in `docs/okf-wiki/index.html`.

## Card prose fragmentation (reported)
The "validates itself" card used `flex items-center` on a container of mixed text and inline `<code>`. Flex turns each text run and each pill into its own flex item, so the sentence broke into pieces and the `bundle/` / `.claude/` pills floated with uneven spacing. It rendered worse on some Chromium variants; a headless render collapsed the gaps, which is why it looked fine in a quick check.

Fix: wrap the prose in a single `<p>` so `flex items-center` centers one child and the inline flow stays intact. Dropped the inconsistent `mx-1` on the two pills (every other pill on the page relies on the natural surrounding spaces).

## Narrow-screen table clip
The two `w-full` tables were wrapped in `overflow-hidden`, which clipped the long `settings.json` cell on mobile with no way to scroll to it. Switched to `overflow-x-auto` in a focusable scroll region (`tabindex="0" role="region"`, matching the page's code blocks) so the columns scroll instead of disappearing.

## Verification
- Rendered the edited page locally: the card is one `<p>` with the full sentence and both pills inline; the OS table scrolls (scrollWidth 513 > clientWidth 340 at 390px) with no page-level horizontal overflow.
- `node scripts/verify_a11y.mjs`: the only remaining serious finding is pre-existing `text-clay/60` contrast on untouched elements, tracked in #132.
- Local Codex review (5.4 low): no actionable findings.
- Node test suite green.

Pre-existing contrast debt filed as #132.