### PR TITLE
Harden okf-wiki source-quoting check against silent provenance loss

### DIFF
--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -173,133 +173,58 @@ def strip_code(text: str) -> str:
     return "\n".join(out)
 
 
-SOURCE_KEY_RE = re.compile(r"^source\s*:(.*)$")  # matched on a de-indented line
+def _plain_scalar_dropped_comment(node, raw_fm):
+    """True if a YAML comment directly truncated this scalar's provenance.
 
-
-def _base_indent(lines):
-    """Indentation of the frontmatter's top-level keys — the indent of its first non-blank
-    line. Frontmatter is normally at column 0, but a consistently indented mapping is still
-    valid YAML; anchoring to this indent finds the real top-level `source` while skipping a
-    deeper, nested `source:` under another key."""
-    for ln in lines:
-        if ln.strip():
-            return len(ln) - len(ln.lstrip())
-    return 0
-
-
-def _source_region_loses_data(text):
-    """True if the raw text of a top-level source value would silently drop provenance to
-    a YAML comment. `text` is the source value — the part after `source:` plus any
-    continuation lines, joined by newlines — scanned as one unit so quote state and flow
-    nesting carry across line breaks.
-
-    A '#' starts a comment and YAML discards the rest of the line, but that loses data only
-    when the '#' interrupts an open unquoted scalar. A '#' inside a quoted string, or one
-    with only whitespace since the last completed value, drops nothing. Quote handling
-    follows YAML: '' is a literal apostrophe inside '...', and a backslash escapes inside
-    "...". A quote opens a string only at a value boundary, so a mid-scalar apostrophe
-    (`Joe's`) stays literal. Flow punctuation (',' '[' ']' '{' '}') is structure only
-    inside a flow collection — in a block scalar it is literal text, so a comment after it
-    still truncates."""
-    i, n = 0, len(text)
-    in_single = in_double = False
-    flow_depth = 0
-    pending = False        # an unquoted scalar is open since the last value boundary
-    at_line_start = True   # before any non-space char on the current physical line
-    while i < n:
-        ch = text[i]
-        if in_single:
-            if ch == "'":
-                if i + 1 < n and text[i + 1] == "'":
-                    i += 2          # '' escapes a literal apostrophe — stay in the string
-                    continue
-                in_single = False
-                pending = False     # the quoted scalar is complete
-            i += 1
-            continue
-        if in_double:
-            if ch == "\\":
-                i += 2              # backslash escapes the next char inside "..."
-                continue
-            if ch == '"':
-                in_double = False
-                pending = False
-            i += 1
-            continue
-        if ch == "\n":
-            if flow_depth == 0:
-                pending = False     # a block line break ends the current element
-            at_line_start = True
-            i += 1
-            continue
-        if ch in (" ", "\t"):
-            i += 1
-            continue
-        if at_line_start and flow_depth == 0 and ch == "-" and (
-                i + 1 >= n or text[i + 1] in (" ", "\t", "\n")):
-            pending = False         # block sequence-entry indicator, not content
-            i += 1
-            continue
-        at_line_start = False
-        if ch == "#" and i > 0 and text[i - 1] in (" ", "\t", "\n"):
-            return pending          # comment: data lost only if a scalar was open
-        if ch in ("'", '"') and not pending:
-            in_single = ch == "'"
-            in_double = ch == '"'
-            i += 1
-            continue
-        if ch in ("[", "{") and not pending:
-            flow_depth += 1         # opens flow only at a value boundary
-            i += 1
-            continue
-        if ch in ("]", "}") and flow_depth > 0:
-            flow_depth -= 1
-            pending = False
-            i += 1
-            continue
-        if ch == "," and flow_depth > 0:
-            pending = False         # flow separator (literal in a block scalar)
-            i += 1
-            continue
-        pending = True              # ordinary scalar content (incl. literal , [ ] in block)
-        i += 1
-    return False
+    `node` is a scalar node from the parsed frontmatter and `raw_fm` the raw text it was
+    parsed from. Only a plain (unquoted) scalar can lose data: a quoted or block scalar
+    (node.style set to ', ", |, or >) keeps a '#' as string content. For a plain scalar,
+    YAML stops the value at the space before an inline '#', so the comment shows up in the
+    raw text immediately after the scalar's end mark, on the same line. That is exactly the
+    silent-truncation case (`issue #445` -> "issue") the SPEC quoting rule guards against;
+    `issue#445` (no space) is one scalar and a '#' on a later line is a standalone comment,
+    and neither trips this."""
+    if node.style is not None:
+        return False
+    j = node.end_mark.index
+    while j < len(raw_fm) and raw_fm[j] in (" ", "\t"):
+        j += 1
+    return j < len(raw_fm) and raw_fm[j] == "#"
 
 
 def check_source_quoting(rel, raw_fm, errors):
-    """Enforce the SPEC 'source' quoting rule on the raw frontmatter, where YAML's comment
-    stripping would otherwise silently drop part of a provenance pointer.
+    """Enforce the SPEC 'source' quoting rule, where YAML's comment stripping would
+    otherwise silently drop part of a provenance pointer.
 
     Quoting source elements is a hard SPEC rule, but YAML drops an unquoted inline '#'
     comment with no error: `- issue #445` parses to "issue", losing "#445". The parsed
-    value cannot reveal the loss, so this scans the raw text of each top-level `source`
-    value (see _source_region_loses_data) for an unquoted, content-truncating '#'. It
-    covers every list shape — block items, single- and multi-line flow lists, wrapped
-    scalars — and is quote- and flow-aware so it neither misses a real loss nor rejects a
-    correctly quoted pointer. It is scoped to the top-level `source` key only (a nested
-    `source:` under other metadata is not the OKF provenance list), and scans every
-    top-level occurrence, since YAML keeps the last of duplicate keys. A bare '#'-first
-    item (null) and a colon-space mapping item are left to check_lists."""
+    value alone cannot reveal the loss, so this re-parses the frontmatter into its node
+    tree (which carries source position marks) and, for every top-level `source` element,
+    checks whether a comment directly truncated a plain scalar (see
+    _plain_scalar_dropped_comment). Delegating the lexing to YAML covers every shape —
+    block items, single- and multi-line flow lists, wrapped scalars, quoted strings with
+    escapes, anchors/tags, and block scalars — without re-implementing the parser. It is
+    scoped to the top-level `source` key only (a nested `source:` under other metadata is
+    not the OKF provenance list) and inspects every top-level occurrence, since YAML keeps
+    the last of duplicate keys. A real parse error is reported by the schema check."""
     if not raw_fm:
         return
