### PR TITLE
okf-wiki: guard against canonical/example file drift (#162)

### DIFF
--- a/.github/workflows/okf-wiki-tests.yml
+++ b/.github/workflows/okf-wiki-tests.yml
@@ -1,0 +1,28 @@
+name: okf-wiki tests
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'okf-wiki/**'
+      - '.github/workflows/okf-wiki-tests.yml'
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      # pytest is a dev-only dep, not in requirements.txt (which declares the
+      # validator's runtime dep, PyYAML). Install both.
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest -r okf-wiki/requirements.txt
+
+      - name: Run okf-wiki test suite
+        run: python -m pytest okf-wiki/tests -q

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -994,3 +994,22 @@ def test_wikilink_in_code_fence_ignored(tmp_path):
     write_concept(b, GOOD.rstrip() + "\n\n```md\nSee [[activecampaign]] (not an OKF link)\n```\n")
     rc, out = validate(b)
     assert rc == 0, out
+
+
+# --- canonical/example sync (#162) ------------------------------------------
+
+def test_example_spec_matches_canonical():
+    # scaffold copies spec/SPEC.md into each bundle verbatim, and example/SPEC.md is a
+    # committed copy. They must stay byte-identical, or the shipped example documents a
+    # different contract than the validator enforces. Drift bit us twice (#149, #159).
+    assert (SKILL / "example" / "SPEC.md").read_text(encoding="utf-8") == \
+           (SKILL / "spec" / "SPEC.md").read_text(encoding="utf-8"), \
+           "okf-wiki/example/SPEC.md drifted from spec/SPEC.md — re-sync the copy"
+
+
+def test_example_validator_matches_canonical():
+    # the example vendors scripts/validate.py; a drifted copy would validate the
+    # committed example against stale rules.
+    assert (SKILL / "example" / "scripts" / "validate.py").read_text(encoding="utf-8") == \
+           (SKILL / "scripts" / "validate.py").read_text(encoding="utf-8"), \
+           "okf-wiki/example/scripts/validate.py drifted from scripts/validate.py — re-sync the copy"


### PR DESCRIPTION
Closes #162. Turns a silent staleness bug into a failing test, and wires the okf-wiki suite into CI so the test can actually enforce it.

## Problem
The OKF spec and validator each live in two tracked places that must move together:
- `okf-wiki/spec/SPEC.md` (canonical, copied verbatim into bundles by `scaffold.py`) and `okf-wiki/example/SPEC.md` (committed example copy)
- `okf-wiki/scripts/validate.py` (canonical) and `okf-wiki/example/scripts/validate.py` (vendored in the example)

Editing one without re-syncing the other ships an example that documents or enforces a different contract than the real validator. This drifted through twice this session before the local Codex pass caught it (#149 example README, #159 example SPEC).

While adding the guard I found a second gap: **no workflow ran pytest at all.** The whole okf-wiki suite (79 tests) only ran on a developer's local machine, so a drift-guard test alone couldn't fail a PR.

## Fix
**Drift guard (commit 1):** two tests assert the copies are byte-identical to their canonical sources:
- `test_example_spec_matches_canonical`
- `test_example_validator_matches_canonical`

Verified the guard actually fails on a perturbed copy (not a vacuous assertion).

**CI runner (commit 2):** `.github/workflows/okf-wiki-tests.yml` runs the suite on any `okf-wiki/**` change: `setup-python` + `pip install pytest -r okf-wiki/requirements.txt` + `pytest okf-wiki/tests`. (pytest is dev-only, so it's installed explicitly; `requirements.txt` declares only the validator's runtime dep, PyYAML.) No untrusted input is interpolated into any run step. This workflow runs on this PR itself, since both changed paths match its filter.

Net: the next unsynced edit, or any validator regression, fails CI instead of shipping. 79 tests passing (was 77).

Closes #162
