### PR TITLE
okf-wiki: harden validator and anchor hook against five audit bugs

### DIFF
--- a/okf-wiki/example/.claude/hooks/okf-anchor.py
+++ b/okf-wiki/example/.claude/hooks/okf-anchor.py
@@ -62,7 +62,9 @@ def main():
     index = find_index()
     if index is None:
         return 0
-    body = strip_frontmatter(index.read_text(encoding="utf-8"))
+    # utf-8-sig strips a leading BOM; without it a BOM defeats the "---" frontmatter
+    # check in strip_frontmatter and the raw YAML block would leak into the context.
+    body = strip_frontmatter(index.read_text(encoding="utf-8-sig"))
     if not body:
         return 0
     print(

--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -71,9 +71,12 @@ SECRET_PATTERNS = [
     ("GitHub fine-grained PAT", re.compile(r"\bgithub_pat_[0-9A-Za-z_]{22,}\b")),
     ("secret assignment", re.compile(
         r"(?i)(?:password|passwd|secret|api[_-]?key|apikey|client[_-]?secret|access[_-]?token|auth[_-]?token)"
-        # value charset includes - _ = so tokens like a fine-grained PAT or a base64
-        # value with padding are not split short of the 24-char entropy threshold.
-        r"\s*[:=]\s*['\"]?[A-Za-z0-9+/_=-]{24,}['\"]?")),
+        # Base64-standard value charset only -- deliberately excludes - and _. A
+        # credential concept documents key paths like `secret: svc/api/prod-key-path`,
+        # and a hyphen/underscore-rich path must not read as a high-entropy value.
+        # Structured tokens that use -/_ (fine-grained PATs, Slack, etc.) have their
+        # own specific patterns above.
+        r"\s*[:=]\s*['\"]?[A-Za-z0-9+/]{24,}['\"]?")),
 ]
 
 
@@ -286,9 +289,17 @@ def main() -> int:
             target = link_destination(raw)
             if not target:
                 continue
-            if target.startswith(("http://", "https://", "mailto:", "#", "tel:")):
+            low = target.lower()
+            # External/anchor links are out of scope. Lower-case the scheme test so an
+            # uppercase scheme (HTTPS://...) is still recognized and skipped, not
+            # resolved as a local path (which would falsely fail as escaping/dangling).
+            if low.startswith(("http://", "https://", "mailto:", "#", "tel:")):
                 continue
-            if ".md" not in target.lower():  # case-insensitive: also catch .MD links
+            # OKF concept files are lowercase .md (discovery uses bundle.rglob("*.md")).
+            # Match .md case-sensitively so the link check and file discovery agree: a
+            # link to a .MD file is out of scope, not a validated internal link -- it can
+            # never resolve to an uppercase-extension file that discovery never scanned.
+            if ".md" not in target:
                 continue
             if target.startswith("/"):
                 errors.append(f"{f.relative_to(bundle)}: root-relative link not allowed "

--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -68,9 +68,12 @@ SECRET_PATTERNS = [
     ("Google API key", re.compile(r"\bAIza[0-9A-Za-z_\-]{35}\b")),
     ("Slack token", re.compile(r"\bxox[baprs]-[0-9A-Za-z-]{10,}")),
     ("GitHub token", re.compile(r"\bgh[pousr]_[0-9A-Za-z]{36,}\b")),
+    ("GitHub fine-grained PAT", re.compile(r"\bgithub_pat_[0-9A-Za-z_]{22,}\b")),
     ("secret assignment", re.compile(
         r"(?i)(?:password|passwd|secret|api[_-]?key|apikey|client[_-]?secret|access[_-]?token|auth[_-]?token)"
-        r"\s*[:=]\s*['\"]?[A-Za-z0-9+/]{24,}['\"]?")),
+        # value charset includes - _ = so tokens like a fine-grained PAT or a base64
+        # value with padding are not split short of the 24-char entropy threshold.
+        r"\s*[:=]\s*['\"]?[A-Za-z0-9+/_=-]{24,}['\"]?")),
 ]
 
 
@@ -185,12 +188,20 @@ def main() -> int:
         f"{p.relative_to(bundle)}: a '*.md' path must be a file, not a directory"
         for p in md_entries if not p.is_file()
     ]
+    # A bundle must have a root index.md. The okf_version gate below only runs when
+    # that file exists, so without this check a bundle that simply omits the root
+    # index (or an empty directory) would validate clean and bypass version gating.
+    if not (bundle / "index.md").is_file():
+        errors.append("index.md: bundle-root index is required and must declare okf_version")
     type_counts: Counter = Counter()
     concepts = 0
 
     for f in md_files:
         rel = f.relative_to(bundle)
