### PR TITLE
okf-wiki: document authoring concepts from existing material

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -42,8 +42,8 @@
     },
     {
       "name": "okf-wiki",
-      "description": "Scaffold an Open Knowledge Format (OKF) knowledge base: one-concept-per-file markdown with YAML frontmatter, directory navigation, and a validator. Generates a starter wiki that passes its own conformance and secret-leak checks, ships session-start hooks that orient Claude on the knowledge base before it works, and includes an optional GitHub-wiki bootstrap. Built for newsroom institutional memory, research atlases, decision logs, and infrastructure maps.",
-      "version": "0.2.0",
+      "description": "Scaffold an Open Knowledge Format (OKF) knowledge base and populate it from existing material: one-concept-per-file markdown with YAML frontmatter, directory navigation, and a validator. Authors concepts from your existing docs, plans, notes, or a repo, generates a starter wiki that passes its own conformance and secret-leak checks, ships session-start hooks that orient Claude on the knowledge base before it works, and includes an optional GitHub-wiki bootstrap. Built for newsroom institutional memory, research atlases, decision logs, and infrastructure maps.",
+      "version": "0.3.0",
       "author": {
         "name": "Joe Amditis",
         "email": "jamditis@gmail.com"

--- a/okf-wiki/.claude-plugin/plugin.json
+++ b/okf-wiki/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "okf-wiki",
-  "version": "0.2.0",
-  "description": "Scaffold an Open Knowledge Format (OKF) knowledge base: one-concept-per-file markdown with YAML frontmatter, a spec, a validator, and session-start hooks that orient Claude on the knowledge base before it works.",
+  "version": "0.3.0",
+  "description": "Scaffold an Open Knowledge Format (OKF) knowledge base and populate it from existing docs, plans, notes, or a repo: one-concept-per-file markdown with YAML frontmatter, a spec, a validator, and session-start hooks that orient Claude on the knowledge base before it works.",
   "author": {
     "name": "Joe Amditis",
     "email": "jamditis@gmail.com"

--- a/okf-wiki/SKILL.md
+++ b/okf-wiki/SKILL.md
@@ -93,13 +93,21 @@ mechanical transform. So you (Claude) author the concepts directly, in this loop
      Path, Process, Reference (Reference is the catch-all).
    - `description` is one line. `source` — quote every element — points at where the fact
      actually came from (the origin file path, URL, command, or event), not at this skill.
-   - Set `verified` and `timestamp` to today; lower `verified` only when you are copying a
-     claim you have not re-checked against reality.
+   - Set `timestamp` to today. Set `verified` to today only for a fact you actually re-checked
+     now; for a claim copied from the source without re-checking, use the date it was last known
+     true (e.g. the source's own date), not today — stamping today makes stale facts look freshly
+     verified.
    - Strip secret values as you go: a credential concept names the key and its retrieval path,
      never the value. The validator fails the build on a leaked secret.
 4. **Place and link.** Put each concept in the right section (create sections as needed), add a
    bullet for it to that section's `index.md`, and cross-link related concepts with relative links.
-5. **Validate in a loop.** Run `python3 scripts/validate.py --bundle bundle`, fix what it
+   When you create a new section, also link it from the bundle-root `index.md` — that root is the
+   navigation map the session anchor loads, so a section missing from it is invisible to orientation
+   even though validation still passes.
+5. **Clear the placeholder.** If you scaffolded fresh, delete the starter `example-concept.md` (and
+   its bullet in the section `index.md`) once real concepts exist — otherwise the sample ships in
+   the finished wiki and still passes validation.
+6. **Validate in a loop.** Run `python3 scripts/validate.py --bundle bundle`, fix what it
    reports, repeat until it exits 0. Unquoted `source` elements and missing frontmatter keys are
    the common failures. Author in batches and validate between them rather than writing fifty
    files and debugging the lot.
@@ -109,10 +117,13 @@ mechanical transform. So you (Claude) author the concepts directly, in this loop
 If the user points you at an existing OKF bundle (e.g. an upstream example: an `index.md`
 carrying `okf_version` plus concept files with frontmatter), you are adopting it, not importing
 it. Copy or clone the tree in, point the validator at the new root, and fix any links that broke
-in the move. To keep it as its own area beside other content, follow Federation in `spec/SPEC.md`
-— a uniquely named top directory, relative cross-links, validate the combined root. Re-authoring
-an already-conforming bundle into your own concepts is wasted work; only reshape it if that is the
-actual goal.
+in the move. To keep it as its own area beside other content, give it a uniquely named top
+directory, then create one combined-root `index.md` that carries `okf_version` and strip the
+frontmatter from each adopted bundle's own root `index.md`, turning it into a normal section index
+(the validator allows `okf_version` on the one combined root only; a nested `index.md` that still
+carries it fails validation). Write cross-links as relative paths and validate the combined root.
+Re-authoring an already-conforming bundle into your own concepts is wasted work; only reshape it if
+that is the actual goal.
 
 ## The format, briefly
 

--- a/okf-wiki/SKILL.md
+++ b/okf-wiki/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: okf-wiki
-description: Scaffold a new Open Knowledge Format (OKF) knowledge base: a tree of small markdown concept files with YAML frontmatter, a spec, a validator, and session-start hooks that orient Claude on the knowledge base before it works. Use when the user wants to start an OKF atlas/wiki/knowledge base, structure docs as one-concept-per-file with provenance, or initialize OKF in a repo (optionally into its GitHub wiki).
+description: Scaffold a new Open Knowledge Format (OKF) knowledge base and populate it from existing material: a tree of small markdown concept files with YAML frontmatter, a spec, a validator, and session-start hooks that orient Claude on the knowledge base before it works. Use when the user wants to start an OKF atlas/wiki/knowledge base, build one from existing docs, plans, notes, or a repo, structure docs as one-concept-per-file with provenance, or initialize OKF in a repo (optionally into its GitHub wiki).
 license: MIT
 metadata:
   author: jamditis
-  version: "0.2.0"
+  version: "0.3.0"
   okf_spec: v1
 ---
 
@@ -71,6 +71,48 @@ Validate any time, from the scaffolded project root:
 ```bash
 python3 scripts/validate.py --bundle bundle    # must exit 0
 ```
+
+## Populate the bundle: author concepts from existing material
+
+Scaffolding leaves an empty tree with one placeholder concept. The usual next request
+— "here are my docs / plans / notes / repo, build the wiki" — has no importer script, and
+can't have one: deciding what counts as a single concept, writing its one-line description,
+choosing its `type`, and pointing `source` at real provenance is judgment work, not a
+mechanical transform. So you (Claude) author the concepts directly, in this loop:
+
+1. **Gather the source.** Read what the user pointed you at — a file, a folder, a repo, or a
+   URL (fetch a URL first). Skim the whole thing before writing anything, so you can see the
+   natural concept boundaries.
+2. **Decide concept boundaries.** One file is one concept: one thing a reader would look up on
+   its own (a service, a decision, a path, a person, an event). Split a doc that covers five
+   things into five concepts; merge fragments that only mean something together into one. A
+   heading is a hint, not a rule — do not blindly map one `##` to one file.
+3. **Draft each concept** at `bundle/<section>/<slug>.md` with the full frontmatter
+   (`type, title, description, source, verified, timestamp, tags`):
+   - `type` from the vocab: Machine, Network, Service, Session, Project, Repo, Credential,
+     Path, Process, Reference (Reference is the catch-all).
+   - `description` is one line. `source` — quote every element — points at where the fact
+     actually came from (the origin file path, URL, command, or event), not at this skill.
+   - Set `verified` and `timestamp` to today; lower `verified` only when you are copying a
+     claim you have not re-checked against reality.
+   - Strip secret values as you go: a credential concept names the key and its retrieval path,
+     never the value. The validator fails the build on a leaked secret.
+4. **Place and link.** Put each concept in the right section (create sections as needed), add a
+   bullet for it to that section's `index.md`, and cross-link related concepts with relative links.
+5. **Validate in a loop.** Run `python3 scripts/validate.py --bundle bundle`, fix what it
+   reports, repeat until it exits 0. Unquoted `source` elements and missing frontmatter keys are
+   the common failures. Author in batches and validate between them rather than writing fifty
+   files and debugging the lot.
+
+### When the source is already OKF
+
+If the user points you at an existing OKF bundle (e.g. an upstream example: an `index.md`
+carrying `okf_version` plus concept files with frontmatter), you are adopting it, not importing
+it. Copy or clone the tree in, point the validator at the new root, and fix any links that broke
+in the move. To keep it as its own area beside other content, follow Federation in `spec/SPEC.md`
+— a uniquely named top directory, relative cross-links, validate the combined root. Re-authoring
+an already-conforming bundle into your own concepts is wasted work; only reshape it if that is the
+actual goal.
 
 ## The format, briefly
 


### PR DESCRIPTION
## What

Adds a "populate the bundle" workflow to the okf-wiki skill so Claude can build a wiki from existing material, not just scaffold an empty tree.

## Why

A tester pointed the skill at existing files and asked Claude to build a wiki. Claude correctly reported there was no importer: `SKILL.md` documented scaffolding an empty tree and validating it, but never the step of turning source material into concepts — which is the most common request. The missing workflow read as a dead end.

## Change

- New **"Populate the bundle"** section: gather source, decide concept boundaries (one lookup-able thing per file), draft each concept with full frontmatter and real `source` provenance, place and link, validate to zero.
- **"When the source is already OKF"** branch: adopt or federate rather than re-author. Covers pointing the skill at an existing bundle (e.g. the upstream example bundles).
- The import is a skill procedure, not a script: deciding what counts as one concept is judgment a deterministic importer can't make.
- Synced version (`0.3.0`) and the capability blurb across `SKILL.md`, `okf-wiki/.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json` so the marketplace advertises the new behavior.

## Testing

- 58 existing tests pass (`pytest okf-wiki/tests/`).
- Both JSON manifests validate; version is consistent across all three metadata files.

Docs and metadata only — no code paths changed.
