### PR TITLE
Publish pre-commit-review hook into the catalog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ claude-skills-journalism/
 ├── README.md                    # User documentation
 ├── LICENSE
 │
-├── hooks/                       # Automated workflow checks (15 hooks)
+├── hooks/                       # Automated workflow checks (16 hooks)
 │   ├── ap-style-check.md        # Writing: AP Style violations
 │   ├── ai-slop-detector.md      # Writing: AI patterns
 │   ├── accessibility-check.md   # Writing: Alt text, headings
@@ -39,7 +39,8 @@ claude-skills-journalism/
 │   ├── archive-reminder.md      # Preservation: Archive URLs
 │   ├── one-way-door-check.md    # Development: Block irreversible decisions
 │   ├── bug-report-detector.md   # Development: Detect bug reports
-│   └── enforce-test-first.md    # Development: Enforce test-first workflow
+│   ├── enforce-test-first.md    # Development: Enforce test-first workflow
+│   └── pre-commit-review.md     # Development: Review staged diff before commit
 │
 ├── # Plugin: journalism-core (14 skills) — registered in marketplace.json
 ├── journalism-core/
@@ -225,6 +226,7 @@ Hooks run automatically at specific workflow events. Most are **non-blocking war
 | one-way-door-check | PreToolUse(Write) | Block irreversible architectural decisions |
 | bug-report-detector | UserPromptSubmit | Detect bug reports |
 | enforce-test-first | PreToolUse(Edit,Write) | Block source edits until test written |
+| pre-commit-review | PreToolUse(Bash) | Surface staged diff for review; flag guardrail deletions |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Hooks are automated checks that run at specific points in your workflow. Most ar
 | [one-way-door-check](./hooks/one-way-door-check.md) | PreToolUse | Block creation of files representing irreversible architectural decisions |
 | [bug-report-detector](./hooks/bug-report-detector.md) | UserPromptSubmit | Detect bug reports and remind to follow test-first workflow |
 | [enforce-test-first](./hooks/enforce-test-first.md) | PreToolUse | Block source code edits until a test file has been written |
+| [pre-commit-review](./hooks/pre-commit-review.md) | PreToolUse | Surface the staged diff for line-by-line review before a commit, and flag deletions of safety-critical guardrails |
 
 ## Skill structure
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -260,7 +260,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Claude skills for journalism">
-    <meta property="og:description" content="56 skills and 15 hooks for journalists, researchers, academics, and media professionals.">
+    <meta property="og:description" content="56 skills and 16 hooks for journalists, researchers, academics, and media professionals.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/">
     <meta property="og:image" content="https://skills.amditis.tech/og-image.png">
@@ -270,7 +270,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Claude skills for journalism">
-    <meta name="twitter:description" content="56 skills and 15 hooks for journalists, researchers, academics, and media professionals.">
+    <meta name="twitter:description" content="56 skills and 16 hooks for journalists, researchers, academics, and media professionals.">
     <meta name="twitter:image" content="https://skills.amditis.tech/og-image.png">
 <script src="ask-ai.js" defer></script>
 
@@ -280,7 +280,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
   "@context": "https://schema.org",
   "@type": "SoftwareSourceCode",
   "name": "Claude skills for journalism",
-  "description": "56 Claude Code skills and 15 workflow hooks for verification, FOIA, data journalism, academic writing, and more. Built for journalists, researchers, and media professionals.",
+  "description": "56 Claude Code skills and 16 workflow hooks for verification, FOIA, data journalism, academic writing, and more. Built for journalists, researchers, and media professionals.",
   "url": "https://skills.amditis.tech",
   "codeRepository": "https://github.com/jamditis/claude-skills-journalism",
   "programmingLanguage": "Markdown",
@@ -335,7 +335,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <!-- Hero -->
             <header class="mb-32 md:mb-44 animate-page-in">
                 <div class="inline-block px-4 py-1 border border-ink/10 mb-6">