-    lines = raw_fm.splitlines()
-    base = _base_indent(lines)
-    for i, ln in enumerate(lines):
-        indent = len(ln) - len(ln.lstrip())
-        m = SOURCE_KEY_RE.match(ln[indent:])
-        if indent != base or not m:
-            continue  # not a top-level source key (deeper => nested under another key)
-        # The source value region: text after `source:` on the key line, plus following
-        # blank, deeper-indented, or block-item ('-') lines, up to the next top-level key.
-        parts = [m.group(1)]
-        for nxt in lines[i + 1:]:
-            nstrip = nxt.strip()
-            nindent = len(nxt) - len(nxt.lstrip())
-            if nstrip == "" or nindent > base or nstrip.startswith("-"):
-                parts.append(nxt)
-            else:
-                break
-        if _source_region_loses_data("\n".join(parts)):
+    try:
+        root = yaml.compose(raw_fm, Loader=yaml.SafeLoader)
+    except yaml.YAMLError:
+        return
+    if not isinstance(root, yaml.MappingNode):
+        return
+    for key_node, val_node in root.value:
+        if not (isinstance(key_node, yaml.ScalarNode) and key_node.value == "source"):
+            continue
+        if isinstance(val_node, yaml.SequenceNode):
+            scalars = [n for n in val_node.value if isinstance(n, yaml.ScalarNode)]
+        elif isinstance(val_node, yaml.ScalarNode):
+            scalars = [val_node]
+        else:
+            scalars = []
+        if any(_plain_scalar_dropped_comment(n, raw_fm) for n in scalars):
             errors.append(
                 f"{rel}: a top-level 'source' element has an unquoted '#' that YAML "
                 f"reads as a comment, dropping the rest of the pointer — quote each "

--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -173,48 +173,106 @@ def strip_code(text: str) -> str:
     return "\n".join(out)
 
 
-def check_source_quoting(rel, raw_fm, errors):
-    """Enforce the SPEC 'source' quoting rule where YAML's comment stripping would
-    otherwise hide a violation.
+SOURCE_KEY_RE = re.compile(r"^source\s*:(.*)$")  # top-level (column 0) only
 
-    In block style an unquoted element with an inline '#' is silently truncated:
-        source:
-          - issue #445      -> parses to "issue"; "#445" is dropped as a comment
-    No parse error fires, so the provenance is lost with the build still green. Flow
-    style is self-enforcing (the '#' comments out the closing ']', a parse error
-    caught earlier), so this scan targets block-style items. The trigger is YAML's
-    own comment rule: a '#' preceded by whitespace, with content before it. A bare
-    '#'-first item parses to null (caught by check_lists); 'issue#445' (no space) is a
-    valid string and left alone; a colon-space makes the item a mapping (also caught
-    by check_lists)."""
+
+def _strip_source_structure(line, is_key_line):
+    """Reduce a source-region line to its raw element text: drop indentation and YAML
+    structure — the `source:` key on the first line, leading block '-' markers, and a
+    leading flow '['. What remains is scanned for an inline comment."""
+    s = SOURCE_KEY_RE.match(line).group(1) if is_key_line else line
+    s = s.strip()
+    while s.startswith("-"):
+        s = s[1:].lstrip()
+    return s.lstrip("[")
+
+
+# A YAML inline comment drops no data when it follows a value that already closed -- a
+# quote, a flow bracket/brace, or a separator. It truncates data only when it interrupts
+# an unquoted scalar, where the char before it is ordinary content.
+_VALUE_COMPLETE = {'"', "'", "]", "}", "[", "{", ","}
+# A quote opens a quoted scalar only at a value boundary -- the start of the value or
+# right after a flow opener/separator. Elsewhere (e.g. the apostrophe in "Joe's") it is a
+# literal character inside a plain scalar.
+_SCALAR_OPENERS = {"[", "{", ","}
+
+
+def _has_truncating_comment(text):
+    """True if `text` holds a YAML inline comment that truncates content: a whitespace-
+    preceded, unquoted '#' that interrupts an unquoted scalar. Quote-aware (a '#' inside
+    '...'/"..." is protected) and structure-aware: a comment after a completed value
+    (`["a"] # why`, `- "a" # note`) or a whole-line comment drops no data and is not
+    flagged. A quote is only treated as a string delimiter at a value boundary, so a
+    plain scalar with an inner apostrophe (`Joe's issue #445`) is still scanned and its
+    truncating '#' caught. The first such '#' decides the line — in YAML everything after
+    it is the comment."""
+    in_single = in_double = False
+    seen_content = False
+    last_nonspace = ""
+    prev = ""
+    for ch in text:
+        if in_single:
+            if ch == "'":
+                in_single = False
+            last_nonspace = ch
+        elif in_double:
+            if ch == '"':
+                in_double = False
+            last_nonspace = ch
+        elif ch == "#" and prev in (" ", "\t"):
+            # YAML comment start. Data is lost only if it cut into an unquoted scalar.
+            return seen_content and last_nonspace not in _VALUE_COMPLETE
+        elif ch in ("'", '"') and (not seen_content or last_nonspace in _SCALAR_OPENERS):
+            if ch == "'":
+                in_single = True
+            else:
+                in_double = True
+            seen_content = True
+            last_nonspace = ch
+        elif not ch.isspace():
+            seen_content = True
+            last_nonspace = ch
+        prev = ch
+    return False
+
+
+def check_source_quoting(rel, raw_fm, errors):
+    """Enforce the SPEC 'source' quoting rule on the raw frontmatter, where YAML's
+    comment stripping would otherwise silently drop part of a provenance pointer.
+
+    Quoting source elements is a hard SPEC rule, but YAML drops an unquoted inline '#'
+    comment with no error: `- issue #445` parses to "issue", losing "#445". The parsed
+    value cannot reveal the loss, so this scans the raw text of the top-level `source`
+    value for an unquoted, content-truncating '#'. It covers every list shape — block
+    items, single- and multi-line flow lists, and wrapped plain scalars — because in all
+    of them such a '#' means dropped data. It is quote-aware (a '#' inside quotes is
+    fine) and scoped to the top-level `source` key only: a nested `source:` inside other
+    allowed metadata is not the OKF provenance list and must not trip the check. Every
+    top-level `source` occurrence is scanned, not just the first: YAML keeps the last of
+    duplicate keys, so a later one is the value that actually parsed. A bare '#'-first
+    item (null) and a colon-space mapping item are left to check_lists."""
     if not raw_fm:
         return
-    in_block = False
-    source_indent = 0
-    for line in raw_fm.splitlines():
-        m = re.match(r"^(\s*)source\s*:(.*)$", line)
-        if m:
-            rest = m.group(2).strip()
-            # block style only when nothing (or just a comment) follows the colon; an
-            # inline flow list or scalar is handled by the YAML parse step.
-            in_block = rest == "" or rest.startswith("#")
-            source_indent = len(m.group(1))
-            continue
-        if not in_block:
-            continue
-        stripped = line.strip()
-        if stripped == "":
-            continue
-        indent = len(line) - len(line.lstrip())
-        if not stripped.startswith("-") and indent <= source_indent:
-            in_block = False  # dedented to a sibling key -> the source block ended
-            continue
-        if stripped.startswith("-"):
-            value = stripped[1:].strip()
-            if value[:1] not in ("'", '"') and re.search(r"\S\s+#", value):
+    lines = raw_fm.splitlines()
+    starts = [i for i, ln in enumerate(lines) if SOURCE_KEY_RE.match(ln)]
+    # absence of source is reported by the required-key check; nothing to scan here
+    for start in starts:
+        # The source value region: the key line plus following blank, indented, or
+        # block-item ('-') lines, up to the next top-level key. This spans block lists,
+        # multi-line flow lists, and wrapped scalars without re-parsing YAML.
+        region = [lines[start]]
+        for ln in lines[start + 1:]:
+            if ln.strip() == "" or ln[:1].isspace() or ln.lstrip().startswith("-"):
+                region.append(ln)
+            else:
+                break
+        for idx, ln in enumerate(region):
+            if _has_truncating_comment(_strip_source_structure(ln, idx == 0)):
                 errors.append(
-                    f"{rel}: 'source' element {value!r} has an unquoted '#' that YAML "
-                    f"reads as a comment, dropping the rest — quote it: - \"{value}\"")
+                    f"{rel}: a top-level 'source' element has an unquoted '#' that YAML "
+                    f"reads as a comment, dropping the rest of the pointer — quote each "
+                    f"source element that contains a '#'")
+                return  # one report per concept is enough
 
 
 def check_dates(rel, fm, errors):

