### PR TITLE
Cost estimator: drop reviewer plan from subscription when review is off

### DIFF
--- a/docs/autonomy/kit/cost-estimator.html
+++ b/docs/autonomy/kit/cost-estimator.html
@@ -337,7 +337,12 @@
         mtokReviewer: Math.max(0, parseFloat($("mtokReviewer").value) || 0),
       };
       const runsPerMonth = perDay * (activeDays / 7) * p.days;
-      const subscription = (parseFloat($("subWorker").value) || 0) + (parseFloat($("subReviewer").value) || 0);
+      // Review off drops the reviewer plan from the headline, matching the metered
+      // side (which bills no review tokens). The with-reviewer figure is shown
+      // below as a footnote, since you might keep that plan for interactive use.
+      const subWorker = parseFloat($("subWorker").value) || 0;
+      const subReviewer = parseFloat($("subReviewer").value) || 0;
+      const subscription = subWorker + (p.reviewOn ? subReviewer : 0);
       const run = meteredPerRun(p);
       const moLo = run[0] * runsPerMonth, moHi = run[1] * runsPerMonth;
       const gapLo = subscription ? moLo / subscription : 0;
@@ -349,6 +354,9 @@
       }));
       body.append(line("Runs / month", intc(runsPerMonth)));
       body.append(line("Subscription / mo", money(subscription), { kSub: "flat, ~$0 per run until limits" }));
+      if (!p.reviewOn && subReviewer) {
+        body.append(line("With reviewer / mo", money(subscription + subReviewer), { kSub: "if you keep the reviewer plan for interactive use" }));
+      }
       body.append(line("Metered / mo", money(moLo) + EN + money(moHi), {
         accent: true, kSub: money(run[0]) + EN + money(run[1]) + " per run",
       }));

--- a/docs/autonomy/kit/estimate_cost.py
+++ b/docs/autonomy/kit/estimate_cost.py
@@ -225,6 +225,20 @@ class Estimate:
     metered_monthly_usd: tuple[float, float]
 
 
+def subscription_total(review_enabled: bool) -> float:
+    """Flat monthly subscription cost for the plans this loop actually uses.
+
+    When review is off, the reviewer plan is dropped so the headline matches the
+    metered side, which already bills zero review tokens. The report still
+    footnotes the reviewer plan separately, because a flat plan you keep for
+    interactive use is money you spend whether or not this loop triggers it
+    (issue #110). Any non-reviewer plan in the table is always counted.
+    """
+    if review_enabled:
+        return sum(SUBSCRIPTION_PLANS_USD.values())
+    return sum(v for k, v in SUBSCRIPTION_PLANS_USD.items() if k != "reviewer")
+
+
 def _validate_effort(name: str, value: str) -> str:
     value = (value or "").lower()
     if value not in VALID_EFFORTS:
@@ -267,14 +281,15 @@ def estimate(inputs: Inputs) -> Estimate:
     # schedule.wake.enabled: false means the loop never fires, so it runs zero
     # times and bills zero metered tokens. Short-circuit before reading cadence —
     # a disabled schedule's cron is moot. The per-run figure stays informational
-    # ("if you turned it on..."); the subscription line is left to issue #110
-    # (a plan you hold whether or not this loop uses it).
+    # ("if you turned it on..."); the subscription line still shows the flat
+    # plans you hold whether or not this loop fires, minus the reviewer plan when
+    # review is off (see subscription_total).
     if not inputs.wake_enabled:
         return Estimate(
             runs_per_active_day=0,
             active_days_per_week=0,
             runs_per_month=0.0,
-            subscription_monthly_usd=sum(SUBSCRIPTION_PLANS_USD.values()),
+            subscription_monthly_usd=subscription_total(inputs.review_enabled),
             metered_per_run_usd=metered_cost_per_run(inputs),
             metered_monthly_usd=(0.0, 0.0),
         )
@@ -296,7 +311,7 @@ def estimate(inputs: Inputs) -> Estimate:
         )
 
     runs_per_month = per_active_day * (active_days / 7.0) * inputs.days_per_month
-    subscription = sum(SUBSCRIPTION_PLANS_USD.values())
+    subscription = subscription_total(inputs.review_enabled)
     run_lo, run_hi = metered_cost_per_run(inputs)
     monthly = (run_lo * runs_per_month, run_hi * runs_per_month)
 
@@ -393,6 +408,21 @@ def format_report(inputs: Inputs, est: Estimate, *, source: str) -> str:
         else "review disabled"
     )
     cadence_note = "" if inputs.wake_enabled else "   (schedule disabled — 0 runs)"
