### PR TITLE
okf-wiki: catch two authoring-error classes (wrong YAML hint #157, silent [[wikilink]] dead refs #158)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -43,7 +43,7 @@
     {
       "name": "okf-wiki",
       "description": "Scaffold an Open Knowledge Format (OKF) knowledge base and populate it from existing material: one-concept-per-file markdown with YAML frontmatter, directory navigation, and a validator. Authors concepts from your existing docs, plans, notes, or a repo, generates a starter wiki that passes its own conformance and secret-leak checks, ships session-start hooks that orient Claude on the knowledge base before it works, and includes an optional GitHub-wiki bootstrap. Built for newsroom institutional memory, research atlases, decision logs, and infrastructure maps.",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "author": {
         "name": "Joe Amditis",
         "email": "jamditis@gmail.com"

--- a/okf-wiki/.claude-plugin/plugin.json
+++ b/okf-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "okf-wiki",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Scaffold an Open Knowledge Format (OKF) knowledge base and populate it from existing docs, plans, notes, or a repo: one-concept-per-file markdown with YAML frontmatter, a spec, a validator, and session-start hooks that orient Claude on the knowledge base before it works.",
   "author": {
     "name": "Joe Amditis",

--- a/okf-wiki/SKILL.md
+++ b/okf-wiki/SKILL.md
@@ -4,7 +4,7 @@ description: Scaffold a new Open Knowledge Format (OKF) knowledge base and popul
 license: MIT
 metadata:
   author: jamditis
-  version: "0.4.0"
+  version: "0.5.0"
   okf_spec: v1
 ---
 
@@ -104,7 +104,9 @@ mechanical transform. So you (Claude) author the concepts directly, in this loop
    - Strip secret values as you go: a credential concept names the key and its retrieval path,
      never the value. The validator fails the build on a leaked secret.
 4. **Place and link.** Put each concept in the right section (create sections as needed), add a
-   bullet for it to that section's `index.md`, and cross-link related concepts with relative links.
+   bullet for it to that section's `index.md`, and cross-link related concepts with relative
+   `[text](path.md)` links — not `[[slug]]` wikilinks. `[[slug]]` is the auto-memory idiom; the
+   OKF validator rejects it and never resolves it, so a typo'd or deleted reference passes silently.
    When you create a new section, also link it from the bundle-root `index.md` — that root is the
    navigation map the session anchor loads, so a section missing from it is invisible to orientation
    even though validation still passes.

--- a/okf-wiki/example/SPEC.md
+++ b/okf-wiki/example/SPEC.md
@@ -85,6 +85,11 @@ Relative markdown links. Every link to a file inside the bundle must resolve to 
 exists; a link that escapes the bundle root or dangles fails validation. The bundle is
 validated as one self-contained tree (see Federation for combining several).
 
+The `[[slug]]` wikilink form is not an OKF link, and the validator rejects it. It is the
+auto-memory cross-reference idiom and easy to reach for by habit, but a `[[slug]]` is never
+resolved or checked, so a dead reference would pass silently. Always link with
+`[text](relative/path.md)`.
+
 ## Federation (optional)
 
 Several bundles can be combined into one tree. Add a new root `index.md` that carries

--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -8,7 +8,8 @@ agent-readable.
 
 Checks:
   1. Every non-reserved .md file has a parseable YAML frontmatter block. A YAML
-     parse error is reported (commonly an unquoted '#' inside a source/tags list).
+     parse error is reported (commonly an unquoted colon-space or '#' in a
+     string field — quote the value).
   2. Frontmatter carries every required key, non-empty:
      type, title, description, source, verified, timestamp, tags.
        - type     is one of the spec type vocab.
@@ -61,6 +62,11 @@ SPEC_VERSION = "0.1"  # the okf_version this validator implements
 # parens so a filename like `missing(v2).md` is still captured (a plain [^)]+
 # would stop at the first ')' and skip the link entirely).
 LINK_RE = re.compile(r"\[[^\]]*\]\(((?:[^()]|\([^()]*\))*)\)")
+# OKF links are relative markdown links only. The [[slug]] wikilink idiom (from the
+# auto-memory system) is not OKF, so a typo'd or deleted [[ref]] would otherwise pass
+# the link check unseen. It is reported as an error. Checked against strip_code output,
+# so a [[x]] shown inside a code fence is illustrative, not flagged.
+WIKILINK_RE = re.compile(r"\[\[([^\[\]]+)\]\]")
 
 # Secret-value detectors. These match credential VALUES, not the key names/paths
 # a credential concept is allowed to document. The generic assignment pattern
@@ -225,8 +231,10 @@ def main() -> int:
             # rejects (e.g. an invalid month), which is not a YAMLError subclass.
             errors.append(
                 f"{rel}: YAML frontmatter parse error ({e.__class__.__name__}: {e}) — "
-                f"check for an unquoted '#' in a source/tags list (quote every element) "
-                f"or an invalid date value")
+                f"quote any string field that holds a YAML-significant character. "
+                f"Common triggers: a colon-space (': ') anywhere in description, title, "
+                f"or a source element; a bare '#' in a source element; an invalid date "
+                f"in verified/timestamp.")
             continue
 
         # Past this point fm is either None or a mapping. Syntactically valid YAML
@@ -290,6 +298,12 @@ def main() -> int:
     # a single tree and point --bundle at that root.
     for f in md_files:
         text = strip_code(f.read_text(encoding="utf-8-sig"))
+        for m in WIKILINK_RE.finditer(text):
+            slug = m.group(1).strip()
+            errors.append(
+                f"{f.relative_to(bundle)}: '[[{slug}]]' is not an OKF link — use a "
+                f"relative markdown link like [text]({slug}.md). The [[slug]] form is "
+                f"the auto-memory convention, not OKF.")
         for raw in LINK_RE.findall(text):
             target = link_destination(raw)
             if not target:

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -8,7 +8,8 @@ agent-readable.
 
 Checks:
   1. Every non-reserved .md file has a parseable YAML frontmatter block. A YAML
-     parse error is reported (commonly an unquoted '#' inside a source/tags list).
+     parse error is reported (commonly an unquoted colon-space or '#' in a
+     string field — quote the value).
   2. Frontmatter carries every required key, non-empty:
      type, title, description, source, verified, timestamp, tags.
        - type     is one of the spec type vocab.
@@ -61,6 +62,11 @@ SPEC_VERSION = "0.1"  # the okf_version this validator implements
 # parens so a filename like `missing(v2).md` is still captured (a plain [^)]+
 # would stop at the first ')' and skip the link entirely).
 LINK_RE = re.compile(r"\[[^\]]*\]\(((?:[^()]|\([^()]*\))*)\)")
+# OKF links are relative markdown links only. The [[slug]] wikilink idiom (from the
+# auto-memory system) is not OKF, so a typo'd or deleted [[ref]] would otherwise pass
+# the link check unseen. It is reported as an error. Checked against strip_code output,
+# so a [[x]] shown inside a code fence is illustrative, not flagged.
+WIKILINK_RE = re.compile(r"\[\[([^\[\]]+)\]\]")
 
 # Secret-value detectors. These match credential VALUES, not the key names/paths
 # a credential concept is allowed to document. The generic assignment pattern
@@ -225,8 +231,10 @@ def main() -> int:
             # rejects (e.g. an invalid month), which is not a YAMLError subclass.
             errors.append(
                 f"{rel}: YAML frontmatter parse error ({e.__class__.__name__}: {e}) — "
-                f"check for an unquoted '#' in a source/tags list (quote every element) "
-                f"or an invalid date value")
+                f"quote any string field that holds a YAML-significant character. "
+                f"Common triggers: a colon-space (': ') anywhere in description, title, "
+                f"or a source element; a bare '#' in a source element; an invalid date "
+                f"in verified/timestamp.")
             continue
 
         # Past this point fm is either None or a mapping. Syntactically valid YAML
@@ -290,6 +298,12 @@ def main() -> int:
     # a single tree and point --bundle at that root.
     for f in md_files:
         text = strip_code(f.read_text(encoding="utf-8-sig"))
+        for m in WIKILINK_RE.finditer(text):
+            slug = m.group(1).strip()
+            errors.append(
+                f"{f.relative_to(bundle)}: '[[{slug}]]' is not an OKF link — use a "
+                f"relative markdown link like [text]({slug}.md). The [[slug]] form is "
+                f"the auto-memory convention, not OKF.")
         for raw in LINK_RE.findall(text):
             target = link_destination(raw)
             if not target:

--- a/okf-wiki/spec/SPEC.md
+++ b/okf-wiki/spec/SPEC.md
@@ -85,6 +85,11 @@ Relative markdown links. Every link to a file inside the bundle must resolve to 
 exists; a link that escapes the bundle root or dangles fails validation. The bundle is
 validated as one self-contained tree (see Federation for combining several).
 
+The `[[slug]]` wikilink form is not an OKF link, and the validator rejects it. It is the
+auto-memory cross-reference idiom and easy to reach for by habit, but a `[[slug]]` is never
+resolved or checked, so a dead reference would pass silently. Always link with
+`[text](relative/path.md)`.
+
 ## Federation (optional)
 
 Several bundles can be combined into one tree. Add a new root `index.md` that carries

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -946,3 +946,40 @@ def test_committed_example_validates():
     assert example.is_dir(), "okf-wiki/example/bundle is missing"
     rc, out = validate(example)
     assert rc == 0, out
+
+
+# --- authoring-error hints (#157, #158) -------------------------------------
+
+def test_yaml_hint_names_colon_space(tmp_path):
+    # #157: an unquoted colon-space in description is the common real trigger. The
+    # parse-error hint must name it, not only the '#'-in-source case it used to.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD.replace("description: a good concept",
+                                  "description: Network analysis finding: send volume"))
+    rc, out = validate(b)
+    assert rc == 1
+    assert "parse error" in out
+    assert "colon-space" in out
+
+
+def test_wikilink_fails(tmp_path):
+    # #158: the [[slug]] idiom is the auto-memory convention, not OKF. An unresolved
+    # [[ref]] used to pass the link check silently; it must now be reported.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD.rstrip() + "\n\nSee [[activecampaign]] for the AC reference.\n")
+    rc, out = validate(b)
+    assert rc == 1
+    assert "not an OKF link" in out
+    assert "activecampaign" in out
+
+
+def test_wikilink_in_code_fence_ignored(tmp_path):
+    # a [[slug]] shown inside a fenced code block is illustrative, mirroring the
+    # link checker's tolerance for fenced example links.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD.rstrip() + "\n\n```md\nSee [[activecampaign]] (not an OKF link)\n```\n")
+    rc, out = validate(b)
+    assert rc == 0, out