-                    <span class="text-[9px] font-bold tracking-[0.4em] uppercase opacity-50">56 Skills // 11 Plugins // 15 Hooks</span>
+                    <span class="text-[9px] font-bold tracking-[0.4em] uppercase opacity-50">56 Skills // 11 Plugins // 16 Hooks</span>
                 </div>
                 <h1 class="font-display fluid-title text-[11vw] md:text-[8.5vw] font-light leading-[0.85] tracking-tight mb-12 text-ink">
                     Skills for <br> <span class="italic font-black">journalism.</span>
@@ -1002,7 +1002,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <section id="hooks" class="reveal-section mb-32">
                 <div class="section-header flex flex-col md:flex-row md:items-end justify-between gap-4">
                     <h2 class="font-display text-4xl font-light italic">11 / Hooks</h2>
-                    <span class="section-label">15 Automated Checks</span>
+                    <span class="section-label">16 Automated Checks</span>
                 </div>
 
                 <p class="text-mist mb-8 max-w-3xl">Hooks run automatically at specific workflow events. Most are <strong>non-blocking warnings</strong>, but two &mdash; one-way-door-check and enforce-test-first &mdash; block intentionally until you resolve them.</p>
@@ -1114,7 +1114,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
                     <!-- Development Hooks -->
                     <h3 class="text-[11px] font-bold uppercase tracking-widest text-mist mb-4">Development</h3>
-                    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
                         <div class="border border-ink/10 p-4 bg-white/20" style="border-color: rgba(180, 83, 9, 0.3);">
                             <div class="flex items-center gap-2 mb-2">
                                 <span class="hook-badge bg-[#b45309]/10 text-[#b45309] font-bold">PreToolUse</span>
@@ -1135,6 +1135,13 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                             </div>
                             <h4 class="font-display font-bold mb-1">enforce-test-first</h4>
                             <p class="text-xs text-mist">Block source edits until test is written.</p>
+                        </div>
+                        <div class="border border-ink/10 p-4 bg-white/20">
+                            <div class="flex items-center gap-2 mb-2">
+                                <span class="hook-badge bg-accent/10 text-accentDark font-bold">PreToolUse</span>
+                            </div>
+                            <h4 class="font-display font-bold mb-1">pre-commit-review</h4>
+                            <p class="text-xs text-mist">Surface the staged diff for review before a commit.</p>
                         </div>
                     </div>
                 </div>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -88,7 +88,7 @@ Personal site: https://jamditis.com
 - finishing-a-development-branch — decide how to land completed work
 - using-git-worktrees — isolate feature work from current workspace
 
-## Hooks (15 workflow hooks)
+## Hooks (16 workflow hooks)
 
 Hooks run automatically at specific workflow events. Most are non-blocking warnings; two block intentionally — `one-way-door-check` exits 2 to prevent irreversible architectural decisions, and `enforce-test-first` blocks source edits until a failing test exists.
 
@@ -116,6 +116,7 @@ Hooks run automatically at specific workflow events. Most are non-blocking warni
 - one-way-door-check — blocks irreversible architectural decisions
 - bug-report-detector — detects when user is describing a bug
 - enforce-test-first — blocks source edits until a test is written
+- pre-commit-review — surfaces the staged diff for review before a commit and flags removed guardrails
 
 ## Plugins
 