--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -173,106 +173,138 @@ def strip_code(text: str) -> str:
     return "\n".join(out)
 
 
-SOURCE_KEY_RE = re.compile(r"^source\s*:(.*)$")  # top-level (column 0) only
+SOURCE_KEY_RE = re.compile(r"^source\s*:(.*)$")  # matched on a de-indented line
 
 
-def _strip_source_structure(line, is_key_line):
-    """Reduce a source-region line to its raw element text: drop indentation and YAML
-    structure — the `source:` key on the first line, leading block '-' markers, and a
-    leading flow '['. What remains is scanned for an inline comment."""
-    s = SOURCE_KEY_RE.match(line).group(1) if is_key_line else line
-    s = s.strip()
-    while s.startswith("-"):
-        s = s[1:].lstrip()
-    return s.lstrip("[")
+def _base_indent(lines):
+    """Indentation of the frontmatter's top-level keys — the indent of its first non-blank
+    line. Frontmatter is normally at column 0, but a consistently indented mapping is still
+    valid YAML; anchoring to this indent finds the real top-level `source` while skipping a
+    deeper, nested `source:` under another key."""
+    for ln in lines:
+        if ln.strip():
+            return len(ln) - len(ln.lstrip())
+    return 0
 
 
-# A YAML inline comment drops no data when it follows a value that already closed -- a
-# quote, a flow bracket/brace, or a separator. It truncates data only when it interrupts
-# an unquoted scalar, where the char before it is ordinary content.
-_VALUE_COMPLETE = {'"', "'", "]", "}", "[", "{", ","}
-# A quote opens a quoted scalar only at a value boundary -- the start of the value or
-# right after a flow opener/separator. Elsewhere (e.g. the apostrophe in "Joe's") it is a
-# literal character inside a plain scalar.
-_SCALAR_OPENERS = {"[", "{", ","}
+def _source_region_loses_data(text):
+    """True if the raw text of a top-level source value would silently drop provenance to
+    a YAML comment. `text` is the source value — the part after `source:` plus any
+    continuation lines, joined by newlines — scanned as one unit so quote state and flow
+    nesting carry across line breaks.
 
-
-def _has_truncating_comment(text):
-    """True if `text` holds a YAML inline comment that truncates content: a whitespace-
-    preceded, unquoted '#' that interrupts an unquoted scalar. Quote-aware (a '#' inside
-    '...'/"..." is protected) and structure-aware: a comment after a completed value
-    (`["a"] # why`, `- "a" # note`) or a whole-line comment drops no data and is not
-    flagged. A quote is only treated as a string delimiter at a value boundary, so a
-    plain scalar with an inner apostrophe (`Joe's issue #445`) is still scanned and its
-    truncating '#' caught. The first such '#' decides the line — in YAML everything after
-    it is the comment."""
+    A '#' starts a comment and YAML discards the rest of the line, but that loses data only
+    when the '#' interrupts an open unquoted scalar. A '#' inside a quoted string, or one
+    with only whitespace since the last completed value, drops nothing. Quote handling
+    follows YAML: '' is a literal apostrophe inside '...', and a backslash escapes inside
+    "...". A quote opens a string only at a value boundary, so a mid-scalar apostrophe
+    (`Joe's`) stays literal. Flow punctuation (',' '[' ']' '{' '}') is structure only
+    inside a flow collection — in a block scalar it is literal text, so a comment after it
+    still truncates."""
+    i, n = 0, len(text)
     in_single = in_double = False
-    seen_content = False
-    last_nonspace = ""
-    prev = ""
-    for ch in text:
+    flow_depth = 0
+    pending = False        # an unquoted scalar is open since the last value boundary
+    at_line_start = True   # before any non-space char on the current physical line
+    while i < n:
+        ch = text[i]
         if in_single:
             if ch == "'":
+                if i + 1 < n and text[i + 1] == "'":
+                    i += 2          # '' escapes a literal apostrophe — stay in the string
+                    continue
                 in_single = False
-            last_nonspace = ch
-        elif in_double:
+                pending = False     # the quoted scalar is complete
+            i += 1
+            continue
+        if in_double:
+            if ch == "\\":
+                i += 2              # backslash escapes the next char inside "..."
+                continue
             if ch == '"':
                 in_double = False
-            last_nonspace = ch
-        elif ch == "#" and prev in (" ", "\t"):
-            # YAML comment start. Data is lost only if it cut into an unquoted scalar.
-            return seen_content and last_nonspace not in _VALUE_COMPLETE
-        elif ch in ("'", '"') and (not seen_content or last_nonspace in _SCALAR_OPENERS):
-            if ch == "'":
-                in_single = True
-            else:
-                in_double = True
-            seen_content = True
-            last_nonspace = ch
-        elif not ch.isspace():
-            seen_content = True
-            last_nonspace = ch
-        prev = ch
+                pending = False
+            i += 1
+            continue
+        if ch == "\n":
+            if flow_depth == 0:
+                pending = False     # a block line break ends the current element
+            at_line_start = True
+            i += 1
+            continue
+        if ch in (" ", "\t"):
+            i += 1
+            continue
+        if at_line_start and flow_depth == 0 and ch == "-" and (
+                i + 1 >= n or text[i + 1] in (" ", "\t", "\n")):
+            pending = False         # block sequence-entry indicator, not content
+            i += 1
+            continue
+        at_line_start = False
+        if ch == "#" and i > 0 and text[i - 1] in (" ", "\t", "\n"):
+            return pending          # comment: data lost only if a scalar was open
+        if ch in ("'", '"') and not pending:
+            in_single = ch == "'"
+            in_double = ch == '"'
+            i += 1
+            continue
+        if ch in ("[", "{") and not pending:
+            flow_depth += 1         # opens flow only at a value boundary
+            i += 1
+            continue
+        if ch in ("]", "}") and flow_depth > 0:
+            flow_depth -= 1
+            pending = False
+            i += 1
+            continue
+        if ch == "," and flow_depth > 0:
+            pending = False         # flow separator (literal in a block scalar)
+            i += 1
+            continue
+        pending = True              # ordinary scalar content (incl. literal , [ ] in block)
+        i += 1
     return False
 
 
 def check_source_quoting(rel, raw_fm, errors):
-    """Enforce the SPEC 'source' quoting rule on the raw frontmatter, where YAML's
-    comment stripping would otherwise silently drop part of a provenance pointer.
+    """Enforce the SPEC 'source' quoting rule on the raw frontmatter, where YAML's comment
+    stripping would otherwise silently drop part of a provenance pointer.
 
     Quoting source elements is a hard SPEC rule, but YAML drops an unquoted inline '#'
     comment with no error: `- issue #445` parses to "issue", losing "#445". The parsed