-        text = f.read_text(encoding="utf-8")
+        # utf-8-sig strips a leading byte-order mark if present. A BOM (common from
+        # Windows editors) would otherwise defeat the startswith("---") frontmatter
+        # check, reporting valid frontmatter as missing.
+        text = f.read_text(encoding="utf-8-sig")
 
         # secret scan on every file, including index.md.
         for label, pat in SECRET_PATTERNS:
@@ -244,6 +255,13 @@ def main() -> int:
 
         concepts += 1
         ctype = fm.get("type", "<none>")
+        # type must be a scalar string. A list/dict (a plausible YAML typo like
+        # `type: [Reference]`) is unhashable and would crash both the Counter
+        # increment and the `in ALLOWED_TYPES` membership test, so report it and
+        # fall back to "<none>" to keep the rest of this concept's checks running.
+        if not isinstance(ctype, str):
+            errors.append(f"{rel}: 'type' must be a string, got {type(ctype).__name__}")
+            ctype = "<none>"
         type_counts[ctype] += 1
 
         for key in REQUIRED_KEYS:
@@ -263,14 +281,14 @@ def main() -> int:
     # self-contained tree. To validate federated content, assemble the bundles into
     # a single tree and point --bundle at that root.
     for f in md_files:
-        text = strip_code(f.read_text(encoding="utf-8"))
+        text = strip_code(f.read_text(encoding="utf-8-sig"))
         for raw in LINK_RE.findall(text):
             target = link_destination(raw)
             if not target:
                 continue
             if target.startswith(("http://", "https://", "mailto:", "#", "tel:")):
                 continue
-            if ".md" not in target:
+            if ".md" not in target.lower():  # case-insensitive: also catch .MD links
                 continue
             if target.startswith("/"):
                 errors.append(f"{f.relative_to(bundle)}: root-relative link not allowed "

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -71,9 +71,12 @@ SECRET_PATTERNS = [
     ("GitHub fine-grained PAT", re.compile(r"\bgithub_pat_[0-9A-Za-z_]{22,}\b")),
     ("secret assignment", re.compile(
         r"(?i)(?:password|passwd|secret|api[_-]?key|apikey|client[_-]?secret|access[_-]?token|auth[_-]?token)"
-        # value charset includes - _ = so tokens like a fine-grained PAT or a base64
-        # value with padding are not split short of the 24-char entropy threshold.
-        r"\s*[:=]\s*['\"]?[A-Za-z0-9+/_=-]{24,}['\"]?")),
+        # Base64-standard value charset only -- deliberately excludes - and _. A
+        # credential concept documents key paths like `secret: svc/api/prod-key-path`,
+        # and a hyphen/underscore-rich path must not read as a high-entropy value.
+        # Structured tokens that use -/_ (fine-grained PATs, Slack, etc.) have their
+        # own specific patterns above.
+        r"\s*[:=]\s*['\"]?[A-Za-z0-9+/]{24,}['\"]?")),
 ]
 
 
@@ -286,9 +289,17 @@ def main() -> int:
             target = link_destination(raw)
             if not target:
                 continue
-            if target.startswith(("http://", "https://", "mailto:", "#", "tel:")):
+            low = target.lower()
+            # External/anchor links are out of scope. Lower-case the scheme test so an
+            # uppercase scheme (HTTPS://...) is still recognized and skipped, not
+            # resolved as a local path (which would falsely fail as escaping/dangling).
+            if low.startswith(("http://", "https://", "mailto:", "#", "tel:")):
                 continue
-            if ".md" not in target.lower():  # case-insensitive: also catch .MD links
+            # OKF concept files are lowercase .md (discovery uses bundle.rglob("*.md")).
+            # Match .md case-sensitively so the link check and file discovery agree: a
+            # link to a .MD file is out of scope, not a validated internal link -- it can
+            # never resolve to an uppercase-extension file that discovery never scanned.
+            if ".md" not in target:
                 continue
             if target.startswith("/"):
                 errors.append(f"{f.relative_to(bundle)}: root-relative link not allowed "

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -68,9 +68,12 @@ SECRET_PATTERNS = [
     ("Google API key", re.compile(r"\bAIza[0-9A-Za-z_\-]{35}\b")),
     ("Slack token", re.compile(r"\bxox[baprs]-[0-9A-Za-z-]{10,}")),
     ("GitHub token", re.compile(r"\bgh[pousr]_[0-9A-Za-z]{36,}\b")),
+    ("GitHub fine-grained PAT", re.compile(r"\bgithub_pat_[0-9A-Za-z_]{22,}\b")),
     ("secret assignment", re.compile(
         r"(?i)(?:password|passwd|secret|api[_-]?key|apikey|client[_-]?secret|access[_-]?token|auth[_-]?token)"
-        r"\s*[:=]\s*['\"]?[A-Za-z0-9+/]{24,}['\"]?")),
+        # value charset includes - _ = so tokens like a fine-grained PAT or a base64
+        # value with padding are not split short of the 24-char entropy threshold.
+        r"\s*[:=]\s*['\"]?[A-Za-z0-9+/_=-]{24,}['\"]?")),
 ]
 
 
