### PR TITLE
okf-wiki: resolve two deferred spec design decisions (type vocab + federation docs)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -43,7 +43,7 @@
     {
       "name": "okf-wiki",
       "description": "Scaffold an Open Knowledge Format (OKF) knowledge base and populate it from existing material: one-concept-per-file markdown with YAML frontmatter, directory navigation, and a validator. Authors concepts from your existing docs, plans, notes, or a repo, generates a starter wiki that passes its own conformance and secret-leak checks, ships session-start hooks that orient Claude on the knowledge base before it works, and includes an optional GitHub-wiki bootstrap. Built for newsroom institutional memory, research atlases, decision logs, and infrastructure maps.",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "author": {
         "name": "Joe Amditis",
         "email": "jamditis@gmail.com"

--- a/docs/okf-wiki/index.html
+++ b/docs/okf-wiki/index.html
@@ -319,7 +319,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                     <tbody class="divide-y divide-mist/20">
                         <tr>
                             <td class="px-5 py-3 font-mono text-sm">type</td>
-                            <td class="px-5 py-3 text-clay/70">One of: Machine, Network, Service, Session, Project, Repo, Credential, Path, Process, Reference</td>
+                            <td class="px-5 py-3 text-clay/70">One of: Machine, Network, Service, Session, Project, Repo, Credential, Path, Process (infrastructure); Concept, Decision, Event, Person, Org, Source (domain-neutral); or Reference (catch-all)</td>
                         </tr>
                         <tr>
                             <td class="px-5 py-3 font-mono text-sm">title</td>

--- a/okf-wiki/.claude-plugin/plugin.json
+++ b/okf-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "okf-wiki",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Scaffold an Open Knowledge Format (OKF) knowledge base and populate it from existing docs, plans, notes, or a repo: one-concept-per-file markdown with YAML frontmatter, a spec, a validator, and session-start hooks that orient Claude on the knowledge base before it works.",
   "author": {
     "name": "Joe Amditis",

--- a/okf-wiki/SKILL.md
+++ b/okf-wiki/SKILL.md
@@ -4,7 +4,7 @@ description: Scaffold a new Open Knowledge Format (OKF) knowledge base and popul
 license: MIT
 metadata:
   author: jamditis
-  version: "0.3.1"
+  version: "0.4.0"
   okf_spec: v1
 ---
 
@@ -92,8 +92,9 @@ mechanical transform. So you (Claude) author the concepts directly, in this loop
    heading is a hint, not a rule — do not blindly map one `##` to one file.
 3. **Draft each concept** at `bundle/<section>/<slug>.md` with the full frontmatter
    (`type, title, description, source, verified, timestamp, tags`):
-   - `type` from the vocab: Machine, Network, Service, Session, Project, Repo, Credential,
-     Path, Process, Reference (Reference is the catch-all).
+   - `type` from the vocab. Infrastructure: Machine, Network, Service, Session, Project,
+     Repo, Credential, Path, Process. Domain-neutral: Concept, Decision, Event, Person,
+     Org, Source. Plus Reference (the catch-all). The set is closed; an unlisted type fails.
    - `description` is one line. `source` — quote every element — points at where the fact
      actually came from (the origin file path, URL, command, or event), not at this skill.
    - Set `timestamp` to today. Set `verified` to today only for a fact you actually re-checked
@@ -134,7 +135,8 @@ Full contract in `spec/SPEC.md`. The load-bearing rules:
 
 - **Required frontmatter** on every concept: `type, title, description, source, verified,
   timestamp, tags`. `type` is one of: Machine, Network, Service, Session, Project, Repo,
-  Credential, Path, Process, Reference.
+  Credential, Path, Process (infrastructure); Concept, Decision, Event, Person, Org, Source
+  (domain-neutral); or Reference (catch-all).
 - **Quote every `source` element** — source pointers carry `#` and `: ` which break YAML
   if unquoted. `source: ["README.md", "issue #445"]`.
 - **`verified`** is the date the fact was last checked against reality; **`timestamp`** is

--- a/okf-wiki/example/SPEC.md
+++ b/okf-wiki/example/SPEC.md
@@ -69,11 +69,15 @@ Provenance lives in `source` — there is no separate citations section or refer
 
 ## Type vocab
 
-`Machine`, `Network`, `Service`, `Session`, `Project`, `Repo`, `Credential`, `Path`,
-`Process`, `Reference`.
+Infrastructure and ops (fleet maps, system docs): `Machine`, `Network`, `Service`,
+`Session`, `Project`, `Repo`, `Credential`, `Path`, `Process`.
+
+Domain-neutral (newsrooms, research atlases, decision logs): `Concept`, `Decision`,
+`Event`, `Person`, `Org`, `Source`.
 
 `Reference` is the catch-all for a concept that is not one of the others. Index files carry
-no frontmatter, so there is no `Index` type.
+no frontmatter, so there is no `Index` type. The set is closed: an unlisted type fails the
+build, which catches typos. To extend it, add the type here and in `scripts/validate.py`.
 
 ## Links
 
@@ -83,11 +87,18 @@ validated as one self-contained tree (see Federation for combining several).
 
 ## Federation (optional)
 
-Several bundles can be combined into one tree by giving each a uniquely named top-level
-directory and concatenating them, with cross-bundle links written as relative paths into the
-sibling directories. Validate the combined result as a single bundle: assemble the tree, then
-point the validator at that root so every link resolves. Most single-repo knowledge bases
-never need this.
+Several bundles can be combined into one tree. Add a new root `index.md` that carries
+`okf_version` and links to each member, then place each bundle under a uniquely named
+subdirectory of that root. A member's own `index.md` is now a nested section index, so remove
+its `okf_version` frontmatter block entirely — a nested `index.md` carries no frontmatter at
+all. Write cross-bundle links as relative paths into the sibling directories. Validate by
+pointing the validator at the new root, so every link resolves and the single `okf_version`
+gate runs once at the top.
+
+A member's marker is stripped when it is nested, so it can no longer be validated on its own
+from inside the combined tree — validate the assembled root instead. (Per-node validation that
+keeps a marker in each member is planned but not yet built.) Most single-repo knowledge bases
+never need any of this.
 
 ## Security (hard)
 

--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -47,8 +47,13 @@ REQUIRED_KEYS = ("type", "title", "description", "source", "verified", "timestam
 LIST_KEYS = ("source", "tags")
 DATE_KEYS = ("verified", "timestamp")
 ALLOWED_TYPES = {
+    # Infrastructure / ops (fleet maps, system docs)
     "Machine", "Network", "Service", "Session", "Project",
-    "Repo", "Credential", "Path", "Process", "Reference",
+    "Repo", "Credential", "Path", "Process",
+    # Domain-neutral (newsrooms, research atlases, decision logs)
+    "Concept", "Decision", "Event", "Person", "Org", "Source",
+    # Catch-all
+    "Reference",
 }
 RESERVED = {"index.md", "log.md"}
 SPEC_VERSION = "0.1"  # the okf_version this validator implements

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -47,8 +47,13 @@ REQUIRED_KEYS = ("type", "title", "description", "source", "verified", "timestam
 LIST_KEYS = ("source", "tags")
 DATE_KEYS = ("verified", "timestamp")
 ALLOWED_TYPES = {
+    # Infrastructure / ops (fleet maps, system docs)
     "Machine", "Network", "Service", "Session", "Project",
-    "Repo", "Credential", "Path", "Process", "Reference",
+    "Repo", "Credential", "Path", "Process",
+    # Domain-neutral (newsrooms, research atlases, decision logs)
+    "Concept", "Decision", "Event", "Person", "Org", "Source",
+    # Catch-all
+    "Reference",
 }
 RESERVED = {"index.md", "log.md"}
 SPEC_VERSION = "0.1"  # the okf_version this validator implements

--- a/okf-wiki/spec/SPEC.md
+++ b/okf-wiki/spec/SPEC.md
@@ -69,11 +69,15 @@ Provenance lives in `source` — there is no separate citations section or refer
 
 ## Type vocab
 
-`Machine`, `Network`, `Service`, `Session`, `Project`, `Repo`, `Credential`, `Path`,
-`Process`, `Reference`.
+Infrastructure and ops (fleet maps, system docs): `Machine`, `Network`, `Service`,
+`Session`, `Project`, `Repo`, `Credential`, `Path`, `Process`.
+
+Domain-neutral (newsrooms, research atlases, decision logs): `Concept`, `Decision`,
+`Event`, `Person`, `Org`, `Source`.
 
 `Reference` is the catch-all for a concept that is not one of the others. Index files carry
-no frontmatter, so there is no `Index` type.
+no frontmatter, so there is no `Index` type. The set is closed: an unlisted type fails the
+build, which catches typos. To extend it, add the type here and in `scripts/validate.py`.
 
 ## Links
 
@@ -83,11 +87,18 @@ validated as one self-contained tree (see Federation for combining several).
 
 ## Federation (optional)
 
-Several bundles can be combined into one tree by giving each a uniquely named top-level
-directory and concatenating them, with cross-bundle links written as relative paths into the
-sibling directories. Validate the combined result as a single bundle: assemble the tree, then
-point the validator at that root so every link resolves. Most single-repo knowledge bases
-never need this.
+Several bundles can be combined into one tree. Add a new root `index.md` that carries
+`okf_version` and links to each member, then place each bundle under a uniquely named
+subdirectory of that root. A member's own `index.md` is now a nested section index, so remove
+its `okf_version` frontmatter block entirely — a nested `index.md` carries no frontmatter at
+all. Write cross-bundle links as relative paths into the sibling directories. Validate by
+pointing the validator at the new root, so every link resolves and the single `okf_version`
+gate runs once at the top.
+
+A member's marker is stripped when it is nested, so it can no longer be validated on its own
+from inside the combined tree — validate the assembled root instead. (Per-node validation that
+keeps a marker in each member is planned but not yet built.) Most single-repo knowledge bases
+never need any of this.
 
 ## Security (hard)
 

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -218,6 +218,18 @@ def test_bad_type_fails(tmp_path):
     assert rc == 1 and "not in the spec vocab" in out
 
 
+def test_domain_neutral_type_validates(tmp_path):
+    # the vocab is a superset: domain-neutral types (newsroom/research/decision-log)
+    # validate alongside the infrastructure types. Closed-set typo rejection is still
+    # covered by test_bad_type_fails above.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    for t in ("Concept", "Decision", "Event", "Person", "Org", "Source"):
+        write_concept(b, GOOD.replace("type: Process", f"type: {t}"), name=f"concepts/{t}.md")
+    rc, out = validate(b)
+    assert rc == 0, out
+
+
 def test_invalid_date_shape_reports_cleanly(tmp_path):
     # date-shaped but invalid (month 13) — PyYAML raises ValueError during parse,
     # which is not a YAMLError. Must report cleanly, not crash with a traceback.
@@ -291,6 +303,39 @@ def test_root_index_unsupported_okf_version_fails(tmp_path):
     (b / "index.md").write_text('---\nokf_version: "0.2"\n---\n# root\n', encoding="utf-8")
     rc, out = validate(b)
     assert rc == 1 and "not supported" in out
+
+
+def build_federated_tree(root, members=("nodeA", "nodeB"), strip_member_markers=True):
+    """Assemble a combined tree the way SPEC.md "Federation" describes: a new root
+    index.md carrying okf_version, each member under its own subdirectory."""
+    nav = "\n".join(f"- [{m}]({m}/index.md)" for m in members)
+    (root).mkdir(parents=True, exist_ok=True)
+    (root / "index.md").write_text(
+        f'---\nokf_version: "0.1"\n---\n# Atlas\n\n{nav}\n', encoding="utf-8")
+    for m in members:
+        (root / m).mkdir(parents=True, exist_ok=True)
+        marker = '---\nokf_version: "0.1"\n---\n' if not strip_member_markers else ""
+        (root / m / "index.md").write_text(
+            f"{marker}# {m}\n\n- [concept](concept.md)\n", encoding="utf-8")
+        (root / m / "concept.md").write_text(GOOD, encoding="utf-8")
+
+
+def test_federated_tree_validates(tmp_path):
+    # the documented strip-and-merge procedure must actually pass: one root marker,
+    # members nested as marker-less section indexes.
+    root = tmp_path / "atlas"
+    build_federated_tree(root)
+    rc, out = validate(root)
+    assert rc == 0, out
+
+
+def test_nested_member_marker_fails(tmp_path):
+    # the failure the SPEC warns about: leaving okf_version on a nested member index.
+    root = tmp_path / "atlas"
+    build_federated_tree(root, strip_member_markers=False)
+    rc, out = validate(root)
+    assert rc == 1
+    assert "reserved file should not carry frontmatter" in out
 
 
 def test_link_escaping_bundle_fails(tmp_path):


### PR DESCRIPTION
Resolves the two design decisions carved out of the okf-wiki audit because they needed a call rather than a mechanical fix. Both decisions confirmed before implementing.

## #152 — type vocabulary was infrastructure-only

The closed type set was all infrastructure concepts (Machine, Network, Service, ...). The dogfood example proves the cost: 14 of 16 concepts fell back to the `Reference` catch-all, and the skill's other stated audiences (newsroom institutional memory, research atlases, decision logs) had no types that fit.

**Decision: non-breaking superset.** Add a domain-neutral group — `Concept`, `Decision`, `Event`, `Person`, `Org`, `Source` — alongside the infra types.
- The set stays **closed**, so a typo'd type still fails the build (covered by `test_bad_type_fails`).
- Existing infrastructure bundles are unaffected: this only adds types, never removes them.

## #154 — the documented federation procedure produced a failing build

`SPEC.md` told users to concatenate independently-valid bundles under one root. But each bundle's `index.md` carries `okf_version`, and the validator rejects any *nested* `index.md` that carries frontmatter — so following the docs literally fails validation.

**Decision: document the working reality now, `--federated` mode later.** Rewrite the federation section to the strip-and-merge procedure that actually passes: one root marker, members nested as marker-less section indexes. Per-node validation (keeping a marker in each member) is noted as planned, not built.

## Tests
- `test_domain_neutral_type_validates` — the new types pass.
- `test_federated_tree_validates` — the documented federation procedure passes.
- `test_nested_member_marker_fails` — the mistake the SPEC warns about fails.
- 73 passing (was 70).

## Notes
- `example/SPEC.md` and `example/scripts/validate.py` kept in sync with the canonical sources.
- Version 0.3.1 -> 0.4.0 (additive vocab) across SKILL.md, plugin.json, marketplace.json.

Closes #152
Closes #154