-    value cannot reveal the loss, so this scans the raw text of the top-level `source`
-    value for an unquoted, content-truncating '#'. It covers every list shape — block
-    items, single- and multi-line flow lists, and wrapped plain scalars — because in all
-    of them such a '#' means dropped data. It is quote-aware (a '#' inside quotes is
-    fine) and scoped to the top-level `source` key only: a nested `source:` inside other
-    allowed metadata is not the OKF provenance list and must not trip the check. Every
-    top-level `source` occurrence is scanned, not just the first: YAML keeps the last of
-    duplicate keys, so a later one is the value that actually parsed. A bare '#'-first
+    value cannot reveal the loss, so this scans the raw text of each top-level `source`
+    value (see _source_region_loses_data) for an unquoted, content-truncating '#'. It
+    covers every list shape — block items, single- and multi-line flow lists, wrapped
+    scalars — and is quote- and flow-aware so it neither misses a real loss nor rejects a
+    correctly quoted pointer. It is scoped to the top-level `source` key only (a nested
+    `source:` under other metadata is not the OKF provenance list), and scans every
+    top-level occurrence, since YAML keeps the last of duplicate keys. A bare '#'-first
     item (null) and a colon-space mapping item are left to check_lists."""
     if not raw_fm:
         return
     lines = raw_fm.splitlines()
-    starts = [i for i, ln in enumerate(lines) if SOURCE_KEY_RE.match(ln)]
-    # absence of source is reported by the required-key check; nothing to scan here
-    for start in starts:
-        # The source value region: the key line plus following blank, indented, or
-        # block-item ('-') lines, up to the next top-level key. This spans block lists,
-        # multi-line flow lists, and wrapped scalars without re-parsing YAML.
-        region = [lines[start]]
-        for ln in lines[start + 1:]:
-            if ln.strip() == "" or ln[:1].isspace() or ln.lstrip().startswith("-"):
-                region.append(ln)
+    base = _base_indent(lines)
+    for i, ln in enumerate(lines):
+        indent = len(ln) - len(ln.lstrip())
+        m = SOURCE_KEY_RE.match(ln[indent:])
+        if indent != base or not m:
+            continue  # not a top-level source key (deeper => nested under another key)
+        # The source value region: text after `source:` on the key line, plus following
+        # blank, deeper-indented, or block-item ('-') lines, up to the next top-level key.
+        parts = [m.group(1)]
+        for nxt in lines[i + 1:]:
+            nstrip = nxt.strip()
+            nindent = len(nxt) - len(nxt.lstrip())
+            if nstrip == "" or nindent > base or nstrip.startswith("-"):
+                parts.append(nxt)
             else:
                 break
-        for idx, ln in enumerate(region):
-            if _has_truncating_comment(_strip_source_structure(ln, idx == 0)):
-                errors.append(
-                    f"{rel}: a top-level 'source' element has an unquoted '#' that YAML "
-                    f"reads as a comment, dropping the rest of the pointer — quote each "
-                    f"source element that contains a '#'")
-                return  # one report per concept is enough
+        if _source_region_loses_data("\n".join(parts)):
+            errors.append(
+                f"{rel}: a top-level 'source' element has an unquoted '#' that YAML "
+                f"reads as a comment, dropping the rest of the pointer — quote each "
+                f"source element that contains a '#'")
+            return  # one report per concept is enough
 
 
 def check_dates(rel, fm, errors):

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -173,133 +173,58 @@ def strip_code(text: str) -> str:
     return "\n".join(out)
 
 
-SOURCE_KEY_RE = re.compile(r"^source\s*:(.*)$")  # matched on a de-indented line
+def _plain_scalar_dropped_comment(node, raw_fm):
+    """True if a YAML comment directly truncated this scalar's provenance.
 