@@ -185,12 +188,20 @@ def main() -> int:
         f"{p.relative_to(bundle)}: a '*.md' path must be a file, not a directory"
         for p in md_entries if not p.is_file()
     ]
+    # A bundle must have a root index.md. The okf_version gate below only runs when
+    # that file exists, so without this check a bundle that simply omits the root
+    # index (or an empty directory) would validate clean and bypass version gating.
+    if not (bundle / "index.md").is_file():
+        errors.append("index.md: bundle-root index is required and must declare okf_version")
     type_counts: Counter = Counter()
     concepts = 0
 
     for f in md_files:
         rel = f.relative_to(bundle)
-        text = f.read_text(encoding="utf-8")
+        # utf-8-sig strips a leading byte-order mark if present. A BOM (common from
+        # Windows editors) would otherwise defeat the startswith("---") frontmatter
+        # check, reporting valid frontmatter as missing.
+        text = f.read_text(encoding="utf-8-sig")
 
         # secret scan on every file, including index.md.
         for label, pat in SECRET_PATTERNS:
@@ -244,6 +255,13 @@ def main() -> int:
 
         concepts += 1
         ctype = fm.get("type", "<none>")
+        # type must be a scalar string. A list/dict (a plausible YAML typo like
+        # `type: [Reference]`) is unhashable and would crash both the Counter
+        # increment and the `in ALLOWED_TYPES` membership test, so report it and
+        # fall back to "<none>" to keep the rest of this concept's checks running.
+        if not isinstance(ctype, str):
+            errors.append(f"{rel}: 'type' must be a string, got {type(ctype).__name__}")
+            ctype = "<none>"
         type_counts[ctype] += 1
 
         for key in REQUIRED_KEYS:
@@ -263,14 +281,14 @@ def main() -> int:
     # self-contained tree. To validate federated content, assemble the bundles into
     # a single tree and point --bundle at that root.
     for f in md_files:
-        text = strip_code(f.read_text(encoding="utf-8"))
+        text = strip_code(f.read_text(encoding="utf-8-sig"))
         for raw in LINK_RE.findall(text):
             target = link_destination(raw)
             if not target:
                 continue
             if target.startswith(("http://", "https://", "mailto:", "#", "tel:")):
                 continue
