### PR TITLE
okf-wiki: fix broken $SKILL_DIR examples, document Windows + wiki prereqs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -43,7 +43,7 @@
     {
       "name": "okf-wiki",
       "description": "Scaffold an Open Knowledge Format (OKF) knowledge base and populate it from existing material: one-concept-per-file markdown with YAML frontmatter, directory navigation, and a validator. Authors concepts from your existing docs, plans, notes, or a repo, generates a starter wiki that passes its own conformance and secret-leak checks, ships session-start hooks that orient Claude on the knowledge base before it works, and includes an optional GitHub-wiki bootstrap. Built for newsroom institutional memory, research atlases, decision logs, and infrastructure maps.",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "author": {
         "name": "Joe Amditis",
         "email": "jamditis@gmail.com"

--- a/docs/okf-wiki/index.html
+++ b/docs/okf-wiki/index.html
@@ -209,7 +209,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <!-- Phase 1: scaffold once -->
             <p class="text-xs font-semibold uppercase tracking-widest text-accentDark mb-3">1 &middot; Scaffold once</p>
             <div class="flex flex-col sm:flex-row items-stretch gap-3 mb-8">
-                <div class="flex-1 bg-ink text-white rounded-xl p-4 font-mono text-sm flex items-center break-all">python3 "$SKILL_DIR/scripts/scaffold.py" ./my-kb</div>
+                <div class="flex-1 bg-ink text-white rounded-xl p-4 font-mono text-sm flex items-center break-all">python3 "${CLAUDE_SKILL_DIR}/scripts/scaffold.py" ./my-kb</div>
                 <div class="flex items-center justify-center text-accent text-2xl font-bold" aria-hidden="true">
                     <span class="sm:hidden">&darr;</span><span class="hidden sm:inline">&rarr;</span>
                 </div>
@@ -371,8 +371,8 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Quickstart</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># SKILL_DIR is this skill's own folder (where SKILL.md lives)</p>
-                <p class="text-white mb-1">python3 "$SKILL_DIR/scripts/scaffold.py" ./my-knowledge-base \</p>
+                <p class="text-white/50 mb-2"># ${CLAUDE_SKILL_DIR} is the skill's own folder; Claude Code fills it in before running</p>
+                <p class="text-white mb-1">python3 "${CLAUDE_SKILL_DIR}/scripts/scaffold.py" ./my-knowledge-base \</p>
                 <p class="text-white mb-1">&nbsp;&nbsp;--title "Team knowledge base" \</p>
                 <p class="text-white mb-4">&nbsp;&nbsp;--sections concepts,services,decisions</p>
                 <p class="text-white/50 mb-2"># the scaffolder validates at the end; re-run any time from the project root</p>
@@ -584,7 +584,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                     a saved GitHub web session you supply.
                 </p>
                 <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto mb-3" tabindex="0" role="region" aria-label="Scrollable content">
-                    <p class="text-white">python3 "$SKILL_DIR/scripts/gh-wiki-bootstrap.py" owner/repo \</p>
+                    <p class="text-white">python3 "${CLAUDE_SKILL_DIR}/scripts/gh-wiki-bootstrap.py" owner/repo \</p>
                     <p class="text-white mb-2">&nbsp;&nbsp;--state path/to/gh_state.json</p>
                     <p class="text-white/50"># then clone https://github.com/owner/repo.wiki.git and push the rest</p>
                 </div>

--- a/docs/okf-wiki/index.html
+++ b/docs/okf-wiki/index.html
@@ -209,7 +209,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <!-- Phase 1: scaffold once -->
             <p class="text-xs font-semibold uppercase tracking-widest text-accentDark mb-3">1 &middot; Scaffold once</p>
             <div class="flex flex-col sm:flex-row items-stretch gap-3 mb-8">
-                <div class="flex-1 bg-ink text-white rounded-xl p-4 font-mono text-sm flex items-center break-all">python3 "${CLAUDE_SKILL_DIR}/scripts/scaffold.py" ./my-kb</div>
+                <div class="flex-1 bg-ink text-white rounded-xl p-4 font-mono text-sm flex items-center break-all">python3 ~/.claude/skills/okf-wiki/scripts/scaffold.py ./my-kb</div>
                 <div class="flex items-center justify-center text-accent text-2xl font-bold" aria-hidden="true">
                     <span class="sm:hidden">&darr;</span><span class="hidden sm:inline">&rarr;</span>
                 </div>
@@ -371,8 +371,8 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
         <section class="mb-12">
             <h2 class="font-display text-2xl font-semibold mb-4">Quickstart</h2>
             <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto" tabindex="0" role="region" aria-label="Scrollable content">
-                <p class="text-white/50 mb-2"># ${CLAUDE_SKILL_DIR} is the skill's own folder; Claude Code fills it in before running</p>
-                <p class="text-white mb-1">python3 "${CLAUDE_SKILL_DIR}/scripts/scaffold.py" ./my-knowledge-base \</p>
+                <p class="text-white/50 mb-2"># run from where you installed the skill (see Installation below); adjust the path if it lives elsewhere</p>
+                <p class="text-white mb-1">python3 ~/.claude/skills/okf-wiki/scripts/scaffold.py ./my-knowledge-base \</p>
                 <p class="text-white mb-1">&nbsp;&nbsp;--title "Team knowledge base" \</p>
                 <p class="text-white mb-4">&nbsp;&nbsp;--sections concepts,services,decisions</p>
                 <p class="text-white/50 mb-2"># the scaffolder validates at the end; re-run any time from the project root</p>
@@ -584,7 +584,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                     a saved GitHub web session you supply.
                 </p>
                 <div class="bg-ink rounded-xl p-5 font-mono text-sm overflow-x-auto mb-3" tabindex="0" role="region" aria-label="Scrollable content">
-                    <p class="text-white">python3 "${CLAUDE_SKILL_DIR}/scripts/gh-wiki-bootstrap.py" owner/repo \</p>
+                    <p class="text-white">python3 ~/.claude/skills/okf-wiki/scripts/gh-wiki-bootstrap.py owner/repo \</p>
                     <p class="text-white mb-2">&nbsp;&nbsp;--state path/to/gh_state.json</p>
                     <p class="text-white/50"># then clone https://github.com/owner/repo.wiki.git and push the rest</p>
                 </div>

--- a/okf-wiki/.claude-plugin/plugin.json
+++ b/okf-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "okf-wiki",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Scaffold an Open Knowledge Format (OKF) knowledge base and populate it from existing docs, plans, notes, or a repo: one-concept-per-file markdown with YAML frontmatter, a spec, a validator, and session-start hooks that orient Claude on the knowledge base before it works.",
   "author": {
     "name": "Joe Amditis",

--- a/okf-wiki/SKILL.md
+++ b/okf-wiki/SKILL.md
@@ -4,7 +4,7 @@ description: Scaffold a new Open Knowledge Format (OKF) knowledge base and popul
 license: MIT
 metadata:
   author: jamditis
-  version: "0.3.0"
+  version: "0.3.1"
   okf_spec: v1
 ---
 
@@ -52,11 +52,14 @@ The `.claude/` hooks sit outside `bundle/`, so they never trip the concept check
 
 ## How to run it
 
-`SKILL_DIR` below is this skill's own directory (the folder holding this `SKILL.md`).
-Scaffold into a new directory; it validates automatically at the end:
+`${CLAUDE_SKILL_DIR}` below is this skill's own directory (the folder holding this
+`SKILL.md`). Claude Code substitutes it with the real absolute path before you run the
+command, so it works regardless of the current directory. On Windows, use `python` instead
+of `python3` (stock Windows has no `python3`). Scaffold into a new directory; it validates
+automatically at the end:
 
 ```bash
-python3 "$SKILL_DIR/scripts/scaffold.py" ./my-knowledge-base \
+python3 "${CLAUDE_SKILL_DIR}/scripts/scaffold.py" ./my-knowledge-base \
   --title "Team knowledge base" \
   --sections concepts,services,decisions
 ```
@@ -66,7 +69,7 @@ Default section is `concepts`. Use `--force` to write into a non-empty directory
 frontmatter date. The session hooks are written by default; `--no-hooks` skips them and
 `--hooks-os posix|windows` overrides the auto-detected launch command (see below).
 
-Validate any time, from the scaffolded project root:
+Validate any time, from the scaffolded project root (use `python` on Windows):
 
 ```bash
 python3 scripts/validate.py --bundle bundle    # must exit 0
@@ -163,12 +166,21 @@ in an existing project.
 ## Optional: publish into a GitHub wiki
 
 OKF lives best as in-repo files (the validator and relative links work directly). A repo's
-GitHub wiki is an optional reading surface. A wiki with zero pages has no git repo to push
-to and no API, so the first page must be created via the web UI; `scripts/gh-wiki-bootstrap.py`
-does that using a saved GitHub web session (a Playwright `storageState` you supply):
+GitHub wiki is an optional reading surface, and wiring it up is an advanced, manual step —
+most users should skip it and keep the bundle in-repo.
+
+A wiki with zero pages has no git repo to push to and no API, so the very first page must be
+created through the web UI. `scripts/gh-wiki-bootstrap.py` automates that one step, but it
+drives a real logged-in browser, so it needs two things you provide yourself (a GitHub PAT
+does not work — wiki pages are a web-UI-only surface):
+
+- **Playwright with Chromium installed:** `pip install playwright && playwright install chromium`.
+- **A saved GitHub web session:** a Playwright `storageState` JSON, captured from a browser
+  where you have already logged into GitHub. The script reuses that session; it does not log
+  in for you. Pass its path with `--state` (default: `~/.cache/gh_state.json`).
 
 ```bash
-python3 "$SKILL_DIR/scripts/gh-wiki-bootstrap.py" owner/repo --state path/to/gh_state.json
+python3 "${CLAUDE_SKILL_DIR}/scripts/gh-wiki-bootstrap.py" owner/repo --state path/to/gh_state.json
 # then: git clone https://github.com/owner/repo.wiki.git and push your pages
 ```
 


### PR DESCRIPTION
## What

Three documentation-correctness fixes from the tooling audit, plus a patch version bump.

## Fixes

- **Run commands used `$SKILL_DIR`, a variable Claude Code never substitutes**, so the scaffold and wiki-bootstrap examples expanded to a broken `/scripts/...` path. Switched to `${CLAUDE_SKILL_DIR}` — the documented substitution Claude Code fills in at skill-load time (code.claude.com/docs skills reference), so the path resolves regardless of cwd or install level (personal/project/plugin). Fixed in `SKILL.md` and the `docs/okf-wiki/index.html` page that mirrors it. Closes #144.
- **Run commands assumed `python3`.** Added a note that Windows uses `python` (stock Windows ships no `python3`). Closes #145.
- **The GitHub-wiki bootstrap section implied a one-command flow.** It now states the real prerequisites: the script drives a logged-in Chromium via Playwright and needs a `storageState` session the user supplies (a PAT does not work — the wiki is a web-UI-only surface), and it is an advanced, optional step most users should skip. Closes #146.

## Notes

- Verified `${CLAUDE_SKILL_DIR}` against the official Claude Code docs: it is a documented string substitution applied to skill content at load time, shown in the canonical example as `python3 ${CLAUDE_SKILL_DIR}/scripts/visualize.py .` in a plain bash block.
- Patch bump to 0.3.1 across `SKILL.md`, `plugin.json`, and `marketplace.json`.

## Testing

- 58 tests pass (`pytest okf-wiki/tests/`) — docs-only change, no test behavior affected.
- JSON manifests validated; version consistent at 0.3.1 across all three.