-
-def _base_indent(lines):
-    """Indentation of the frontmatter's top-level keys — the indent of its first non-blank
-    line. Frontmatter is normally at column 0, but a consistently indented mapping is still
-    valid YAML; anchoring to this indent finds the real top-level `source` while skipping a
-    deeper, nested `source:` under another key."""
-    for ln in lines:
-        if ln.strip():
-            return len(ln) - len(ln.lstrip())
-    return 0
-
-
-def _source_region_loses_data(text):
-    """True if the raw text of a top-level source value would silently drop provenance to
-    a YAML comment. `text` is the source value — the part after `source:` plus any
-    continuation lines, joined by newlines — scanned as one unit so quote state and flow
-    nesting carry across line breaks.
-
-    A '#' starts a comment and YAML discards the rest of the line, but that loses data only
-    when the '#' interrupts an open unquoted scalar. A '#' inside a quoted string, or one
-    with only whitespace since the last completed value, drops nothing. Quote handling
-    follows YAML: '' is a literal apostrophe inside '...', and a backslash escapes inside
-    "...". A quote opens a string only at a value boundary, so a mid-scalar apostrophe
-    (`Joe's`) stays literal. Flow punctuation (',' '[' ']' '{' '}') is structure only
-    inside a flow collection — in a block scalar it is literal text, so a comment after it
-    still truncates."""
-    i, n = 0, len(text)
-    in_single = in_double = False
-    flow_depth = 0
-    pending = False        # an unquoted scalar is open since the last value boundary
-    at_line_start = True   # before any non-space char on the current physical line
-    while i < n:
-        ch = text[i]
-        if in_single:
-            if ch == "'":
-                if i + 1 < n and text[i + 1] == "'":
-                    i += 2          # '' escapes a literal apostrophe — stay in the string
-                    continue
-                in_single = False
-                pending = False     # the quoted scalar is complete
-            i += 1
-            continue
-        if in_double:
-            if ch == "\\":
-                i += 2              # backslash escapes the next char inside "..."
-                continue
-            if ch == '"':
-                in_double = False
-                pending = False
-            i += 1
-            continue
-        if ch == "\n":
-            if flow_depth == 0:
-                pending = False     # a block line break ends the current element
-            at_line_start = True
-            i += 1
-            continue
-        if ch in (" ", "\t"):
-            i += 1
-            continue
-        if at_line_start and flow_depth == 0 and ch == "-" and (
-                i + 1 >= n or text[i + 1] in (" ", "\t", "\n")):
-            pending = False         # block sequence-entry indicator, not content
-            i += 1
-            continue
-        at_line_start = False
-        if ch == "#" and i > 0 and text[i - 1] in (" ", "\t", "\n"):
-            return pending          # comment: data lost only if a scalar was open
-        if ch in ("'", '"') and not pending:
-            in_single = ch == "'"
-            in_double = ch == '"'
-            i += 1
-            continue
-        if ch in ("[", "{") and not pending:
-            flow_depth += 1         # opens flow only at a value boundary
-            i += 1
-            continue
-        if ch in ("]", "}") and flow_depth > 0:
-            flow_depth -= 1
-            pending = False
-            i += 1
-            continue
-        if ch == "," and flow_depth > 0:
-            pending = False         # flow separator (literal in a block scalar)
-            i += 1
-            continue
-        pending = True              # ordinary scalar content (incl. literal , [ ] in block)
-        i += 1
-    return False
+    `node` is a scalar node from the parsed frontmatter and `raw_fm` the raw text it was
+    parsed from. Only a plain (unquoted) scalar can lose data: a quoted or block scalar
+    (node.style set to ', ", |, or >) keeps a '#' as string content. For a plain scalar,
+    YAML stops the value at the space before an inline '#', so the comment shows up in the
+    raw text immediately after the scalar's end mark, on the same line. That is exactly the
+    silent-truncation case (`issue #445` -> "issue") the SPEC quoting rule guards against;
+    `issue#445` (no space) is one scalar and a '#' on a later line is a standalone comment,
+    and neither trips this."""
+    if node.style is not None:
+        return False
+    j = node.end_mark.index
+    while j < len(raw_fm) and raw_fm[j] in (" ", "\t"):
+        j += 1
+    return j < len(raw_fm) and raw_fm[j] == "#"
 
 
 def check_source_quoting(rel, raw_fm, errors):
-    """Enforce the SPEC 'source' quoting rule on the raw frontmatter, where YAML's comment
-    stripping would otherwise silently drop part of a provenance pointer.
+    """Enforce the SPEC 'source' quoting rule, where YAML's comment stripping would
+    otherwise silently drop part of a provenance pointer.
 
     Quoting source elements is a hard SPEC rule, but YAML drops an unquoted inline '#'
     comment with no error: `- issue #445` parses to "issue", losing "#445". The parsed
-    value cannot reveal the loss, so this scans the raw text of each top-level `source`
-    value (see _source_region_loses_data) for an unquoted, content-truncating '#'. It
-    covers every list shape — block items, single- and multi-line flow lists, wrapped
-    scalars — and is quote- and flow-aware so it neither misses a real loss nor rejects a
-    correctly quoted pointer. It is scoped to the top-level `source` key only (a nested
-    `source:` under other metadata is not the OKF provenance list), and scans every
-    top-level occurrence, since YAML keeps the last of duplicate keys. A bare '#'-first
-    item (null) and a colon-space mapping item are left to check_lists."""
+    value alone cannot reveal the loss, so this re-parses the frontmatter into its node
+    tree (which carries source position marks) and, for every top-level `source` element,
+    checks whether a comment directly truncated a plain scalar (see
+    _plain_scalar_dropped_comment). Delegating the lexing to YAML covers every shape —
+    block items, single- and multi-line flow lists, wrapped scalars, quoted strings with
+    escapes, anchors/tags, and block scalars — without re-implementing the parser. It is
+    scoped to the top-level `source` key only (a nested `source:` under other metadata is
+    not the OKF provenance list) and inspects every top-level occurrence, since YAML keeps
+    the last of duplicate keys. A real parse error is reported by the schema check."""
     if not raw_fm:
         return
-    lines = raw_fm.splitlines()
-    base = _base_indent(lines)
-    for i, ln in enumerate(lines):
-        indent = len(ln) - len(ln.lstrip())
-        m = SOURCE_KEY_RE.match(ln[indent:])
-        if indent != base or not m:
-            continue  # not a top-level source key (deeper => nested under another key)
-        # The source value region: text after `source:` on the key line, plus following
-        # blank, deeper-indented, or block-item ('-') lines, up to the next top-level key.
-        parts = [m.group(1)]
-        for nxt in lines[i + 1:]:
-            nstrip = nxt.strip()
-            nindent = len(nxt) - len(nxt.lstrip())
-            if nstrip == "" or nindent > base or nstrip.startswith("-"):
-                parts.append(nxt)
-            else:
-                break
-        if _source_region_loses_data("\n".join(parts)):
+    try:
+        root = yaml.compose(raw_fm, Loader=yaml.SafeLoader)
+    except yaml.YAMLError:
+        return
+    if not isinstance(root, yaml.MappingNode):
+        return
+    for key_node, val_node in root.value:
+        if not (isinstance(key_node, yaml.ScalarNode) and key_node.value == "source"):
+            continue
+        if isinstance(val_node, yaml.SequenceNode):
+            scalars = [n for n in val_node.value if isinstance(n, yaml.ScalarNode)]
+        elif isinstance(val_node, yaml.ScalarNode):
+            scalars = [val_node]
+        else:
+            scalars = []
+        if any(_plain_scalar_dropped_comment(n, raw_fm) for n in scalars):
             errors.append(
                 f"{rel}: a top-level 'source' element has an unquoted '#' that YAML "
                 f"reads as a comment, dropping the rest of the pointer — quote each "

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -173,48 +173,106 @@ def strip_code(text: str) -> str:
     return "\n".join(out)
 
 
-def check_source_quoting(rel, raw_fm, errors):
-    """Enforce the SPEC 'source' quoting rule where YAML's comment stripping would
-    otherwise hide a violation.
+SOURCE_KEY_RE = re.compile(r"^source\s*:(.*)$")  # top-level (column 0) only
 
-    In block style an unquoted element with an inline '#' is silently truncated:
-        source:
-          - issue #445      -> parses to "issue"; "#445" is dropped as a comment
-    No parse error fires, so the provenance is lost with the build still green. Flow
-    style is self-enforcing (the '#' comments out the closing ']', a parse error
-    caught earlier), so this scan targets block-style items. The trigger is YAML's
-    own comment rule: a '#' preceded by whitespace, with content before it. A bare
-    '#'-first item parses to null (caught by check_lists); 'issue#445' (no space) is a
-    valid string and left alone; a colon-space makes the item a mapping (also caught
-    by check_lists)."""
+
+def _strip_source_structure(line, is_key_line):
+    """Reduce a source-region line to its raw element text: drop indentation and YAML
+    structure — the `source:` key on the first line, leading block '-' markers, and a
+    leading flow '['. What remains is scanned for an inline comment."""
+    s = SOURCE_KEY_RE.match(line).group(1) if is_key_line else line
+    s = s.strip()
+    while s.startswith("-"):
+        s = s[1:].lstrip()
+    return s.lstrip("[")
+
+
+# A YAML inline comment drops no data when it follows a value that already closed -- a
+# quote, a flow bracket/brace, or a separator. It truncates data only when it interrupts
+# an unquoted scalar, where the char before it is ordinary content.
+_VALUE_COMPLETE = {'"', "'", "]", "}", "[", "{", ","}
+# A quote opens a quoted scalar only at a value boundary -- the start of the value or
+# right after a flow opener/separator. Elsewhere (e.g. the apostrophe in "Joe's") it is a
+# literal character inside a plain scalar.
+_SCALAR_OPENERS = {"[", "{", ","}
+
+
+def _has_truncating_comment(text):
+    """True if `text` holds a YAML inline comment that truncates content: a whitespace-
+    preceded, unquoted '#' that interrupts an unquoted scalar. Quote-aware (a '#' inside
+    '...'/"..." is protected) and structure-aware: a comment after a completed value
+    (`["a"] # why`, `- "a" # note`) or a whole-line comment drops no data and is not
+    flagged. A quote is only treated as a string delimiter at a value boundary, so a
+    plain scalar with an inner apostrophe (`Joe's issue #445`) is still scanned and its
+    truncating '#' caught. The first such '#' decides the line — in YAML everything after
+    it is the comment."""
+    in_single = in_double = False
+    seen_content = False
+    last_nonspace = ""
+    prev = ""
+    for ch in text:
+        if in_single:
+            if ch == "'":
+                in_single = False
+            last_nonspace = ch
+        elif in_double:
+            if ch == '"':
+                in_double = False
+            last_nonspace = ch
+        elif ch == "#" and prev in (" ", "\t"):
+            # YAML comment start. Data is lost only if it cut into an unquoted scalar.
+            return seen_content and last_nonspace not in _VALUE_COMPLETE
+        elif ch in ("'", '"') and (not seen_content or last_nonspace in _SCALAR_OPENERS):
+            if ch == "'":
+                in_single = True
+            else:
+                in_double = True
+            seen_content = True
+            last_nonspace = ch
+        elif not ch.isspace():
+            seen_content = True
+            last_nonspace = ch
+        prev = ch
+    return False
+
+
+def check_source_quoting(rel, raw_fm, errors):
+    """Enforce the SPEC 'source' quoting rule on the raw frontmatter, where YAML's
+    comment stripping would otherwise silently drop part of a provenance pointer.
+
+    Quoting source elements is a hard SPEC rule, but YAML drops an unquoted inline '#'
+    comment with no error: `- issue #445` parses to "issue", losing "#445". The parsed
+    value cannot reveal the loss, so this scans the raw text of the top-level `source`
+    value for an unquoted, content-truncating '#'. It covers every list shape — block
+    items, single- and multi-line flow lists, and wrapped plain scalars — because in all
+    of them such a '#' means dropped data. It is quote-aware (a '#' inside quotes is
+    fine) and scoped to the top-level `source` key only: a nested `source:` inside other
+    allowed metadata is not the OKF provenance list and must not trip the check. Every
+    top-level `source` occurrence is scanned, not just the first: YAML keeps the last of
+    duplicate keys, so a later one is the value that actually parsed. A bare '#'-first
+    item (null) and a colon-space mapping item are left to check_lists."""
     if not raw_fm:
         return
-    in_block = False
-    source_indent = 0
-    for line in raw_fm.splitlines():
-        m = re.match(r"^(\s*)source\s*:(.*)$", line)
-        if m:
-            rest = m.group(2).strip()
-            # block style only when nothing (or just a comment) follows the colon; an
-            # inline flow list or scalar is handled by the YAML parse step.
-            in_block = rest == "" or rest.startswith("#")
-            source_indent = len(m.group(1))
-            continue
-        if not in_block:
-            continue
-        stripped = line.strip()
-        if stripped == "":
-            continue
-        indent = len(line) - len(line.lstrip())
-        if not stripped.startswith("-") and indent <= source_indent:
-            in_block = False  # dedented to a sibling key -> the source block ended
-            continue
-        if stripped.startswith("-"):
-            value = stripped[1:].strip()
-            if value[:1] not in ("'", '"') and re.search(r"\S\s+#", value):
+    lines = raw_fm.splitlines()
+    starts = [i for i, ln in enumerate(lines) if SOURCE_KEY_RE.match(ln)]
+    # absence of source is reported by the required-key check; nothing to scan here
+    for start in starts:
+        # The source value region: the key line plus following blank, indented, or
+        # block-item ('-') lines, up to the next top-level key. This spans block lists,
+        # multi-line flow lists, and wrapped scalars without re-parsing YAML.
+        region = [lines[start]]
+        for ln in lines[start + 1:]:
+            if ln.strip() == "" or ln[:1].isspace() or ln.lstrip().startswith("-"):
+                region.append(ln)
+            else:
+                break
+        for idx, ln in enumerate(region):
+            if _has_truncating_comment(_strip_source_structure(ln, idx == 0)):
                 errors.append(
-                    f"{rel}: 'source' element {value!r} has an unquoted '#' that YAML "
-                    f"reads as a comment, dropping the rest — quote it: - \"{value}\"")
+                    f"{rel}: a top-level 'source' element has an unquoted '#' that YAML "
+                    f"reads as a comment, dropping the rest of the pointer — quote each "
+                    f"source element that contains a '#'")
+                return  # one report per concept is enough
 
 
 def check_dates(rel, fm, errors):

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -173,106 +173,138 @@ def strip_code(text: str) -> str:
     return "\n".join(out)
 
 
-SOURCE_KEY_RE = re.compile(r"^source\s*:(.*)$")  # top-level (column 0) only
+SOURCE_KEY_RE = re.compile(r"^source\s*:(.*)$")  # matched on a de-indented line
 
 
-def _strip_source_structure(line, is_key_line):
-    """Reduce a source-region line to its raw element text: drop indentation and YAML
-    structure — the `source:` key on the first line, leading block '-' markers, and a
-    leading flow '['. What remains is scanned for an inline comment."""
-    s = SOURCE_KEY_RE.match(line).group(1) if is_key_line else line
-    s = s.strip()
-    while s.startswith("-"):
-        s = s[1:].lstrip()
-    return s.lstrip("[")
+def _base_indent(lines):
+    """Indentation of the frontmatter's top-level keys — the indent of its first non-blank
+    line. Frontmatter is normally at column 0, but a consistently indented mapping is still
+    valid YAML; anchoring to this indent finds the real top-level `source` while skipping a
+    deeper, nested `source:` under another key."""
+    for ln in lines:
+        if ln.strip():
+            return len(ln) - len(ln.lstrip())
+    return 0
 
 
-# A YAML inline comment drops no data when it follows a value that already closed -- a
-# quote, a flow bracket/brace, or a separator. It truncates data only when it interrupts
-# an unquoted scalar, where the char before it is ordinary content.
-_VALUE_COMPLETE = {'"', "'", "]", "}", "[", "{", ","}
-# A quote opens a quoted scalar only at a value boundary -- the start of the value or
-# right after a flow opener/separator. Elsewhere (e.g. the apostrophe in "Joe's") it is a
-# literal character inside a plain scalar.
-_SCALAR_OPENERS = {"[", "{", ","}
+def _source_region_loses_data(text):
+    """True if the raw text of a top-level source value would silently drop provenance to
+    a YAML comment. `text` is the source value — the part after `source:` plus any
+    continuation lines, joined by newlines — scanned as one unit so quote state and flow
+    nesting carry across line breaks.
 
-
-def _has_truncating_comment(text):
-    """True if `text` holds a YAML inline comment that truncates content: a whitespace-
-    preceded, unquoted '#' that interrupts an unquoted scalar. Quote-aware (a '#' inside
-    '...'/"..." is protected) and structure-aware: a comment after a completed value
-    (`["a"] # why`, `- "a" # note`) or a whole-line comment drops no data and is not
-    flagged. A quote is only treated as a string delimiter at a value boundary, so a
-    plain scalar with an inner apostrophe (`Joe's issue #445`) is still scanned and its
-    truncating '#' caught. The first such '#' decides the line — in YAML everything after
-    it is the comment."""
+    A '#' starts a comment and YAML discards the rest of the line, but that loses data only
+    when the '#' interrupts an open unquoted scalar. A '#' inside a quoted string, or one
+    with only whitespace since the last completed value, drops nothing. Quote handling
+    follows YAML: '' is a literal apostrophe inside '...', and a backslash escapes inside
+    "...". A quote opens a string only at a value boundary, so a mid-scalar apostrophe
+    (`Joe's`) stays literal. Flow punctuation (',' '[' ']' '{' '}') is structure only
+    inside a flow collection — in a block scalar it is literal text, so a comment after it
+    still truncates."""
+    i, n = 0, len(text)
     in_single = in_double = False
-    seen_content = False
-    last_nonspace = ""
-    prev = ""
-    for ch in text:
+    flow_depth = 0
+    pending = False        # an unquoted scalar is open since the last value boundary
+    at_line_start = True   # before any non-space char on the current physical line
+    while i < n:
+        ch = text[i]
         if in_single:
             if ch == "'":
+                if i + 1 < n and text[i + 1] == "'":
+                    i += 2          # '' escapes a literal apostrophe — stay in the string
+                    continue
                 in_single = False
-            last_nonspace = ch
-        elif in_double:
+                pending = False     # the quoted scalar is complete
+            i += 1
+            continue
+        if in_double:
+            if ch == "\\":
+                i += 2              # backslash escapes the next char inside "..."
+                continue
             if ch == '"':
                 in_double = False
-            last_nonspace = ch
-        elif ch == "#" and prev in (" ", "\t"):
-            # YAML comment start. Data is lost only if it cut into an unquoted scalar.
-            return seen_content and last_nonspace not in _VALUE_COMPLETE
-        elif ch in ("'", '"') and (not seen_content or last_nonspace in _SCALAR_OPENERS):
-            if ch == "'":
-                in_single = True
-            else:
-                in_double = True
-            seen_content = True
-            last_nonspace = ch
-        elif not ch.isspace():
-            seen_content = True
-            last_nonspace = ch
-        prev = ch
+                pending = False
+            i += 1
+            continue
+        if ch == "\n":
+            if flow_depth == 0:
+                pending = False     # a block line break ends the current element
+            at_line_start = True
+            i += 1
+            continue
+        if ch in (" ", "\t"):
+            i += 1
+            continue
+        if at_line_start and flow_depth == 0 and ch == "-" and (
+                i + 1 >= n or text[i + 1] in (" ", "\t", "\n")):
+            pending = False         # block sequence-entry indicator, not content
+            i += 1
+            continue
+        at_line_start = False
+        if ch == "#" and i > 0 and text[i - 1] in (" ", "\t", "\n"):
+            return pending          # comment: data lost only if a scalar was open
+        if ch in ("'", '"') and not pending:
+            in_single = ch == "'"
+            in_double = ch == '"'
+            i += 1
+            continue
+        if ch in ("[", "{") and not pending:
+            flow_depth += 1         # opens flow only at a value boundary
+            i += 1
+            continue
+        if ch in ("]", "}") and flow_depth > 0:
+            flow_depth -= 1
+            pending = False
+            i += 1
+            continue
+        if ch == "," and flow_depth > 0:
+            pending = False         # flow separator (literal in a block scalar)
+            i += 1
+            continue
+        pending = True              # ordinary scalar content (incl. literal , [ ] in block)
+        i += 1
     return False
 
 
 def check_source_quoting(rel, raw_fm, errors):
-    """Enforce the SPEC 'source' quoting rule on the raw frontmatter, where YAML's
-    comment stripping would otherwise silently drop part of a provenance pointer.
+    """Enforce the SPEC 'source' quoting rule on the raw frontmatter, where YAML's comment
+    stripping would otherwise silently drop part of a provenance pointer.
 
     Quoting source elements is a hard SPEC rule, but YAML drops an unquoted inline '#'
     comment with no error: `- issue #445` parses to "issue", losing "#445". The parsed
-    value cannot reveal the loss, so this scans the raw text of the top-level `source`
-    value for an unquoted, content-truncating '#'. It covers every list shape — block
-    items, single- and multi-line flow lists, and wrapped plain scalars — because in all
-    of them such a '#' means dropped data. It is quote-aware (a '#' inside quotes is
-    fine) and scoped to the top-level `source` key only: a nested `source:` inside other
-    allowed metadata is not the OKF provenance list and must not trip the check. Every
-    top-level `source` occurrence is scanned, not just the first: YAML keeps the last of
-    duplicate keys, so a later one is the value that actually parsed. A bare '#'-first
+    value cannot reveal the loss, so this scans the raw text of each top-level `source`
+    value (see _source_region_loses_data) for an unquoted, content-truncating '#'. It
+    covers every list shape — block items, single- and multi-line flow lists, wrapped
+    scalars — and is quote- and flow-aware so it neither misses a real loss nor rejects a
+    correctly quoted pointer. It is scoped to the top-level `source` key only (a nested
+    `source:` under other metadata is not the OKF provenance list), and scans every
+    top-level occurrence, since YAML keeps the last of duplicate keys. A bare '#'-first
     item (null) and a colon-space mapping item are left to check_lists."""
     if not raw_fm:
         return
     lines = raw_fm.splitlines()
-    starts = [i for i, ln in enumerate(lines) if SOURCE_KEY_RE.match(ln)]
-    # absence of source is reported by the required-key check; nothing to scan here
-    for start in starts:
-        # The source value region: the key line plus following blank, indented, or
-        # block-item ('-') lines, up to the next top-level key. This spans block lists,
-        # multi-line flow lists, and wrapped scalars without re-parsing YAML.
-        region = [lines[start]]
-        for ln in lines[start + 1:]:
-            if ln.strip() == "" or ln[:1].isspace() or ln.lstrip().startswith("-"):
-                region.append(ln)
+    base = _base_indent(lines)
+    for i, ln in enumerate(lines):
+        indent = len(ln) - len(ln.lstrip())
+        m = SOURCE_KEY_RE.match(ln[indent:])
+        if indent != base or not m:
+            continue  # not a top-level source key (deeper => nested under another key)
+        # The source value region: text after `source:` on the key line, plus following
+        # blank, deeper-indented, or block-item ('-') lines, up to the next top-level key.
+        parts = [m.group(1)]
+        for nxt in lines[i + 1:]:
+            nstrip = nxt.strip()
+            nindent = len(nxt) - len(nxt.lstrip())
+            if nstrip == "" or nindent > base or nstrip.startswith("-"):
+                parts.append(nxt)
             else:
                 break
-        for idx, ln in enumerate(region):
-            if _has_truncating_comment(_strip_source_structure(ln, idx == 0)):
-                errors.append(
-                    f"{rel}: a top-level 'source' element has an unquoted '#' that YAML "
-                    f"reads as a comment, dropping the rest of the pointer — quote each "
-                    f"source element that contains a '#'")
-                return  # one report per concept is enough
+        if _source_region_loses_data("\n".join(parts)):
+            errors.append(
+                f"{rel}: a top-level 'source' element has an unquoted '#' that YAML "
+                f"reads as a comment, dropping the rest of the pointer — quote each "
+                f"source element that contains a '#'")
+            return  # one report per concept is enough
 
 
 def check_dates(rel, fm, errors):

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -1153,6 +1153,62 @@ def test_source_unquoted_with_apostrophe_then_hash_fails(tmp_path):
     assert "source" in out and "#" in out
 
 
+def test_source_block_item_with_comma_then_hash_fails(tmp_path):
+    # a comma is a flow separator only inside `[...]`; in a block scalar it is literal
+    # text, so `- report, #445` keeps "report," and still drops "#445". The scan must
+    # not treat the comma as a completed value the way it does inside flow.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_source("source:\n  - report, #445"))
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "source" in out and "#" in out
+
+
+def test_source_single_quoted_doubled_apostrophe_passes(tmp_path):
+    # '' is YAML's escape for a literal apostrophe inside a single-quoted string, so
+    # 'Joe''s issue #445' keeps "#445" inside the (valid, complete) string. The scan must
+    # not close the string on the first quote of the pair and reject a correct pointer.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_source("source: ['Joe''s issue #445']"))
+    rc, out = validate(b)
+    assert rc == 0, out
+
+
+def test_source_multiline_quoted_scalar_passes(tmp_path):
+    # a quoted scalar may wrap onto the next line; YAML folds it and keeps "#445" inside
+    # the string. The scan must carry quote state across the line break, not treat the
+    # continuation as plain text and reject it.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_source('source: ["issue\n  tracker #445"]'))
+    rc, out = validate(b)
+    assert rc == 0, out
+
+
+def test_source_indented_frontmatter_unquoted_hash_fails(tmp_path):
+    # a consistently indented frontmatter mapping is valid YAML with top-level keys off
+    # column 0. The scan must anchor to the frontmatter's base indent so it still finds
+    # the real top-level `source` (and still drops its truncated provenance).
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, (
+        "---\n"
+        "  type: Process\n"
+        "  title: t\n"
+        "  description: d\n"
+        "  source:\n"
+        "    - issue #445\n"
+        '  verified: "2026-06-23"\n'
+        '  timestamp: "2026-06-23"\n'
+        '  tags: ["x"]\n'
+        "---\n# t\n"))
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "source" in out and "#" in out
+
+
 # --- uppercase .md extension handling (#150 sub-item 2) ----------------------
 
 def test_uppercase_md_file_rejected(tmp_path):

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -1209,6 +1209,48 @@ def test_source_indented_frontmatter_unquoted_hash_fails(tmp_path):
     assert "source" in out and "#" in out
 
 
