### PR TITLE
okf-wiki: enforce source-quoting in block-style lists too (#155)

### DIFF
--- a/okf-wiki/example/SPEC.md
+++ b/okf-wiki/example/SPEC.md
@@ -61,9 +61,11 @@ rejects an unquoted source. Always quote them:
 source: ["README.md", "issue #445", "git log 9c2e510"]
 ```
 
-The validator enforces this through the YAML parse step: an unquoted element carrying a
-significant character fails to parse and is reported as an error. An element that is already
-quote-safe (a bare filename) parses fine and is accepted — quote everything anyway so you
+The validator enforces this in both list styles. In flow style (`["a", b]`) an unquoted
+element carrying a significant character fails to parse and is reported as an error. In block
+style (`- a`) YAML would silently drop an inline `#` comment and pass, so the validator also
+scans the raw source text and rejects an unquoted element with a `#`. An element that is
+already quote-safe (a bare filename) is accepted either way — quote everything anyway so you
 never have to judge which is which.
 
 `tags` and `description` follow a lighter rule: quote an element only when it contains a

--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -14,6 +14,8 @@ Checks:
      type, title, description, source, verified, timestamp, tags.
        - type     is one of the spec type vocab.
        - source   is a non-empty list of non-empty strings (provenance pointers).
+                  An unquoted '#' in a block-style element (which YAML would silently
+                  drop as a comment, losing the rest) is rejected — quote it.
        - tags     is a list.
        - verified, timestamp parse as ISO dates (YYYY-MM-DD).
   3. Reserved filenames (index.md, log.md) name no concept and carry no
@@ -96,14 +98,27 @@ SECRET_PATTERNS = [
 ]
 
 
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n?(.*)$", re.DOTALL)
+
+
 def parse_frontmatter(text: str):
     """Return (frontmatter_dict_or_None, body). Raises yaml.YAMLError on bad YAML."""
     if not text.startswith("---"):
         return None, text
-    m = re.match(r"^---\n(.*?)\n---\n?(.*)$", text, re.DOTALL)
+    m = FRONTMATTER_RE.match(text)
     if not m:
         return None, text
     return yaml.safe_load(m.group(1)) or {}, m.group(2)
+
+
+def frontmatter_block(text: str) -> str | None:
+    """Return the raw YAML frontmatter text (between the --- fences), or None. Used to
+    enforce rules on the source text before YAML strips comments (see
+    check_source_quoting)."""
+    if not text.startswith("---"):
+        return None
+    m = FRONTMATTER_RE.match(text)
+    return m.group(1) if m else None
 
 
 def link_destination(raw: str) -> str:
@@ -156,6 +171,50 @@ def strip_code(text: str) -> str:
                 fence = None
             out.append("")
     return "\n".join(out)
+
+
+def check_source_quoting(rel, raw_fm, errors):
+    """Enforce the SPEC 'source' quoting rule where YAML's comment stripping would
+    otherwise hide a violation.
+
+    In block style an unquoted element with an inline '#' is silently truncated:
+        source:
+          - issue #445      -> parses to "issue"; "#445" is dropped as a comment
+    No parse error fires, so the provenance is lost with the build still green. Flow
+    style is self-enforcing (the '#' comments out the closing ']', a parse error
+    caught earlier), so this scan targets block-style items. The trigger is YAML's
+    own comment rule: a '#' preceded by whitespace, with content before it. A bare
+    '#'-first item parses to null (caught by check_lists); 'issue#445' (no space) is a
+    valid string and left alone; a colon-space makes the item a mapping (also caught
+    by check_lists)."""
+    if not raw_fm:
+        return
+    in_block = False
+    source_indent = 0
+    for line in raw_fm.splitlines():
+        m = re.match(r"^(\s*)source\s*:(.*)$", line)
+        if m:
+            rest = m.group(2).strip()
+            # block style only when nothing (or just a comment) follows the colon; an
+            # inline flow list or scalar is handled by the YAML parse step.
+            in_block = rest == "" or rest.startswith("#")
+            source_indent = len(m.group(1))
+            continue
+        if not in_block:
+            continue
+        stripped = line.strip()
+        if stripped == "":
+            continue
+        indent = len(line) - len(line.lstrip())
+        if not stripped.startswith("-") and indent <= source_indent:
+            in_block = False  # dedented to a sibling key -> the source block ended
+            continue
+        if stripped.startswith("-"):
+            value = stripped[1:].strip()
+            if value[:1] not in ("'", '"') and re.search(r"\S\s+#", value):
+                errors.append(
+                    f"{rel}: 'source' element {value!r} has an unquoted '#' that YAML "
+                    f"reads as a comment, dropping the rest — quote it: - \"{value}\"")
 
 
 def check_dates(rel, fm, errors):
@@ -295,6 +354,7 @@ def main() -> int:
 
         check_lists(rel, fm, errors)
         check_dates(rel, fm, errors)
+        check_source_quoting(rel, frontmatter_block(text), errors)
 
     # Link resolution: every internal link to a .md file must resolve to a file
     # that exists inside the bundle. A link escaping the bundle root or pointing at

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -14,6 +14,8 @@ Checks:
      type, title, description, source, verified, timestamp, tags.
        - type     is one of the spec type vocab.
        - source   is a non-empty list of non-empty strings (provenance pointers).
+                  An unquoted '#' in a block-style element (which YAML would silently
+                  drop as a comment, losing the rest) is rejected — quote it.
        - tags     is a list.
        - verified, timestamp parse as ISO dates (YYYY-MM-DD).
   3. Reserved filenames (index.md, log.md) name no concept and carry no
@@ -96,14 +98,27 @@ SECRET_PATTERNS = [
 ]
 
 
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n?(.*)$", re.DOTALL)
+
+
 def parse_frontmatter(text: str):
     """Return (frontmatter_dict_or_None, body). Raises yaml.YAMLError on bad YAML."""
     if not text.startswith("---"):
         return None, text
-    m = re.match(r"^---\n(.*?)\n---\n?(.*)$", text, re.DOTALL)
+    m = FRONTMATTER_RE.match(text)
     if not m:
         return None, text
     return yaml.safe_load(m.group(1)) or {}, m.group(2)
+
+
+def frontmatter_block(text: str) -> str | None:
+    """Return the raw YAML frontmatter text (between the --- fences), or None. Used to
+    enforce rules on the source text before YAML strips comments (see
+    check_source_quoting)."""
+    if not text.startswith("---"):
+        return None
+    m = FRONTMATTER_RE.match(text)
+    return m.group(1) if m else None
 
 
 def link_destination(raw: str) -> str:
@@ -156,6 +171,50 @@ def strip_code(text: str) -> str:
                 fence = None
             out.append("")
     return "\n".join(out)
+
+
+def check_source_quoting(rel, raw_fm, errors):
+    """Enforce the SPEC 'source' quoting rule where YAML's comment stripping would
+    otherwise hide a violation.
+
+    In block style an unquoted element with an inline '#' is silently truncated:
+        source:
+          - issue #445      -> parses to "issue"; "#445" is dropped as a comment
+    No parse error fires, so the provenance is lost with the build still green. Flow
+    style is self-enforcing (the '#' comments out the closing ']', a parse error
+    caught earlier), so this scan targets block-style items. The trigger is YAML's
+    own comment rule: a '#' preceded by whitespace, with content before it. A bare
+    '#'-first item parses to null (caught by check_lists); 'issue#445' (no space) is a
+    valid string and left alone; a colon-space makes the item a mapping (also caught
+    by check_lists)."""
+    if not raw_fm:
+        return
+    in_block = False
+    source_indent = 0
+    for line in raw_fm.splitlines():
+        m = re.match(r"^(\s*)source\s*:(.*)$", line)
+        if m:
+            rest = m.group(2).strip()
+            # block style only when nothing (or just a comment) follows the colon; an
+            # inline flow list or scalar is handled by the YAML parse step.
+            in_block = rest == "" or rest.startswith("#")
+            source_indent = len(m.group(1))
+            continue
+        if not in_block:
+            continue
+        stripped = line.strip()
+        if stripped == "":
+            continue
+        indent = len(line) - len(line.lstrip())
+        if not stripped.startswith("-") and indent <= source_indent:
+            in_block = False  # dedented to a sibling key -> the source block ended
+            continue
+        if stripped.startswith("-"):
+            value = stripped[1:].strip()
+            if value[:1] not in ("'", '"') and re.search(r"\S\s+#", value):
+                errors.append(
+                    f"{rel}: 'source' element {value!r} has an unquoted '#' that YAML "
+                    f"reads as a comment, dropping the rest — quote it: - \"{value}\"")
 
 
 def check_dates(rel, fm, errors):
@@ -295,6 +354,7 @@ def main() -> int:
 
         check_lists(rel, fm, errors)
         check_dates(rel, fm, errors)
+        check_source_quoting(rel, frontmatter_block(text), errors)
 
     # Link resolution: every internal link to a .md file must resolve to a file
     # that exists inside the bundle. A link escaping the bundle root or pointing at

--- a/okf-wiki/spec/SPEC.md
+++ b/okf-wiki/spec/SPEC.md
@@ -61,9 +61,11 @@ rejects an unquoted source. Always quote them:
 source: ["README.md", "issue #445", "git log 9c2e510"]
 ```
 
-The validator enforces this through the YAML parse step: an unquoted element carrying a
-significant character fails to parse and is reported as an error. An element that is already
-quote-safe (a bare filename) parses fine and is accepted — quote everything anyway so you
+The validator enforces this in both list styles. In flow style (`["a", b]`) an unquoted
+element carrying a significant character fails to parse and is reported as an error. In block
+style (`- a`) YAML would silently drop an inline `#` comment and pass, so the validator also
+scans the raw source text and rejects an unquoted element with a `#`. An element that is
+already quote-safe (a bare filename) is accepted either way — quote everything anyway so you
 never have to judge which is which.
 
 `tags` and `description` follow a lighter rule: quote an element only when it contains a

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -1013,3 +1013,60 @@ def test_example_validator_matches_canonical():
     assert (SKILL / "example" / "scripts" / "validate.py").read_text(encoding="utf-8") == \
            (SKILL / "scripts" / "validate.py").read_text(encoding="utf-8"), \
            "okf-wiki/example/scripts/validate.py drifted from scripts/validate.py — re-sync the copy"
+
+
+# --- source-quoting enforcement in block style (#155) -----------------------
+
+def _concept_with_source(source_yaml):
+    # a valid concept whose `source:` field is the given raw YAML (flow or block).
+    return (
+        "---\n"
+        "type: Process\n"
+        "title: good\n"
+        "description: a good concept\n"
+        f"{source_yaml}\n"
+        "verified: 2026-06-23\n"
+        "timestamp: 2026-06-23\n"
+        'tags: ["x"]\n'
+        "---\n# good\n"
+    )
+
+
+def test_source_block_unquoted_hash_fails(tmp_path):
+    # the bug: block-style `- issue #445` parses to "issue" (YAML drops "#445" as a
+    # comment) with no error, silently losing provenance. Must fail explicitly.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_source('source:\n  - "README.md"\n  - issue #445'))
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "source" in out and "#" in out
+
+
+def test_source_block_quoted_hash_passes(tmp_path):
+    # quoting the element protects it — this is the documented fix, so it must pass.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_source('source:\n  - "README.md"\n  - "issue #445"'))
+    rc, out = validate(b)
+    assert rc == 0, out
+
+
+def test_source_block_hash_no_space_ok(tmp_path):
+    # `issue#445` (no space before #) is NOT a YAML comment — it stays intact, so the
+    # guard must not false-positive on it.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_source("source:\n  - issue#445"))
+    rc, out = validate(b)
+    assert rc == 0, out
+
+
+def test_source_flow_unquoted_hash_still_fails(tmp_path):
+    # flow style was already enforced (the '#' comments out the closing ']' -> parse
+    # error). Guard against regressing that while fixing block style.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_source('source: ["README.md", issue #445]'))
+    rc, out = validate(b)
+    assert rc == 1, out


### PR DESCRIPTION
Closes #155. Makes the SPEC's "hard" source-quoting rule actually hard in both list styles.

## Bug
The SPEC says every `source` element with a YAML-significant character must be quoted, and calls it a hard rule. It was only enforced in **flow** style, where an unquoted significant char breaks the parse:

```yaml
source: ["README.md", issue #445]   # '#' comments out the ']' -> parse error -> caught
```

**Block** style had no tripwire — YAML drops the `#445` as a trailing comment and yields a valid string:

```yaml
source:
  - issue #445                       # parses to "issue"; "#445" silently dropped, build green
```

The provenance just vanished, with no validation error.

## Fix
Scan the raw frontmatter (before YAML strips comments) for block-style `source` items and reject an unquoted element carrying an inline `#`. The trigger is YAML's own comment rule — a `#` preceded by whitespace with content before it (`\S\s+#`) — so:

- `- issue #445` → **error**, with a fix hint (`quote it: - "issue #445"`)
- `- "issue #445"` → passes (quoting protects it)
- `- issue#445` (no space) → passes (not a YAML comment; the string stays intact)
- `- # whole comment` (null element) and `- key: val` (mapping) → still caught by the existing list checks, not double-reported

Flow-style enforcement is unchanged.

## Scope note (bug-class sweep)
`source` is the only field the SPEC marks as a *hard* quoting rule. `tags`/`description` are deliberately lighter (quote only when a character demands it), so a dropped `#` in a block-style tag isn't a contract violation the way a lost source pointer is. The fix stops at the one field the spec marks hard.

## Tests
Test-first (per the repo bug workflow): added 4 tests — unquoted-hash block fails, quoted passes, no-space passes, flow-style still fails. 83 passing (was 79). SPEC + validator docstring updated; `example/` copies synced (the #162 drift guard enforces that).

Closes #155