--- a/hooks/pre-commit-review.md
+++ b/hooks/pre-commit-review.md
@@ -1,0 +1,40 @@
+---
+name: pre-commit-review
+event: PreToolUse
+tools:
+  - Bash
+description: Surface the staged diff for line-by-line review before a commit, and flag deletions of safety-critical guardrails
+---
+
+# Pre-commit review
+
+When a `git commit` is about to run, surface the diff it will capture and a short review checklist, so the change gets read instead of scrolling past unseen. Committing without reading the diff is how an accidental deletion, a leftover debug line, or a removed guardrail slips into history, and history is the one place a mistake is expensive to walk back. Reading the diff is the cheapest place to catch that, so this hook puts it in front of you at commit time.
+
+It is advisory: by default it does not block the commit. It surfaces the diff and the checklist as context, then the commit proceeds. The value is that the change and any risky removals get seen before they land; the commit itself is not stopped. See "blocking vs advisory" below for turning it into a hard stop.
+
+## When it runs
+
+On a `Bash` tool call whose command is a `git commit` (including `git commit -m`, `git commit -am`, and a `git commit` chained after `&&`). Anything that is not a commit passes straight through.
+
+The diff it reviews is whatever the commit will actually capture. For a normal commit that is the staged set (`git diff --cached`). For a commit that stages tracked files itself (`-a`, `-am`, `--all`), `git commit -a` lands the staged set as well as the unstaged changes to tracked files, so it reviews both together. A flow like `git add -p` followed by `git commit -am` does not hide the already-staged hunks. If nothing would be committed, it does nothing.
+
+## What it surfaces
+
+- **The diff that will be committed**, so the actual change is in front of you before it lands. Long diffs are truncated to a readable window with the total line count noted, so a large commit still announces its size rather than scrolling past.
+- **A safety-removal flag.** If the diff *removes* lines carrying safety-critical language (merge restrictions, "no exceptions", "mandatory", "must not", "do not push", or anything about bypassing review), it calls that out specifically. Deleting a guardrail is occasionally correct and often a mistake, so it should be a conscious choice rather than a line that scrolled by.
+
+## How to respond
+
+Read the diff the hook surfaced, then confirm before the commit lands:
+
+1. **Every removed line was removed on purpose.** Nothing deleted by accident or left over from debugging.
+2. **No safety guardrail was dropped** without intent. If the safety-removal flag fired, double-check that line.
+3. **The commit message explains why, not just what.** The diff already shows what changed; the message is where the reason lives.
+
+If any of those is unsettled, fix it (amend or follow up) rather than leaving it in history.
+
+## Blocking vs advisory
+
+By default this is a non-blocking hook: it surfaces the diff and checklist, and the commit proceeds. That keeps the diff visible on every commit without standing between a careful author and a clean commit, and without training people to reflexively click past a gate. The trade-off is that it surfaces the change rather than enforcing a stop.
+
+If you want a hard gate, where the commit is refused until the diff is acknowledged, wire it as a blocking hook: exit non-zero, or return an `ask` or `deny` permission decision, the way `one-way-door-check` and `enforce-test-first` block in this collection. Blocking guarantees the pause; advisory keeps the friction low. Pick by how much you trust the committing author to read what they are shown.


### PR DESCRIPTION
Publishes the local `pre-commit-review` guardrail as a portable hook, the next reachable item in the tier-B editorial-hook track (refs #115, group 5). It joins `copywriting-preflight` (#135) as an editorial-discipline hook in the collection.

## What it does

Surfaces the diff a `git commit` will capture, plus a short review checklist, and flags when the commit *removes* a safety-critical line (merge restrictions, "must not", "do not push", review-bypass language). The point is that the change gets read before it lands in history, where a mistake is expensive to walk back.

It is advisory (non-blocking), matching the source hook and the convention of the other surfacing hooks here (`copywriting-preflight`, `bug-report-detector`). The doc is explicit that a non-blocking hook surfaces rather than gates, documents the blocking alternative for anyone who wants a hard stop, and describes `git commit -a` accurately (it captures staged plus unstaged tracked changes, reviewed together) so the spec matches git's real semantics.

## Catalog consistency

Hook count bumped 15 to 16 everywhere it is stated:
- `CLAUDE.md` tree and hook table
- `README.md` development hooks table
- `docs/index.html` (og/twitter/JSON-LD meta, hero stat, section label, and a new card in the development card grid, widened to four columns)
- `docs/llms.txt` header and development list

No executable code ships; the published artifact is the declarative hook doc, matching the repo's hook convention.

Refs #115

wake-20260625T1705-2e009f