### PR TITLE
okf-wiki: version the format so vocab growth doesn't misfire on old validators (#161)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -43,7 +43,7 @@
     {
       "name": "okf-wiki",
       "description": "Scaffold an Open Knowledge Format (OKF) knowledge base and populate it from existing material: one-concept-per-file markdown with YAML frontmatter, directory navigation, and a validator. Authors concepts from your existing docs, plans, notes, or a repo, generates a starter wiki that passes its own conformance and secret-leak checks, ships session-start hooks that orient Claude on the knowledge base before it works, and includes an optional GitHub-wiki bootstrap. Built for newsroom institutional memory, research atlases, decision logs, and infrastructure maps.",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "author": {
         "name": "Joe Amditis",
         "email": "jamditis@gmail.com"

--- a/docs/okf-wiki/index.html
+++ b/docs/okf-wiki/index.html
@@ -399,7 +399,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <p class="text-white">&nbsp;&nbsp;README.md<span class="text-white/50">            # how the bundle is laid out</span></p>
                 <p class="text-white">&nbsp;&nbsp;scripts/validate.py<span class="text-white/50">  # the validator, copied in</span></p>
                 <p class="text-white">&nbsp;&nbsp;bundle/<span class="text-white/50">              # the only validated tree</span></p>
-                <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;index.md<span class="text-white/50">           # carries okf_version: "0.1"</span></p>
+                <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;index.md<span class="text-white/50">           # carries okf_version: "0.2"</span></p>
                 <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;concepts/</p>
                 <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;index.md</p>
                 <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;example-concept.md<span class="text-white/50">  # a filled-in starter concept</span></p>

--- a/okf-wiki/.claude-plugin/plugin.json
+++ b/okf-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "okf-wiki",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Scaffold an Open Knowledge Format (OKF) knowledge base and populate it from existing docs, plans, notes, or a repo: one-concept-per-file markdown with YAML frontmatter, a spec, a validator, and session-start hooks that orient Claude on the knowledge base before it works.",
   "author": {
     "name": "Joe Amditis",

--- a/okf-wiki/SKILL.md
+++ b/okf-wiki/SKILL.md
@@ -4,7 +4,7 @@ description: Scaffold a new Open Knowledge Format (OKF) knowledge base and popul
 license: MIT
 metadata:
   author: jamditis
-  version: "0.5.0"
+  version: "0.6.0"
   okf_spec: v1
 ---
 
@@ -39,7 +39,7 @@ in `spec/SPEC.md` (in this skill's directory) — read it before changing struct
     hooks/okf-anchor.py   SessionStart: load the index into context
     hooks/okf-orient.py   PreToolUse: gate the first action on orientation
   bundle/                 the OKF bundle (the validated tree)
-    index.md              carries okf_version: "0.1"
+    index.md              carries okf_version: "0.2"
     <section>/
       index.md
       example-concept.md  a starter concept with full frontmatter

--- a/okf-wiki/example/SPEC.md
+++ b/okf-wiki/example/SPEC.md
@@ -23,7 +23,7 @@ with an `index.md`. Larger bundles group concepts into subdirectories by subject
 
 ## Files
 
-- The bundle-root `index.md` carries `okf_version: "0.1"` in frontmatter — only there.
+- The bundle-root `index.md` carries `okf_version: "0.2"` in frontmatter — only there.
 - Per-directory `index.md`: a heading, an optional one-line preamble, then bullet
   navigation. No frontmatter. (Keep the preamble to one line — it orients, it doesn't narrate.)
 - `log.md` (optional, per directory): dated entries, newest first, no frontmatter.
@@ -33,6 +33,12 @@ with an `index.md`. Larger bundles group concepts into subdirectories by subject
 The validator enforces the frontmatter rules here — reserved files carry no frontmatter, and
 only the bundle-root `index.md` carries `okf_version` (and nothing else). The index/log body
 shapes above are recommendations for human readers, not validator-checked structure.
+
+The current format version is `0.2`. The validator accepts `0.1` and `0.2`, so a newer
+validator still reads an older bundle, and new scaffolds emit `0.2`. Adding allowed types is
+backward compatible and bumps the format version: a bundle using the newer types declares
+`0.2`, so an older validator reports a clear unsupported-version error instead of a misleading
+bad-type one.
 
 ## Concept frontmatter (required keys, all non-empty)
 

--- a/okf-wiki/example/bundle/index.md
+++ b/okf-wiki/example/bundle/index.md
@@ -1,5 +1,5 @@
 ---
-okf_version: "0.1"
+okf_version: "0.2"
 ---
 # claude-skills-journalism wiki
 

--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -57,7 +57,12 @@ ALLOWED_TYPES = {
     "Reference",
 }
 RESERVED = {"index.md", "log.md"}
-SPEC_VERSION = "0.1"  # the okf_version this validator implements
+# okf_version values this validator accepts. The last entry is the current format
+# version (what scaffold writes for a new bundle); older entries stay supported so a
+# newer validator still reads an older bundle. Adding allowed types is backward
+# compatible and bumps the format version (0.1 -> 0.2).
+SUPPORTED_VERSIONS = ("0.1", "0.2")
+SPEC_VERSION = SUPPORTED_VERSIONS[-1]  # current format version, written by new scaffolds
 # Inline markdown link. The destination group allows one level of balanced
 # parens so a filename like `missing(v2).md` is still captured (a plain [^)]+
 # would stop at the first ')' and skip the link entirely).
@@ -253,10 +258,10 @@ def main() -> int:
                     errors.append("index.md: bundle-root index must declare okf_version in frontmatter")
                 else:
                     version = str(fm.get("okf_version")).strip()
-                    if version != SPEC_VERSION:
+                    if version not in SUPPORTED_VERSIONS:
                         errors.append(
                             f"index.md: okf_version {fm.get('okf_version')!r} is not supported "
-                            f"(this validator supports okf_version {SPEC_VERSION})")
+                            f"(this validator supports {', '.join(SUPPORTED_VERSIONS)})")
                 extra = sorted(keys - {"okf_version"})
                 if extra:
                     errors.append(f"index.md: bundle-root index may carry only okf_version, found {extra}")

--- a/okf-wiki/scripts/scaffold.py
+++ b/okf-wiki/scripts/scaffold.py
@@ -93,7 +93,7 @@ def copy_if_absent(src: Path, dst: Path, preserved: list[Path]) -> None:
 def root_index(title: str, sections: list[str]) -> str:
     nav = "\n".join(f"- [{s}]({s}/index.md)" for s in sections)
     return (
-        '---\nokf_version: "0.1"\n---\n'
+        '---\nokf_version: "0.2"\n---\n'
         f"# {title}\n\n"
         "An Open Knowledge Format bundle. One concept per file; provenance in each file's frontmatter.\n\n"
         "## Sections\n\n"

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -57,7 +57,12 @@ ALLOWED_TYPES = {
     "Reference",
 }
 RESERVED = {"index.md", "log.md"}
-SPEC_VERSION = "0.1"  # the okf_version this validator implements
+# okf_version values this validator accepts. The last entry is the current format
+# version (what scaffold writes for a new bundle); older entries stay supported so a
+# newer validator still reads an older bundle. Adding allowed types is backward
+# compatible and bumps the format version (0.1 -> 0.2).
+SUPPORTED_VERSIONS = ("0.1", "0.2")
+SPEC_VERSION = SUPPORTED_VERSIONS[-1]  # current format version, written by new scaffolds
 # Inline markdown link. The destination group allows one level of balanced
 # parens so a filename like `missing(v2).md` is still captured (a plain [^)]+
 # would stop at the first ')' and skip the link entirely).
@@ -253,10 +258,10 @@ def main() -> int:
                     errors.append("index.md: bundle-root index must declare okf_version in frontmatter")
                 else:
                     version = str(fm.get("okf_version")).strip()
-                    if version != SPEC_VERSION:
+                    if version not in SUPPORTED_VERSIONS:
                         errors.append(
                             f"index.md: okf_version {fm.get('okf_version')!r} is not supported "
-                            f"(this validator supports okf_version {SPEC_VERSION})")
+                            f"(this validator supports {', '.join(SUPPORTED_VERSIONS)})")
                 extra = sorted(keys - {"okf_version"})
                 if extra:
                     errors.append(f"index.md: bundle-root index may carry only okf_version, found {extra}")

--- a/okf-wiki/spec/SPEC.md
+++ b/okf-wiki/spec/SPEC.md
@@ -23,7 +23,7 @@ with an `index.md`. Larger bundles group concepts into subdirectories by subject
 
 ## Files
 
-- The bundle-root `index.md` carries `okf_version: "0.1"` in frontmatter — only there.
+- The bundle-root `index.md` carries `okf_version: "0.2"` in frontmatter — only there.
 - Per-directory `index.md`: a heading, an optional one-line preamble, then bullet
   navigation. No frontmatter. (Keep the preamble to one line — it orients, it doesn't narrate.)
 - `log.md` (optional, per directory): dated entries, newest first, no frontmatter.
@@ -33,6 +33,12 @@ with an `index.md`. Larger bundles group concepts into subdirectories by subject
 The validator enforces the frontmatter rules here — reserved files carry no frontmatter, and
 only the bundle-root `index.md` carries `okf_version` (and nothing else). The index/log body
 shapes above are recommendations for human readers, not validator-checked structure.
+
+The current format version is `0.2`. The validator accepts `0.1` and `0.2`, so a newer
+validator still reads an older bundle, and new scaffolds emit `0.2`. Adding allowed types is
+backward compatible and bumps the format version: a bundle using the newer types declares
+`0.2`, so an older validator reports a clear unsupported-version error instead of a misleading
+bad-type one.
 
 ## Concept frontmatter (required keys, all non-empty)
 

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -82,7 +82,7 @@ def test_multi_section_scaffold_validates(tmp_path):
 def test_root_index_carries_okf_version(tmp_path):
     scaffold(tmp_path / "kb")
     root = (tmp_path / "kb" / "bundle" / "index.md").read_text()
-    assert 'okf_version: "0.1"' in root
+    assert 'okf_version: "0.2"' in root
 
 
 def test_refuses_nonempty_dir_without_force(tmp_path):
@@ -300,9 +300,20 @@ def test_root_index_missing_okf_version_fails(tmp_path):
 def test_root_index_unsupported_okf_version_fails(tmp_path):
     scaffold(tmp_path / "kb", "--no-validate")
     b = tmp_path / "kb" / "bundle"
-    (b / "index.md").write_text('---\nokf_version: "0.2"\n---\n# root\n', encoding="utf-8")
+    (b / "index.md").write_text('---\nokf_version: "0.9"\n---\n# root\n', encoding="utf-8")
     rc, out = validate(b)
     assert rc == 1 and "not supported" in out
+
+
+def test_root_index_legacy_version_validates(tmp_path):
+    # backward compat: a 0.1 bundle (e.g. the fleet atlas) still validates under the
+    # newer validator, which accepts both 0.1 and the current format version.
+    scaffold(tmp_path / "kb", "--no-validate")
+    root = tmp_path / "kb" / "bundle" / "index.md"
+    root.write_text(root.read_text().replace('okf_version: "0.2"', 'okf_version: "0.1"'),
+                    encoding="utf-8")
+    rc, out = validate(tmp_path / "kb" / "bundle")
+    assert rc == 0, out
 
 
 def build_federated_tree(root, members=("nodeA", "nodeB"), strip_member_markers=True):


### PR DESCRIPTION
Resolves #161 (the `okf_version` policy decision). Implements the chosen approach: a range gate plus a format-version bump to 0.2.

## Problem
The type vocab grew in 0.5.0, but the format version stayed `0.1` and the version gate was exact-equality (`version != SPEC_VERSION`). Two consequences:

- A new bundle using `type: Decision` still declared `okf_version: "0.1"`. Run it through an **older vendored validator** (okf-wiki copies `validate.py` into every bundle it scaffolds) and you got `type 'Decision' not in the spec vocab` — misleading, since the error points at your data, not at the stale validator.
- Exact-equality meant *any* version other than `0.1` was rejected, so the format could never evolve without a breaking change.

## Fix
- `SUPPORTED_VERSIONS = ("0.1", "0.2")`; the gate now checks membership, and `SPEC_VERSION` is the latest entry.
- New scaffolds emit `okf_version: "0.2"`; adding allowed types is a backward-compatible format bump.
- Existing `0.1` bundles (the fleet atlas included) keep validating. A stale vendored validator now reports a clear `okf_version "0.2" is not supported` instead of a misleading bad-type error.
- This also removes the exact-equality strictness for good — future format changes just add to `SUPPORTED_VERSIONS`.

## Tests
- `test_root_index_carries_okf_version` — scaffold emits `0.2`.
- `test_root_index_legacy_version_validates` — a `0.1` bundle still validates (backward compat).
- `test_root_index_unsupported_okf_version_fails` — an unknown version (`0.9`) still fails.
- 77 passing (was 76).

## Notes
- SPEC and SKILL.md document the versioning policy; the docs page sample and the example bundle move to `0.2`; example/ copies (validator + SPEC) kept in sync.
- Plugin 0.5.0 -> 0.6.0. (Format version `okf_version` 0.1 -> 0.2 is a separate number from the plugin's semver.)

Closes #161