### PR TITLE
Add copywriting-preflight hook: interview for intent before drafting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,10 +24,11 @@ claude-skills-journalism/
 ├── README.md                    # User documentation
 ├── LICENSE
 │
-├── hooks/                       # Automated workflow checks (14 hooks)
+├── hooks/                       # Automated workflow checks (15 hooks)
 │   ├── ap-style-check.md        # Writing: AP Style violations
 │   ├── ai-slop-detector.md      # Writing: AI patterns
 │   ├── accessibility-check.md   # Writing: Alt text, headings
+│   ├── copywriting-preflight.md # Writing: Intent interview before drafting
 │   ├── source-attribution-check.md  # Verification: Unattributed claims
 │   ├── verification-reminder.md # Verification: Fact-check prompt
 │   ├── data-methodology-check.md    # Verification: Methodology docs
@@ -196,6 +197,7 @@ Hooks run automatically at specific workflow events. Most are **non-blocking war
 | ap-style-check | PostToolUse(Write,Edit) | Flag AP Style violations |
 | ai-slop-detector | PostToolUse(Write,Edit) | Warn about AI patterns |
 | accessibility-check | PostToolUse(Write,Edit) | Check alt text, headings, links |
+| copywriting-preflight | UserPromptSubmit | Interview for intent before drafting |
 
 ### Verification
 | Hook | Event | Purpose |

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Hooks are automated checks that run at specific points in your workflow. Most ar
 | [ap-style-check](./hooks/ap-style-check.md) | PostToolUse | Flag common AP Style violations |
 | [ai-slop-detector](./hooks/ai-slop-detector.md) | PostToolUse | Warn about AI-generated patterns |
 | [accessibility-check](./hooks/accessibility-check.md) | PostToolUse | Check alt text, heading structure, link text |
+| [copywriting-preflight](./hooks/copywriting-preflight.md) | UserPromptSubmit | Interview for intent before drafting a new piece or revision |
 
 ### Verification hooks
 

--- a/docs/autonomy/kit/cost-estimator.html
+++ b/docs/autonomy/kit/cost-estimator.html
@@ -337,7 +337,12 @@
         mtokReviewer: Math.max(0, parseFloat($("mtokReviewer").value) || 0),
       };
       const runsPerMonth = perDay * (activeDays / 7) * p.days;
-      const subscription = (parseFloat($("subWorker").value) || 0) + (parseFloat($("subReviewer").value) || 0);
+      // Review off drops the reviewer plan from the headline, matching the metered
+      // side (which bills no review tokens). The with-reviewer figure is shown
+      // below as a footnote, since you might keep that plan for interactive use.
+      const subWorker = parseFloat($("subWorker").value) || 0;
+      const subReviewer = parseFloat($("subReviewer").value) || 0;
+      const subscription = subWorker + (p.reviewOn ? subReviewer : 0);
       const run = meteredPerRun(p);
       const moLo = run[0] * runsPerMonth, moHi = run[1] * runsPerMonth;
       const gapLo = subscription ? moLo / subscription : 0;
@@ -349,6 +354,9 @@
       }));
       body.append(line("Runs / month", intc(runsPerMonth)));
       body.append(line("Subscription / mo", money(subscription), { kSub: "flat, ~$0 per run until limits" }));
+      if (!p.reviewOn && subReviewer) {
+        body.append(line("With reviewer / mo", money(subscription + subReviewer), { kSub: "if you keep the reviewer plan for interactive use" }));
+      }
       body.append(line("Metered / mo", money(moLo) + EN + money(moHi), {
         accent: true, kSub: money(run[0]) + EN + money(run[1]) + " per run",
       }));

--- a/docs/autonomy/kit/estimate_cost.py
+++ b/docs/autonomy/kit/estimate_cost.py
@@ -225,6 +225,20 @@ class Estimate:
     metered_monthly_usd: tuple[float, float]
 
 
+def subscription_total(review_enabled: bool) -> float:
+    """Flat monthly subscription cost for the plans this loop actually uses.
+
+    When review is off, the reviewer plan is dropped so the headline matches the
+    metered side, which already bills zero review tokens. The report still
+    footnotes the reviewer plan separately, because a flat plan you keep for
+    interactive use is money you spend whether or not this loop triggers it
+    (issue #110). Any non-reviewer plan in the table is always counted.
+    """
+    if review_enabled:
+        return sum(SUBSCRIPTION_PLANS_USD.values())
+    return sum(v for k, v in SUBSCRIPTION_PLANS_USD.items() if k != "reviewer")
+
+
 def _validate_effort(name: str, value: str) -> str:
     value = (value or "").lower()
     if value not in VALID_EFFORTS:
@@ -267,14 +281,15 @@ def estimate(inputs: Inputs) -> Estimate:
     # schedule.wake.enabled: false means the loop never fires, so it runs zero
     # times and bills zero metered tokens. Short-circuit before reading cadence —
     # a disabled schedule's cron is moot. The per-run figure stays informational
-    # ("if you turned it on..."); the subscription line is left to issue #110
-    # (a plan you hold whether or not this loop uses it).
+    # ("if you turned it on..."); the subscription line still shows the flat
+    # plans you hold whether or not this loop fires, minus the reviewer plan when
+    # review is off (see subscription_total).
     if not inputs.wake_enabled:
         return Estimate(
             runs_per_active_day=0,
             active_days_per_week=0,
             runs_per_month=0.0,
-            subscription_monthly_usd=sum(SUBSCRIPTION_PLANS_USD.values()),
+            subscription_monthly_usd=subscription_total(inputs.review_enabled),
             metered_per_run_usd=metered_cost_per_run(inputs),
             metered_monthly_usd=(0.0, 0.0),
         )
@@ -296,7 +311,7 @@ def estimate(inputs: Inputs) -> Estimate:
         )
 
     runs_per_month = per_active_day * (active_days / 7.0) * inputs.days_per_month
-    subscription = sum(SUBSCRIPTION_PLANS_USD.values())
+    subscription = subscription_total(inputs.review_enabled)
     run_lo, run_hi = metered_cost_per_run(inputs)
     monthly = (run_lo * runs_per_month, run_hi * runs_per_month)
 
@@ -393,6 +408,21 @@ def format_report(inputs: Inputs, est: Estimate, *, source: str) -> str:
         else "review disabled"
     )
     cadence_note = "" if inputs.wake_enabled else "   (schedule disabled — 0 runs)"