-            if ".md" not in target:
+            if ".md" not in target.lower():  # case-insensitive: also catch .MD links
                 continue
             if target.startswith("/"):
                 errors.append(f"{f.relative_to(bundle)}: root-relative link not allowed "

--- a/okf-wiki/templates/hooks/okf-anchor.py
+++ b/okf-wiki/templates/hooks/okf-anchor.py
@@ -62,7 +62,9 @@ def main():
     index = find_index()
     if index is None:
         return 0
-    body = strip_frontmatter(index.read_text(encoding="utf-8"))
+    # utf-8-sig strips a leading BOM; without it a BOM defeats the "---" frontmatter
+    # check in strip_frontmatter and the raw YAML block would leak into the context.
+    body = strip_frontmatter(index.read_text(encoding="utf-8-sig"))
     if not body:
         return 0
     print(

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -365,14 +365,36 @@ def test_github_pat_secret_detected(tmp_path):
     assert rc == 1 and "secret leak" in out
 
 
-def test_uppercase_md_link_checked(tmp_path):
-    # the .md link check is case-insensitive: a dangling uppercase-extension link
-    # must still be caught, not silently skipped.
+def test_uppercase_md_extension_out_of_scope(tmp_path):
+    # OKF concept files are lowercase .md (discovery uses *.md). A link to a .MD
+    # file is out of scope, not a validated internal link -- so it must NOT resolve
+    # (which would let .MD content bypass frontmatter/secret checks) and must NOT
+    # false-fail as dangling. It is simply skipped, like a link to a .txt file.
     scaffold(tmp_path / "kb", "--no-validate")
     b = tmp_path / "kb" / "bundle"
     write_concept(b, GOOD.rstrip() + "\nSee [x](NOPE.MD).\n")
     rc, out = validate(b)
-    assert rc == 1 and "dangling" in out
+    assert rc == 0, out
+
+
+def test_uppercase_scheme_link_not_flagged(tmp_path):
+    # an external link with an uppercase scheme must be recognized as external and
+    # skipped, not resolved as a local path (which falsely fails as escaping).
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD.rstrip() + "\nSee [s](HTTPS://example.com/readme.md).\n")
+    rc, out = validate(b)
+    assert rc == 0, out
+
+
+def test_documented_credential_path_not_flagged(tmp_path):
+    # OKF credential concepts document key NAMES/paths, not values; a hyphenated
+    # path after a secret-ish label must not read as a high-entropy leaked value.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD.rstrip() + "\nsecret: service/api/prod-client-secret-path\n")
+    rc, out = validate(b)
+    assert rc == 0, out
 
 
 # --- session hooks: scaffold wiring -----------------------------------------

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -322,6 +322,59 @@ def test_md_directory_fails_cleanly(tmp_path):
     assert "Traceback" not in out
 
 
+def test_nonscalar_type_reports_cleanly(tmp_path):
+    # type as a list/dict (a plausible YAML typo) is unhashable; counting it or
+    # testing membership would crash. Must report cleanly, not traceback.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD.replace("type: Process", "type: [Process]"))
+    rc, out = validate(b)
+    assert rc == 1 and "'type' must be a string" in out
+    assert "Traceback" not in out
+
+
+def test_missing_root_index_fails(tmp_path):
+    # a bundle with concepts but no root index.md must fail: the okf_version gate
+    # only runs when that file exists, so its absence would otherwise pass.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD)
+    (b / "index.md").unlink()
+    rc, out = validate(b)
+    assert rc == 1 and "bundle-root index is required" in out
+
+
+def test_bom_frontmatter_is_parsed(tmp_path):
+    # a leading UTF-8 BOM (common from Windows editors) must not make valid
+    # frontmatter read as missing; utf-8-sig strips it.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, "﻿" + GOOD)
+    rc, out = validate(b)
+    assert rc == 0, out
+
+
+def test_github_pat_secret_detected(tmp_path):
+    # build a fine-grained PAT shape from fragments so no real-looking token lives
+    # in this test file. The classic gh*_ pattern misses github_pat_.
+    fake = "github_pat_" + "11ABCDE" + "FGHIJKLMNOPQRSTUVWXYZ"
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD.rstrip() + f"\ntoken = {fake}\n")
+    rc, out = validate(b)
+    assert rc == 1 and "secret leak" in out
+
+
+def test_uppercase_md_link_checked(tmp_path):
+    # the .md link check is case-insensitive: a dangling uppercase-extension link
+    # must still be caught, not silently skipped.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD.rstrip() + "\nSee [x](NOPE.MD).\n")
+    rc, out = validate(b)
+    assert rc == 1 and "dangling" in out
+
+
 # --- session hooks: scaffold wiring -----------------------------------------
 
 def test_default_scaffold_writes_hooks(tmp_path):


### PR DESCRIPTION
## What

Hardens the OKF validator and anchor hook against robustness bugs surfaced by a tooling audit. The validator is copied into every scaffolded project, so each one ships to end users.

## Fixes

- **Non-scalar `type` crashed the validator** with an unhashable-key traceback (`type: [Reference]` — a plausible YAML typo). Now reports a clean error and continues. Closes #137.
- **A bundle with no root `index.md` passed**, bypassing the `okf_version` gate (an empty directory validated clean). Now requires the root index. Closes #138.
- **A UTF-8 BOM defeated the frontmatter check**, reporting valid frontmatter as missing and leaking the raw block into the anchor hook's injected context (common from Windows editors). Now reads with `utf-8-sig`. Closes #139.
- **The secret scan missed `github_pat_` fine-grained PATs.** Added a dedicated PAT pattern. Closes #140.
- **The link scheme guard was case-sensitive**, so an uppercase scheme (`HTTPS://...`) false-failed as an escaping local link. Now normalized to case-insensitive (pre-existing FP, fixed in the same code).

## Cloud-review follow-up (one round)

The first pass also widened the generic secret charset and made the `.md` link check case-insensitive. Cloud review found both to be net-negative, and both were reverted:

- The widened charset (`[A-Za-z0-9+/_=-]`) false-positived on documented credential *paths* like `secret: svc/api/prod-key-path` — exactly what an OKF credential concept is meant to contain. Reverted to base64-standard; the `github_pat_` pattern stays for the real gap.
- Case-insensitive `.md` link resolution without case-insensitive file discovery (`bundle.rglob("*.md")`) let a link to a `secret.MD` file resolve while that file was never scanned — a validation bypass. Reverted to case-sensitive `.md` so resolution and discovery agree. #141 (catch `.MD` links) is therefore resolved as **by-design**: OKF concept files are lowercase `.md`, like file discovery; `.MD` is out of scope, same as `.txt`.

## Notes

- The committed example's copies of `validate.py` and `okf-anchor.py` are synced to match.
- Tests build secret-shaped strings from fragments so no real-looking token lives in the test file.

## Testing

- 65 tests pass (`pytest okf-wiki/tests/`), up from 58.
- Each fix has a dedicated test; reverts are covered by regression tests (documented-path no-FP, uppercase-scheme no-FP, `.MD` out-of-scope).