+def test_source_comment_line_before_unquoted_item_fails(tmp_path):
+    # a benign comment in the source value must not stop the scan: `source: # note` then
+    # `- issue #445` still drops "#445" from the real (later) item.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_source("source: # note\n  - issue #445"))
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "source" in out and "#" in out
+
+
+def test_source_flow_wrapped_at_base_indent_fails(tmp_path):
+    # a flow list may wrap with no extra indentation; YAML still parses the continuation,
+    # so `source: [` then a column-0 `"README.md", issue #445` still drops "#445".
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_source('source: [\n"README.md", issue #445\n]'))
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "source" in out and "#" in out
+
+
+def test_source_block_scalar_with_hash_passes(tmp_path):
+    # a literal/folded block scalar keeps '#' as string content, not a comment, so a
+    # source written that way is valid and must not be flagged.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_source("source:\n  - |\n    issue #445"))
+    rc, out = validate(b)
+    assert rc == 0, out
+
+
+def test_source_anchored_quoted_value_passes(tmp_path):
+    # a YAML anchor/tag before a quoted value still protects the '#' inside the string;
+    # the scan must not read the anchor as plain content and reject the quoted pointer.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_source('source: [&p "issue #445"]'))
+    rc, out = validate(b)
+    assert rc == 0, out
+
+
 # --- uppercase .md extension handling (#150 sub-item 2) ----------------------
 
 def test_uppercase_md_file_rejected(tmp_path):

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -1074,6 +1074,85 @@ def test_source_flow_unquoted_hash_still_fails(tmp_path):
     assert rc == 1, out
 
 