+    # With review off, the headline subscription drops the reviewer plan (matching
+    # the metered side). Still surface the with-reviewer figure, since you might
+    # keep that plan for interactive use even though this loop won't trigger it.
+    reviewer_plan = SUBSCRIPTION_PLANS_USD.get("reviewer", 0.0)
+    subscription_lines = [
+        "Subscription billing (flat plans)",
+        f"  monthly           {_money(est.subscription_monthly_usd)}"
+        "   (until plan limits; ~$0 marginal per run)",
+    ]
+    if not inputs.review_enabled and reviewer_plan:
+        subscription_lines.append(
+            f"  with reviewer     {_money(est.subscription_monthly_usd + reviewer_plan)}"
+            "   (review is off; add this only if you keep the reviewer plan for "
+            "interactive use)"
+        )
     lines = [
         "Autonomy loop cost estimate",
         f"  source            {source}",
@@ -403,9 +433,7 @@ def format_report(inputs: Inputs, est: Estimate, *, source: str) -> str:
         f"  runs/active day   {est.runs_per_active_day}{active_note}",
         f"  runs/month        {est.runs_per_month:,.0f}",
         "",
-        "Subscription billing (flat plans)",
-        f"  monthly           {_money(est.subscription_monthly_usd)}"
-        "   (until plan limits; ~$0 marginal per run)",
+        *subscription_lines,
         "",
         "Metered API billing (pay per token)",
         f"  per run           {_money(lo_run)} – {_money(hi_run)}",

--- a/docs/autonomy/kit/test_estimate_cost.py
+++ b/docs/autonomy/kit/test_estimate_cost.py
@@ -336,6 +336,41 @@ def test_disabled_review_zeroes_review_cost():
     assert ec.metered_cost_per_run(_inputs(review_enabled=False, max_passes=99)) == off
 
 
+def test_subscription_total_drops_reviewer_when_review_off():
+    # issue #110: the subscription helper mirrors the metered side — review on
+    # sums every plan, review off drops the reviewer plan only.
+    assert ec.subscription_total(True) == sum(ec.SUBSCRIPTION_PLANS_USD.values())
+    assert ec.subscription_total(False) == sum(
+        v for k, v in ec.SUBSCRIPTION_PLANS_USD.items() if k != "reviewer"
+    )
+    assert ec.subscription_total(False) == ec.SUBSCRIPTION_PLANS_USD["worker"]
+
+
+def test_disabled_review_lowers_subscription_headline():
+    # issue #110: review off => the headline subscription excludes the reviewer
+    # plan, both on the normal path and the wake-disabled short-circuit.
+    on = ec.estimate(_inputs(review_enabled=True))
+    off = ec.estimate(_inputs(review_enabled=False))
+    assert on.subscription_monthly_usd == sum(ec.SUBSCRIPTION_PLANS_USD.values())
+    assert off.subscription_monthly_usd == ec.SUBSCRIPTION_PLANS_USD["worker"]
+    assert off.subscription_monthly_usd < on.subscription_monthly_usd
+    wake_off = ec.estimate(_inputs(review_enabled=False, wake_enabled=False))
+    assert wake_off.subscription_monthly_usd == ec.SUBSCRIPTION_PLANS_USD["worker"]
+
+
+def test_format_report_shows_with_reviewer_footnote_when_review_off():
+    # issue #110: with review off the report shows both — the worker-only
+    # headline and the with-reviewer figure for someone who keeps that plan.
+    off = _inputs(review_enabled=False)
+    report_off = ec.format_report(off, ec.estimate(off), source="flags")
+    assert "with reviewer" in report_off
+    full = sum(ec.SUBSCRIPTION_PLANS_USD.values())
+    assert ec._money(full) in report_off  # the with-reviewer total is surfaced
+    on = _inputs(review_enabled=True)
+    report_on = ec.format_report(on, ec.estimate(on), source="flags")
+    assert "with reviewer" not in report_on.lower()
+
+
 def test_disabled_review_allows_zero_max_passes():
     # max_passes 0 is moot when review is off, so estimate() accepts it; it's
     # rejected only when review is enabled.


### PR DESCRIPTION
Closes #110.

When `review.enabled: false` (or `nudges.review: false`), the metered estimate already drops review tokens, but the **subscription** total always summed every plan — so a review-off config reported $120/mo instead of $100/mo.

## The judgment call
#110 filed this rather than fixing it in-PR because it is a modeling choice:
- **Drop it:** review off means you are not paying for the reviewer CLI plan -> show worker-only.
- **Keep it:** a subscription is a flat plan you hold regardless of whether a given loop uses it.

Resolved by **showing both**: the headline drops the reviewer plan to match the metered side, and a `with reviewer` footnote shows the figure for someone who keeps that plan for interactive use even though this loop will not trigger it.

```
Subscription billing (flat plans)
  monthly           $100   (until plan limits; ~$0 marginal per run)
  with reviewer     $120   (review is off; add this only if you keep the reviewer plan for interactive use)
```

## Implementation
- `subscription_total(review_enabled)` gates the reviewer plan on `review_enabled` and counts any non-reviewer plan unconditionally.
- Both `estimate()` paths (normal + wake-disabled short-circuit) and the HTML calculator (`cost-estimator.html`) call the same logic, keeping the Python/JS math in sync (the parity the issue flagged).
- The `#110` comment in the wake-disabled branch is updated since the question is now answered.

## Verification
- `pytest`: 70 passed. New tests cover the helper, both estimate branches, and the report footnote (mirrors `test_disabled_review_zeroes_review_cost` on the subscription side).
- Rendered the HTML calculator headless: review on -> $120 / no footnote; review off -> $100 + `With reviewer $120` footnote. Matches the CLI byte-for-byte.
- `ruff format` + `ruff check`: clean.
- Local Codex review (5.4 low): no actionable findings.