### PR DESCRIPTION
Two validator bugs reported by @deblock1376 while authoring a real knowledge base. Both verified against the live code and fixed here.

## #157 — YAML parse-error hint named the wrong field and character
The parse-error hint was hardcoded to `check for an unquoted '#' in a source/tags list`, but it fires for *any* YAML parse failure in the frontmatter. The common real trigger is a colon-space in `description` (YAML reads `: ` as a mapping indicator), so a user with a bad `description` was sent to check `source` for a `#` — wrong field, wrong character.

**Fix:** rewrite the hint to be field-agnostic and name colon-space first:
> quote any string field that holds a YAML-significant character. Common triggers: a colon-space (`: `) anywhere in description, title, or a source element; a bare `#` in a source element; an invalid date in verified/timestamp.

## #158 — `[[wikilink]]` cross-refs passed silently as dead refs
`LINK_RE` only matches `[text](path)`, so `[[slug]]` was invisible to the link checker — a typo'd or deleted `[[ref]]` passed forever. The idiom bleeds in from the auto-memory system, where `[[slug]]` is the cross-ref convention.

**Fix (decision: flag + document):**
- The validator now reports any `[[slug]]` as not an OKF link, checked against `strip_code` output so a fenced/inline example stays fine.
- `SPEC.md` and the `SKILL.md` authoring loop name the boundary explicitly, distinguishing OKF relative links from the auto-memory `[[slug]]` idiom — correcting the habit at the source, not just catching it downstream.

## Tests
- `test_yaml_hint_names_colon_space` — the new hint names colon-space.
- `test_wikilink_fails` — a bare `[[slug]]` is rejected.
- `test_wikilink_in_code_fence_ignored` — a fenced `[[slug]]` example stays clean.
- 76 passing (was 73). Committed example bundle is wikilink-free, so the new rule doesn't break it.

## Notes
- example/ copies (validator + SPEC) kept in sync with the canonical sources.
- Version 0.4.0 -> 0.5.0 (new validation behavior).

Closes #157
Closes #158