+# --- source-quoting hardening: cloud-review edge cases from #166 -------------
+
+def test_source_multiline_flow_unquoted_hash_fails(tmp_path):
+    # a flow list can close on a later line, so the '#' does NOT comment out the ']' and
+    # YAML parses cleanly while dropping "#445". The raw scan must still catch it.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_source('source: ["README.md", issue #445\n  ]'))
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "source" in out and "#" in out
+
+
+def test_source_wrapped_scalar_unquoted_hash_fails(tmp_path):
+    # a block item that wraps onto a continuation line is one plain scalar; YAML strips a
+    # '#' comment on the continuation too. The scan must inspect continuation lines.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_source('source:\n  - issue\n    tracker #445'))
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "source" in out and "#" in out
+
+
+def test_source_nested_key_not_flagged(tmp_path):
+    # the scan must target only the top-level `source` provenance list. A nested
+    # `source:` inside other (allowed) metadata is not the OKF source and must not make
+    # a bundle with a valid top-level source fail.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_source(
+        'source: ["README.md"]\nextra:\n  source:\n    - issue #445'))
+    rc, out = validate(b)
+    assert rc == 0, out
+
+
+def test_source_trailing_comment_after_complete_flow_ok(tmp_path):
+    # a YAML comment after a COMPLETE value drops no data, so it must not be flagged:
+    # `source: ["README.md"] # why` keeps ["README.md"].
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_source('source: ["README.md"] # provenance'))
+    rc, out = validate(b)
+    assert rc == 0, out
+
+
+def test_source_trailing_comment_after_quoted_block_item_ok(tmp_path):
+    # likewise a comment after a quoted block item is benign (the element is complete).
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_source('source:\n  - "README.md" # note'))
+    rc, out = validate(b)
+    assert rc == 0, out
+
+
+def test_source_duplicate_key_later_unquoted_hash_fails(tmp_path):
+    # YAML keeps the LAST of duplicate keys, so a valid first source followed by a later
+    # source that drops "#445" must still fail — scan every top-level source occurrence.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_source(
+        'source: ["README.md"]\nsource:\n  - issue #445'))
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "source" in out and "#" in out
+
+
+def test_source_unquoted_with_apostrophe_then_hash_fails(tmp_path):
+    # a quote mid plain-scalar (the apostrophe in "Joe's") is literal YAML content, so
+    # `- Joe's issue #445` is an unquoted scalar that still drops "#445" — the scan must
+    # not mistake the apostrophe for the start of a quoted string and skip the comment.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_source("source:\n  - Joe's issue #445"))
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "source" in out and "#" in out
+
+
 # --- uppercase .md extension handling (#150 sub-item 2) ----------------------
 
 def test_uppercase_md_file_rejected(tmp_path):