+    # With review off, the headline subscription drops the reviewer plan (matching
+    # the metered side). Still surface the with-reviewer figure, since you might
+    # keep that plan for interactive use even though this loop won't trigger it.
+    reviewer_plan = SUBSCRIPTION_PLANS_USD.get("reviewer", 0.0)
+    subscription_lines = [
+        "Subscription billing (flat plans)",
+        f"  monthly           {_money(est.subscription_monthly_usd)}"
+        "   (until plan limits; ~$0 marginal per run)",
+    ]
+    if not inputs.review_enabled and reviewer_plan:
+        subscription_lines.append(
+            f"  with reviewer     {_money(est.subscription_monthly_usd + reviewer_plan)}"
+            "   (review is off; add this only if you keep the reviewer plan for "
+            "interactive use)"
+        )
     lines = [
         "Autonomy loop cost estimate",
         f"  source            {source}",
@@ -403,9 +433,7 @@ def format_report(inputs: Inputs, est: Estimate, *, source: str) -> str:
         f"  runs/active day   {est.runs_per_active_day}{active_note}",
         f"  runs/month        {est.runs_per_month:,.0f}",
         "",
-        "Subscription billing (flat plans)",
-        f"  monthly           {_money(est.subscription_monthly_usd)}"
-        "   (until plan limits; ~$0 marginal per run)",
+        *subscription_lines,
         "",
         "Metered API billing (pay per token)",
         f"  per run           {_money(lo_run)} – {_money(hi_run)}",

--- a/docs/autonomy/kit/test_estimate_cost.py
+++ b/docs/autonomy/kit/test_estimate_cost.py
@@ -336,6 +336,41 @@ def test_disabled_review_zeroes_review_cost():
     assert ec.metered_cost_per_run(_inputs(review_enabled=False, max_passes=99)) == off
 
 
+def test_subscription_total_drops_reviewer_when_review_off():
+    # issue #110: the subscription helper mirrors the metered side — review on
+    # sums every plan, review off drops the reviewer plan only.
+    assert ec.subscription_total(True) == sum(ec.SUBSCRIPTION_PLANS_USD.values())
+    assert ec.subscription_total(False) == sum(
+        v for k, v in ec.SUBSCRIPTION_PLANS_USD.items() if k != "reviewer"
+    )
+    assert ec.subscription_total(False) == ec.SUBSCRIPTION_PLANS_USD["worker"]
+
+
+def test_disabled_review_lowers_subscription_headline():
+    # issue #110: review off => the headline subscription excludes the reviewer
+    # plan, both on the normal path and the wake-disabled short-circuit.
+    on = ec.estimate(_inputs(review_enabled=True))
+    off = ec.estimate(_inputs(review_enabled=False))
+    assert on.subscription_monthly_usd == sum(ec.SUBSCRIPTION_PLANS_USD.values())
+    assert off.subscription_monthly_usd == ec.SUBSCRIPTION_PLANS_USD["worker"]
+    assert off.subscription_monthly_usd < on.subscription_monthly_usd
+    wake_off = ec.estimate(_inputs(review_enabled=False, wake_enabled=False))
+    assert wake_off.subscription_monthly_usd == ec.SUBSCRIPTION_PLANS_USD["worker"]
+
+
+def test_format_report_shows_with_reviewer_footnote_when_review_off():
+    # issue #110: with review off the report shows both — the worker-only
+    # headline and the with-reviewer figure for someone who keeps that plan.
+    off = _inputs(review_enabled=False)
+    report_off = ec.format_report(off, ec.estimate(off), source="flags")
+    assert "with reviewer" in report_off
+    full = sum(ec.SUBSCRIPTION_PLANS_USD.values())
+    assert ec._money(full) in report_off  # the with-reviewer total is surfaced
+    on = _inputs(review_enabled=True)
+    report_on = ec.format_report(on, ec.estimate(on), source="flags")
+    assert "with reviewer" not in report_on.lower()
+
+
 def test_disabled_review_allows_zero_max_passes():
     # max_passes 0 is moot when review is off, so estimate() accepts it; it's
     # rejected only when review is enabled.

--- a/docs/index.html
+++ b/docs/index.html
@@ -260,7 +260,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Claude skills for journalism">
-    <meta property="og:description" content="56 skills and 14 hooks for journalists, researchers, academics, and media professionals.">
+    <meta property="og:description" content="56 skills and 15 hooks for journalists, researchers, academics, and media professionals.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/">
     <meta property="og:image" content="https://skills.amditis.tech/og-image.png">
@@ -270,7 +270,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Claude skills for journalism">
-    <meta name="twitter:description" content="56 skills and 14 hooks for journalists, researchers, academics, and media professionals.">
+    <meta name="twitter:description" content="56 skills and 15 hooks for journalists, researchers, academics, and media professionals.">
     <meta name="twitter:image" content="https://skills.amditis.tech/og-image.png">
 <script src="ask-ai.js" defer></script>
 
@@ -280,7 +280,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
   "@context": "https://schema.org",
   "@type": "SoftwareSourceCode",
   "name": "Claude skills for journalism",
-  "description": "56 Claude Code skills and 14 workflow hooks for verification, FOIA, data journalism, academic writing, and more. Built for journalists, researchers, and media professionals.",
+  "description": "56 Claude Code skills and 15 workflow hooks for verification, FOIA, data journalism, academic writing, and more. Built for journalists, researchers, and media professionals.",
   "url": "https://skills.amditis.tech",
   "codeRepository": "https://github.com/jamditis/claude-skills-journalism",
   "programmingLanguage": "Markdown",
@@ -335,7 +335,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <!-- Hero -->
             <header class="mb-32 md:mb-44 animate-page-in">
                 <div class="inline-block px-4 py-1 border border-ink/10 mb-6">
-                    <span class="text-[9px] font-bold tracking-[0.4em] uppercase opacity-50">56 Skills // 11 Plugins // 14 Hooks</span>
+                    <span class="text-[9px] font-bold tracking-[0.4em] uppercase opacity-50">56 Skills // 11 Plugins // 15 Hooks</span>
                 </div>
                 <h1 class="font-display fluid-title text-[11vw] md:text-[8.5vw] font-light leading-[0.85] tracking-tight mb-12 text-ink">
                     Skills for <br> <span class="italic font-black">journalism.</span>
@@ -1002,7 +1002,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <section id="hooks" class="reveal-section mb-32">
                 <div class="section-header flex flex-col md:flex-row md:items-end justify-between gap-4">
                     <h2 class="font-display text-4xl font-light italic">11 / Hooks</h2>
-                    <span class="section-label">14 Automated Checks</span>
+                    <span class="section-label">15 Automated Checks</span>
                 </div>
 
                 <p class="text-mist mb-8 max-w-3xl">Hooks run automatically at specific workflow events. Most are <strong>non-blocking warnings</strong>, but two &mdash; one-way-door-check and enforce-test-first &mdash; block intentionally until you resolve them.</p>
@@ -1010,7 +1010,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <div class="deckle-card-solid p-8">
                     <!-- Writing Quality Hooks -->
                     <h3 class="text-[11px] font-bold uppercase tracking-widest text-mist mb-4">Writing quality</h3>
-                    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
                         <div class="border border-ink/10 p-4 bg-white/20">
                             <div class="flex items-center gap-2 mb-2">
                                 <span class="hook-badge bg-accent/10 text-accentDark font-bold">PostToolUse</span>
@@ -1031,6 +1031,13 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                             </div>
                             <h4 class="font-display font-bold mb-1">accessibility-check</h4>
                             <p class="text-xs text-mist">Check alt text, heading structure, link text.</p>
+                        </div>
+                        <div class="border border-ink/10 p-4 bg-white/20">
+                            <div class="flex items-center gap-2 mb-2">
+                                <span class="hook-badge bg-ink/10 text-ink font-bold">UserPromptSubmit</span>
+                            </div>
+                            <h4 class="font-display font-bold mb-1">copywriting-preflight</h4>
+                            <p class="text-xs text-mist">Interview for intent before drafting a piece or revision.</p>
                         </div>
                     </div>
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -88,7 +88,7 @@ Personal site: https://jamditis.com
 - finishing-a-development-branch — decide how to land completed work
 - using-git-worktrees — isolate feature work from current workspace
 
-## Hooks (14 workflow hooks)
+## Hooks (15 workflow hooks)
 
 Hooks run automatically at specific workflow events. Most are non-blocking warnings; two block intentionally — `one-way-door-check` exits 2 to prevent irreversible architectural decisions, and `enforce-test-first` blocks source edits until a failing test exists.
 
@@ -96,6 +96,7 @@ Hooks run automatically at specific workflow events. Most are non-blocking warni
 - ap-style-check — flags AP Style violations on write/edit
 - ai-slop-detector — warns about AI writing patterns
 - accessibility-check — checks alt text, headings, link text
+- copywriting-preflight — interviews for intent before drafting a new piece or revision
 
 ### Verification
 - source-attribution-check — flags unattributed quotes or claims

--- a/hooks/copywriting-preflight.md
+++ b/hooks/copywriting-preflight.md
@@ -3,28 +3,48 @@ name: copywriting-preflight
 event: UserPromptSubmit
 description: Detects writing and revision requests and prompts an intent interview before drafting
 match_patterns:
-  - "blog post"
-  - "substack post"
+  # Noun forms that rarely appear in code or admin prompts (safe to match bare)
   - "op-ed"
   - "press release"
-  - "newsletter"
+  - "substack post"
   - "talking points"
-  - "write a post"
+  # Drafting: a verb paired with a writing noun, so code prompts do not match
+  - "write a blog post"
+  - "draft a blog post"
+  - "write a newsletter"
+  - "draft a newsletter"
   - "write an article"
+  - "draft an article"
   - "write an essay"
+  - "draft an essay"
+  - "write a memo"
+  - "draft a memo"
   - "write a pitch"
+  - "draft a pitch"
+  - "write a proposal"
+  - "draft a proposal"
+  - "write a one-pager"
+  - "draft a one-pager"
+  - "draft an announcement"
   - "write copy"
   - "write the copy"
-  - "draft a post"
-  - "draft an article"
-  - "draft a pitch"
-  - "draft an announcement"
-  - "polish the draft"
-  - "punch up the copy"
+  - "draft the copy"
+  # Revision: a verb paired with a writing noun
   - "rewrite the post"
   - "rewrite the article"
+  - "rewrite the draft"
+  - "rewrite the copy"
   - "revise the draft"
+  - "revise the article"
+  - "revise the piece"
+  - "polish the draft"
+  - "polish the copy"
+  - "punch up the copy"
   - "tighten the copy"
+  - "tighten the draft"
+  - "edit the draft"
+  - "refine the draft"
+  - "strengthen the piece"
 ---
 
 # Copywriting preflight
@@ -35,14 +55,14 @@ This hook does not write anything. It pauses to gather intent, then gets out of 
 
 ## Detection criteria
 
-Skip very short messages (a one-line aside is rarely a real writing request). Otherwise, treat the message as a writing task when it contains:
+The signal is the verb-plus-writing-noun pairing, not message length. A terse command that matches a writing pattern — "write copy", "op-ed", "press release" — is still a real request, and terse is often exactly when an intent interview is most useful, so do not skip it for being short. Treat the message as a writing task when it contains:
 
-- **New writing:** "write/draft/create a [post, article, blog, essay, script, copy, memo, pitch, newsletter, press release, announcement, proposal, one-pager, talking points]", plus named forms like "op-ed", "blog post", "substack post", "press release".
-- **Revision:** a revision verb ("revise", "rewrite", "rework", "polish", "tighten", "punch up", "edit", "refine", "strengthen") **next to** a writing-context word ("draft", "post", "article", "piece", "copy", "script", "newsletter", "write-up"). Require both, so "tighten that" about a code hook does not trip it.
+- **New writing:** a drafting verb ("write", "draft", "create") next to a prose form (post, blog post, article, essay, memo, pitch, newsletter, press release, op-ed, announcement, proposal, one-pager, copy, talking points).
+- **Revision:** a revision verb ("revise", "rewrite", "rework", "polish", "tighten", "punch up", "edit", "refine", "strengthen") **next to** a writing-context word ("draft", "post", "article", "piece", "copy", "newsletter", "write-up"). Require both, so "tighten that" about a code hook does not trip it.
 
 Check revision first — it is the more specific case, since it implies a piece already exists.
 
-The `match_patterns` above are deliberately writing-noun-specific (`blog post`, `op-ed`, `write copy`) rather than bare verbs (`write a`, `rewrite`), so code prompts like "write a SQL query" or "rewrite this regex" never trip the interview. If a borderline prompt does match, apply the verb-plus-writing-noun test before interviewing and skip silently when the request turns out to be about code.
+The `match_patterns` above pair a verb with a writing noun (`write a newsletter`, `rewrite the post`) and keep bare nouns only for forms that rarely show up in code or admin prompts (`op-ed`, `press release`). That is why "write a SQL query", "build a newsletter signup form", and "rewrite this regex" never trip the interview. "Script" is deliberately left out: in a code repo "write a script" almost always means code, not a screenplay. If a borderline prompt still matches, apply the verb-plus-writing-noun test before interviewing and skip silently when the request turns out to be about code.
 
 ## Response (new writing)
 

--- a/hooks/copywriting-preflight.md
+++ b/hooks/copywriting-preflight.md
@@ -1,0 +1,80 @@
+---
+name: copywriting-preflight
+event: UserPromptSubmit
+description: Detects writing and revision requests and prompts an intent interview before drafting
+match_patterns:
+  - "blog post"
+  - "substack post"
+  - "op-ed"
+  - "press release"
+  - "newsletter"
+  - "talking points"
+  - "write a post"
+  - "write an article"
+  - "write an essay"
+  - "write a pitch"
+  - "write copy"
+  - "write the copy"
+  - "draft a post"
+  - "draft an article"
+  - "draft a pitch"
+  - "draft an announcement"
+  - "polish the draft"
+  - "punch up the copy"
+  - "rewrite the post"
+  - "rewrite the article"
+  - "revise the draft"
+  - "tighten the copy"
+---
+
+# Copywriting preflight
+
+When the user asks for a new piece of writing or a revision, interview them about intent **before** drafting a single word. Jumping straight to a draft produces generic copy that misses the audience, message, and tone the user actually had in mind — and then both of you spend more time fixing the wrong draft than a 30-second interview would have cost.
+
+This hook does not write anything. It pauses to gather intent, then gets out of the way.
+
+## Detection criteria
+
+Skip very short messages (a one-line aside is rarely a real writing request). Otherwise, treat the message as a writing task when it contains:
+
+- **New writing:** "write/draft/create a [post, article, blog, essay, script, copy, memo, pitch, newsletter, press release, announcement, proposal, one-pager, talking points]", plus named forms like "op-ed", "blog post", "substack post", "press release".
+- **Revision:** a revision verb ("revise", "rewrite", "rework", "polish", "tighten", "punch up", "edit", "refine", "strengthen") **next to** a writing-context word ("draft", "post", "article", "piece", "copy", "script", "newsletter", "write-up"). Require both, so "tighten that" about a code hook does not trip it.
+
+Check revision first — it is the more specific case, since it implies a piece already exists.
+
+The `match_patterns` above are deliberately writing-noun-specific (`blog post`, `op-ed`, `write copy`) rather than bare verbs (`write a`, `rewrite`), so code prompts like "write a SQL query" or "rewrite this regex" never trip the interview. If a borderline prompt does match, apply the verb-plus-writing-noun test before interviewing and skip silently when the request turns out to be about code.
+
+## Response (new writing)
+
+Before drafting, use `AskUserQuestion` to map out:
+
+1. **Audience** — who is this for?
+2. **Key message** — what is the one thing they should take away (the thesis)?
+3. **Tone** — formal, conversational, urgent, reflective?
+4. **Emphasis** — what should be foregrounded, and what should be played down?
+5. **Voice** — first person, organizational voice, journalistic remove?
+6. **Boundaries** — specific points to include, and anything to avoid?
+
+Then draft against the answers, not against a guess.
+
+## Response (revision)
+
+Before rewriting, use `AskUserQuestion` to clarify:
+
+1. **What is working and what is not** in the current draft?
+2. **Should the framing or angle change**, or only the execution?
+3. **Any shifts in emphasis or tone** from the current version?
+
+Then revise to the brief, rather than re-drafting from scratch and discarding what already worked.
+
+## Loading a style guide
+
+If the project defines a writing style guide — a `STYLE_GUIDE.md`, a voice-and-tone doc, or whatever path the project configures — load it into context before drafting so the piece matches the established voice. If none exists, ask the user whether one should be followed.
+
+## Finalizing
+
+Before calling a draft done, read it back against the intent answers and the style guide: does it hit the audience, carry the key message, and stay in the right voice? If the project has an editorial or preflight check, run it on the draft. Fix what drifted before handing the draft over.
+
+## Non-blocking
+
+This hook prompts an interview but does not block any tool. The user can decline the questions and ask you to draft directly; the goal is a deliberate pause, not a gate.


### PR DESCRIPTION
Publishes the local `copywriting-preflight` guardrail as a portable hook in `hooks/`. Completes the copywriting-preflight item of #115 ("publish next reachable item").

## What it does
On a writing or revision request, the hook pauses to interview for intent — audience, key message, tone, emphasis, voice, boundaries — before drafting, instead of producing a generic draft and then fixing the wrong thing. Non-blocking: the user can decline and ask for a draft directly.

## De-personalization
Ported from a local source and stripped of machine- and user-specific couplings:
- the hardcoded style-guide path is now generic ("if the project defines a `STYLE_GUIDE.md`, voice-and-tone doc, or configured path");
- the personal editorial-check script reference is now a generic "if the project has an editorial or preflight check, run it."

No `/home/...`, no personal names, no private paths. Verified clean.

## Trigger precision
`match_patterns` are writing-noun-specific (`blog post`, `op-ed`, `write copy`, `polish the draft`) rather than bare verbs, so code prompts like "write a SQL query", "draft a migration", or "rewrite this regex" do not trip the interview. The body's verb-plus-writing-noun test is the second layer for borderline prompts. Verified: the four code-task phrases above match no pattern; the prose-task phrases do.

## Count bump
Hook count goes 14 -> 15 everywhere it is stated, so metadata and the visible page agree:
- `CLAUDE.md` — tree comment + Writing quality table row
- `README.md` — Writing quality hooks table row
- `docs/index.html` — OG/Twitter/JSON-LD descriptions, the visible "15 Hooks" / "15 Automated Checks" stats, and a new card in the hooks grid (grid widened to a 4-up responsive layout)
- `docs/llms.txt` — section count + Writing quality listing

## Review
Two local Codex passes (5.4 low). Pass 1 caught the visible landing-page stats and card grid that a metadata-only edit would have missed; pass 2 caught the overly-broad `match_patterns`. Both fixed in this branch. Skill-lint requirements (frontmatter `name` + `event`) verified locally.

Refs #115