### PR TITLE
okf-wiki: clarify verified-date rule for conversation-authored concepts (#172)

### DIFF
--- a/okf-wiki/SKILL.md
+++ b/okf-wiki/SKILL.md
@@ -97,10 +97,23 @@ mechanical transform. So you (Claude) author the concepts directly, in this loop
      Org, Source. Plus Reference (the catch-all). The set is closed; an unlisted type fails.
    - `description` is one line. `source` — quote every element — points at where the fact
      actually came from (the origin file path, URL, command, or event), not at this skill.
-   - Set `timestamp` to today. Set `verified` to today only for a fact you actually re-checked
-     now; for a claim copied from the source without re-checking, use the date it was last known
-     true (e.g. the source's own date), not today — stamping today makes stale facts look freshly
-     verified.
+   - Set `timestamp` to today. `verified` is the date the fact was last confirmed true — set it by
+     how you came to know it, not reflexively to today:
+     - You re-checked it against reality now, or the user is the authority for it (a decision,
+       preference, or intent they state in this session): today.
+     - The user is recalling external or system state (a spec, a path, a config): their memory is a
+       source claim, not a re-check, so date it to when that state was last checked or to the
+       recollection's own date — not today just because it came up now.
+     - It was copied from a dated source without re-checking: the date it was last known true (the
+       source's own date), not today.
+     - It came from an undated record you cannot re-confirm (a memory file, an old conversation):
+       the oldest date you can evidence — file timestamp, introducing commit, or the date it was
+       said — never today. If you cannot evidence any date at all, it is not yet a verifiable fact;
+       find a datable source or leave the concept out.
+     When the date is uncertain, round it down: an older `verified` correctly reads as "may be
+     stale, re-check," while today reads as "just confirmed." The frontmatter date is the contract;
+     a caveat in the body does not undo an overstated value, because the validator and tools read
+     only the date.
    - Strip secret values as you go: a credential concept names the key and its retrieval path,
      never the value. The validator fails the build on a leaked secret.
 4. **Place and link.** Put each concept in the right section (create sections as needed), add a
@@ -141,8 +154,10 @@ Full contract in `spec/SPEC.md`. The load-bearing rules:
   (domain-neutral); or Reference (catch-all).
 - **Quote every `source` element** — source pointers carry `#` and `: ` which break YAML
   if unquoted. `source: ["README.md", "issue #445"]`.
-- **`verified`** is the date the fact was last checked against reality; **`timestamp`** is
-  when the concept was authored/updated. Both ISO `YYYY-MM-DD`.
+- **`verified`** is the date the fact was last confirmed true — a re-check against reality, or the
+  user stating a fact they are the authority for (a decision, a preference); a fact they merely
+  recall about external state is a source claim, not a re-check. **`timestamp`** is when the concept
+  was authored/updated. Both ISO `YYYY-MM-DD`. See the authoring loop above for the full date rules.
 - **No secret values, ever.** A credential concept documents the key name and retrieval
   path, never the value. The validator fails the build on a leaked secret.
 - **`index.md` and `log.md` are reserved** — no frontmatter (except the bundle-root

--- a/okf-wiki/example/SPEC.md
+++ b/okf-wiki/example/SPEC.md
@@ -51,9 +51,22 @@ bad-type one.
 | `title` | the concept name |
 | `description` | one line |
 | `source` | YAML list of provenance pointers (paths, commands, URLs, events) |
-| `verified` | ISO date `YYYY-MM-DD` the concept was last checked against reality |
+| `verified` | ISO date `YYYY-MM-DD` the fact was last confirmed true (see note below) |
 | `timestamp` | ISO date authored/updated |
 | `tags` | YAML list |
+
+`verified` note: it records when the fact was last confirmed true, which is not always today. A
+fact you re-checked against reality now is confirmed today, as is one the user is the authority for
+— a decision, preference, or intent they state directly. But a fact the user is recalling about
+external or system state is a source claim, not a re-check: date it to when that state was last
+checked or to the recollection's own date, not today. A claim copied from a dated source without
+re-checking carries that source's date. A fact taken from an undated record you cannot re-confirm (a
+memory file, an old conversation) carries the oldest date you can evidence — file timestamp,
+introducing commit, or the date it was said — never today; if no date can be evidenced, the fact is
+not yet verifiable, so find a datable source or leave it out. When the date is uncertain, round it
+down: an older `verified` reads as "may be stale," today reads as "just confirmed." The date is the
+contract; a caveat in the concept body does not undo it, because the validator and tools read only
+the date.
 
 `source` quoting rule (hard): QUOTE every element of the `source` list. Source pointers
 routinely carry YAML-significant characters — a `#` (e.g. `"issue #445"`) starts a comment

--- a/okf-wiki/spec/SPEC.md
+++ b/okf-wiki/spec/SPEC.md
@@ -51,9 +51,22 @@ bad-type one.
 | `title` | the concept name |
 | `description` | one line |
 | `source` | YAML list of provenance pointers (paths, commands, URLs, events) |
-| `verified` | ISO date `YYYY-MM-DD` the concept was last checked against reality |
+| `verified` | ISO date `YYYY-MM-DD` the fact was last confirmed true (see note below) |
 | `timestamp` | ISO date authored/updated |
 | `tags` | YAML list |
+
+`verified` note: it records when the fact was last confirmed true, which is not always today. A
+fact you re-checked against reality now is confirmed today, as is one the user is the authority for
+— a decision, preference, or intent they state directly. But a fact the user is recalling about
+external or system state is a source claim, not a re-check: date it to when that state was last
+checked or to the recollection's own date, not today. A claim copied from a dated source without
+re-checking carries that source's date. A fact taken from an undated record you cannot re-confirm (a
+memory file, an old conversation) carries the oldest date you can evidence — file timestamp,
+introducing commit, or the date it was said — never today; if no date can be evidenced, the fact is
+not yet verifiable, so find a datable source or leave it out. When the date is uncertain, round it
+down: an older `verified` reads as "may be stale," today reads as "just confirmed." The date is the
+contract; a caveat in the concept body does not undo it, because the validator and tools read only
+the date.
 
 `source` quoting rule (hard): QUOTE every element of the `source` list. Source pointers
 routinely carry YAML-significant characters — a `#` (e.g. `"issue #445"`) starts a comment


### PR DESCRIPTION
Closes #172.

## Problem

The `verified`-date guidance covered only two authoring cases: a fact re-checked now (today) and a claim copied from a dated source (the source's date). It said nothing about the common OKF path of authoring concepts from conversation context or undated memory files, where there is no obvious "last known true" date. Authors were left to either stamp today (false precision) or guess. Since `verified` is the field that carries the format's freshness/provenance signal, the gap is load-bearing.

## Resolution

Disambiguate by the thing that actually settles it — **who is the authority for the fact**:

- **Re-checked now, or a fact the user is the authority for** (a decision, preference, or intent they state in-session): today. The user is the ground truth.
- **A fact the user recalls about external/system state** (a spec, a path, a config): a source claim, not a re-check — their memory can be stale, so it carries the date that state was last checked, not today.
- **Copied from a dated source** without re-checking: the source's own date.
- **From an undated record you can't re-confirm**: the oldest date you can evidence (file timestamp, introducing commit, the date it was said), never today. If no date can be evidenced at all, it isn't yet a verifiable fact — find a datable source or leave it out.

Guiding principle added: `verified` must not overstate confidence, so when the date is uncertain, round it **down**. An older date reads as "may be stale, re-check"; today reads as "just confirmed." The frontmatter date is the contract — a caveat in the concept body does not undo an overstated value, because the validator and downstream tooling read only the date.

## Changes

- `okf-wiki/SKILL.md` — expanded the authoring-loop `verified` step and the brief-recap bullet.
- `okf-wiki/spec/SPEC.md` — reframed the table cell and added a `verified` note.
- `okf-wiki/example/SPEC.md` — mirrored byte-for-byte (drift guard `test_example_spec_matches_canonical`).

Docs-only. Validator exits 0 and the 101-test suite stays green.

## Note on #171

Investigated alongside this. #171 reports that okf-wiki hooks re-read files after each `Write`. okf-wiki has only ever shipped two hooks — `okf-anchor.py` (SessionStart, prints the index once) and `okf-orient.py` (PreToolUse, blocks the first action once then unblocks); neither reads or prints file contents, and there has never been a PostToolUse hook (confirmed across full git history). The read-backs the reporter observed are a Claude Code platform / other-plugin behavior, not okf-wiki — so there is no okf-wiki code change to make. Detail posted on the issue.