### PR DESCRIPTION
## What

Hardens `check_source_quoting` in the okf-wiki validator so an unquoted `#`
can no longer silently truncate a `source` provenance pointer, and so valid
frontmatter is no longer rejected.

The block-style enforcement added in #166 had three gaps that the cloud
review on that PR flagged after it merged, and reviewing this fix locally
surfaced three more. All six are fixed here with one regression test each.

## The six cases

| # | Shape | Before | Now |
|---|-------|--------|-----|
| 1 | multi-line flow list `["a", b #c\n]` | passed, dropped `#c` | rejected |
| 2 | wrapped block scalar (`#` on a continuation line) | passed, dropped data | rejected |
| 3 | nested `source:` in other metadata | valid bundle **rejected** | accepted |
| 4 | trailing comment after a complete value (`["a"] # why`, `- "a" # note`) | valid bundle **rejected** | accepted |
| 5 | duplicate top-level `source:` keys (YAML keeps the last) | only the first scanned | every occurrence scanned |
| 6 | plain scalar with an inner apostrophe (`Joe's issue #445`) | passed, dropped `#445` | rejected |

## How

The old code special-cased lines starting with `-`, so any other list shape
fell through. The rewrite extracts the raw text of every top-level `source`
value region and scans it with one quote- and structure-aware pass:

- a `#` is data loss only when it interrupts an **unquoted scalar** — a `#`
  after a closed quote, flow bracket, or separator is a benign comment;
- a quote opens a string only at a **value boundary**, so a mid-scalar
  apostrophe stays literal content.

This collapses block, flow, and wrapped shapes into a single rule and removes
the two false positives (cases 3 and 4) that could reject conforming bundles.

## Tests

Six new regression tests (one per case) plus the existing source-quoting
suite. Full okf-wiki suite: 93 passed. The example bundle still validates,
and the vendored `example/scripts/validate.py` copy stays byte-identical
(the #162 drift guard enforces this).
