### PR TITLE
okf-wiki: reject uppercase-extension markdown files (#150 sub-item 2)

### DIFF
--- a/okf-wiki/example/SPEC.md
+++ b/okf-wiki/example/SPEC.md
@@ -29,6 +29,9 @@ with an `index.md`. Larger bundles group concepts into subdirectories by subject
 - `log.md` (optional, per directory): dated entries, newest first, no frontmatter.
 - Concept files: one concept each, frontmatter required (below).
 - Reserved filenames: `index.md`, `log.md`.
+- All markdown files use a lowercase `.md` extension. A non-lowercase extension (`.MD`,
+  `.Md`) is non-conforming and rejected — the validator discovers files case-insensitively
+  so such a file cannot escape validation, and link checks match `.md` case-insensitively too.
 
 The validator enforces the frontmatter rules here — reserved files carry no frontmatter, and
 only the bundle-root `index.md` carries `okf_version` (and nothing else). The index/log body

--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -257,10 +257,12 @@ def main() -> int:
         print(f"FAIL: bundle path is not a directory: {bundle}")
         return 1
 
-    # rglob("*.md") also matches a directory named like "archive.md"; reading one
-    # raises IsADirectoryError. Iterate only real files, and report any *.md path
-    # that is a directory as a clean validation failure rather than crashing.
-    md_entries = sorted(bundle.rglob("*.md"))
+    # Discover markdown files case-insensitively (suffix .lower() == ".md") so a
+    # non-conforming Foo.MD cannot hide from validation behind a case-sensitive glob;
+    # it is found here and rejected below. rglob("*") also yields a directory named
+    # like "archive.md"; reading one raises IsADirectoryError, so keep only real files
+    # and report any .md-suffixed path that is a directory rather than crashing.
+    md_entries = sorted(p for p in bundle.rglob("*") if p.suffix.lower() == ".md")
     md_files = [p for p in md_entries if p.is_file()]
     errors: list[str] = [
         f"{p.relative_to(bundle)}: a '*.md' path must be a file, not a directory"
@@ -281,12 +283,25 @@ def main() -> int:
         # check, reporting valid frontmatter as missing.
         text = f.read_text(encoding="utf-8-sig")
 
-        # secret scan on every file, including index.md.
+        # secret scan on every file, including index.md and a non-conforming Foo.MD
+        # (a leak is a leak regardless of extension — scan before rejecting below).
         for label, pat in SECRET_PATTERNS:
             if pat.search(text):
                 errors.append(
                     f"{rel}: possible secret leak ({label}) — remove the value, "
                     f"document the key name/path instead")
+
+        # OKF concept and index files use a lowercase .md extension. A non-lowercase
+        # extension (Foo.MD) is non-conforming: it was discovered case-insensitively
+        # above so its content is still secret-scanned, then rejected here instead of
+        # validated as a concept. With the case-insensitive link check below, this
+        # closes the bypass where an uppercase-extension file and links to it both
+        # escaped validation.
+        if f.suffix != ".md":
+            errors.append(
+                f"{rel}: non-conforming filename — OKF concept files use a lowercase "
+                f"'.md' extension, found {f.suffix!r}; rename it to .md")
+            continue
 
         try:
             fm, body = parse_frontmatter(text)
@@ -362,6 +377,8 @@ def main() -> int:
     # self-contained tree. To validate federated content, assemble the bundles into
     # a single tree and point --bundle at that root.
     for f in md_files:
+        if f.suffix != ".md":
+            continue  # non-conforming file already reported; don't pile on link errors
         text = strip_code(f.read_text(encoding="utf-8-sig"))
         for m in WIKILINK_RE.finditer(text):
             slug = m.group(1).strip()
@@ -379,11 +396,11 @@ def main() -> int:
             # resolved as a local path (which would falsely fail as escaping/dangling).
             if low.startswith(("http://", "https://", "mailto:", "#", "tel:")):
                 continue
-            # OKF concept files are lowercase .md (discovery uses bundle.rglob("*.md")).
-            # Match .md case-sensitively so the link check and file discovery agree: a
-            # link to a .MD file is out of scope, not a validated internal link -- it can
-            # never resolve to an uppercase-extension file that discovery never scanned.
-            if ".md" not in target:
+            # Match .md case-insensitively, the same way discovery now does, so a link
+            # to an uppercase-extension file (ghost.MD) is checked for dangling/escape
+            # instead of silently skipped. If such a target file exists it is separately
+            # rejected as non-conforming above, so the two checks stay in agreement.
+            if ".md" not in low:
                 continue
             if target.startswith("/"):
                 errors.append(f"{f.relative_to(bundle)}: root-relative link not allowed "

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -257,10 +257,12 @@ def main() -> int:
         print(f"FAIL: bundle path is not a directory: {bundle}")
         return 1
 
-    # rglob("*.md") also matches a directory named like "archive.md"; reading one
-    # raises IsADirectoryError. Iterate only real files, and report any *.md path
-    # that is a directory as a clean validation failure rather than crashing.
-    md_entries = sorted(bundle.rglob("*.md"))
+    # Discover markdown files case-insensitively (suffix .lower() == ".md") so a
+    # non-conforming Foo.MD cannot hide from validation behind a case-sensitive glob;
+    # it is found here and rejected below. rglob("*") also yields a directory named
+    # like "archive.md"; reading one raises IsADirectoryError, so keep only real files
+    # and report any .md-suffixed path that is a directory rather than crashing.
+    md_entries = sorted(p for p in bundle.rglob("*") if p.suffix.lower() == ".md")
     md_files = [p for p in md_entries if p.is_file()]
     errors: list[str] = [
         f"{p.relative_to(bundle)}: a '*.md' path must be a file, not a directory"
@@ -281,12 +283,25 @@ def main() -> int:
         # check, reporting valid frontmatter as missing.
         text = f.read_text(encoding="utf-8-sig")
 
-        # secret scan on every file, including index.md.
+        # secret scan on every file, including index.md and a non-conforming Foo.MD
+        # (a leak is a leak regardless of extension — scan before rejecting below).
         for label, pat in SECRET_PATTERNS:
             if pat.search(text):
                 errors.append(
                     f"{rel}: possible secret leak ({label}) — remove the value, "
                     f"document the key name/path instead")
+
+        # OKF concept and index files use a lowercase .md extension. A non-lowercase
+        # extension (Foo.MD) is non-conforming: it was discovered case-insensitively
+        # above so its content is still secret-scanned, then rejected here instead of
+        # validated as a concept. With the case-insensitive link check below, this
+        # closes the bypass where an uppercase-extension file and links to it both
+        # escaped validation.
+        if f.suffix != ".md":
+            errors.append(
+                f"{rel}: non-conforming filename — OKF concept files use a lowercase "
+                f"'.md' extension, found {f.suffix!r}; rename it to .md")
+            continue
 
         try:
             fm, body = parse_frontmatter(text)
@@ -362,6 +377,8 @@ def main() -> int:
     # self-contained tree. To validate federated content, assemble the bundles into
     # a single tree and point --bundle at that root.
     for f in md_files:
+        if f.suffix != ".md":
+            continue  # non-conforming file already reported; don't pile on link errors
         text = strip_code(f.read_text(encoding="utf-8-sig"))
         for m in WIKILINK_RE.finditer(text):
             slug = m.group(1).strip()
@@ -379,11 +396,11 @@ def main() -> int:
             # resolved as a local path (which would falsely fail as escaping/dangling).
             if low.startswith(("http://", "https://", "mailto:", "#", "tel:")):
                 continue
-            # OKF concept files are lowercase .md (discovery uses bundle.rglob("*.md")).
-            # Match .md case-sensitively so the link check and file discovery agree: a
-            # link to a .MD file is out of scope, not a validated internal link -- it can
-            # never resolve to an uppercase-extension file that discovery never scanned.
-            if ".md" not in target:
+            # Match .md case-insensitively, the same way discovery now does, so a link
+            # to an uppercase-extension file (ghost.MD) is checked for dangling/escape
+            # instead of silently skipped. If such a target file exists it is separately
+            # rejected as non-conforming above, so the two checks stay in agreement.
+            if ".md" not in low:
                 continue
             if target.startswith("/"):
                 errors.append(f"{f.relative_to(bundle)}: root-relative link not allowed "

--- a/okf-wiki/spec/SPEC.md
+++ b/okf-wiki/spec/SPEC.md
@@ -29,6 +29,9 @@ with an `index.md`. Larger bundles group concepts into subdirectories by subject
 - `log.md` (optional, per directory): dated entries, newest first, no frontmatter.
 - Concept files: one concept each, frontmatter required (below).
 - Reserved filenames: `index.md`, `log.md`.
+- All markdown files use a lowercase `.md` extension. A non-lowercase extension (`.MD`,
+  `.Md`) is non-conforming and rejected — the validator discovers files case-insensitively
+  so such a file cannot escape validation, and link checks match `.md` case-insensitively too.
 
 The validator enforces the frontmatter rules here — reserved files carry no frontmatter, and
 only the bundle-root `index.md` carries `okf_version` (and nothing else). The index/log body

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -495,16 +495,18 @@ def test_github_pat_secret_detected(tmp_path):
     assert rc == 1 and "secret leak" in out
 
 
-def test_uppercase_md_extension_out_of_scope(tmp_path):
-    # OKF concept files are lowercase .md (discovery uses *.md). A link to a .MD
-    # file is out of scope, not a validated internal link -- so it must NOT resolve
-    # (which would let .MD content bypass frontmatter/secret checks) and must NOT
-    # false-fail as dangling. It is simply skipped, like a link to a .txt file.
+def test_link_to_existing_uppercase_md_fails(tmp_path):
+    # the case the prior case-sensitive design worried about: a link to an existing
+    # Foo.MD used to "resolve" as valid while discovery never scanned that file. Now
+    # discovery finds Target.MD and rejects it as non-conforming, so a bundle that
+    # contains it fails -- the file check and the link check stay in agreement.
     scaffold(tmp_path / "kb", "--no-validate")
     b = tmp_path / "kb" / "bundle"
-    write_concept(b, GOOD.rstrip() + "\nSee [x](NOPE.MD).\n")
+    write_concept(b, GOOD, name="concepts/Target.MD")
+    write_concept(b, GOOD.rstrip() + "\n\nSee [target](Target.MD).\n", name="concepts/c.md")
     rc, out = validate(b)
-    assert rc == 0, out
+    assert rc == 1, out
+    assert "Target.MD" in out
 
 
 def test_uppercase_scheme_link_not_flagged(tmp_path):
@@ -1070,3 +1072,38 @@ def test_source_flow_unquoted_hash_still_fails(tmp_path):
     write_concept(b, _concept_with_source('source: ["README.md", issue #445]'))
     rc, out = validate(b)
     assert rc == 1, out
+
+
+# --- uppercase .md extension handling (#150 sub-item 2) ----------------------
+
+def test_uppercase_md_file_rejected(tmp_path):
+    # a Foo.MD file escaped the case-sensitive discovery (rglob("*.md")) entirely, so
+    # its content was never validated. Discover it case-insensitively and reject the
+    # non-conforming extension.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD, name="concepts/Foo.MD")
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "Foo.MD" in out and ("extension" in out or "non-conforming" in out)
+
+
+def test_mixedcase_md_file_rejected(tmp_path):
+    # same rule for any non-lowercase extension, e.g. .Md
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD, name="concepts/Bar.Md")
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "Bar.Md" in out
+
+
+def test_dangling_uppercase_md_link_caught(tmp_path):
+    # the link checker matched .md case-sensitively, so [x](ghost.MD) was skipped and a
+    # dangling uppercase-extension link passed silently. It must now be caught.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD.rstrip() + "\n\nSee [the ghost](ghost.MD).\n")
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "ghost.MD" in out


### PR DESCRIPTION
Implements **sub-item 2** of #150. Does **not** close #150 — the entropy-based secret-detection half (sub-item 1) stays open as tracked future work.

## Bug
File discovery used case-sensitive `rglob("*.md")` and the link checker matched `.md` case-sensitively to agree with it. On a case-sensitive filesystem that left a bypass:
- A `Foo.MD` file was never discovered, so its frontmatter/content was never validated.
- A link `[x](ghost.MD)` was skipped, so a dangling uppercase-extension link passed silently.

The issue flagged the trap: making *only* the link check case-insensitive re-breaks the design — a link to an existing `Existing.MD` would "resolve" as valid against a file discovery never scanned.

## Fix (both halves moved together)
- **Discovery** is now case-insensitive (`p.suffix.lower() == ".md"`), so a `.MD` file can't hide.
- A discovered file whose extension isn't exactly lowercase `.md` is **rejected as non-conforming** — the answer to "is `.MD` a valid concept?" is no. The secret scan still runs on it first (a leak is a leak regardless of extension).
- The **link check** matches `.md` case-insensitively, so:
  - `[x](ghost.MD)` (missing) → caught as dangling
  - `[x](Target.MD)` (exists) → the bundle fails via `Target.MD`'s own non-conforming error
  - the file check and link check stay in agreement instead of disagreeing

## Tests
Test-first (4 cases): `.MD` file rejected, `.Md` file rejected, dangling `.MD` link caught, link to an existing `.MD` file fails. Repurposed the old `test_uppercase_md_extension_out_of_scope` (which pinned the prior skip-it behavior) into `test_link_to_existing_uppercase_md_fails`. 86 passing (was 83). SPEC + validator docstring document the rule; `example/` copies synced.

Part of #150