### PR TITLE
fix(autonomy-kit): well-formed launchd template + static template checks (#104)

### DIFF
--- a/docs/autonomy/kit/templates/launchd.plist.example
+++ b/docs/autonomy/kit/templates/launchd.plist.example
@@ -12,8 +12,9 @@
   wake. The block below covers 7am-7pm; add or remove <dict>s to change the
   cadence (match it to schedule.wake.cron in your config.yaml).
 
-  macOS note: the wake script must call `gtimeout --foreground`, not `timeout`.
-  Install GNU coreutils first:  brew install coreutils
+  macOS note: the wake script must run `gtimeout` (GNU coreutils) in foreground
+  mode, not plain `timeout`, so the kill signal reaches the agent and the log
+  flushes before it dies. Install coreutils first:  brew install coreutils
 
   Untested as of this version. The Linux path is the one that's been run end to
   end; this plist is reasoned from the same design but not yet verified. Load it,

--- a/docs/autonomy/kit/test_templates.py
+++ b/docs/autonomy/kit/test_templates.py
@@ -1,0 +1,152 @@
+"""Static checks for the scheduler templates.
+
+The macOS and Windows recipes cannot be run end to end on the Linux box this kit
+was built on (issue #104), but the templates are still text files with structure
+that must hold before anyone spends real Mac or Windows time on them. These
+checks run anywhere Python does and catch the failure modes that would otherwise
+only surface on the target OS:
+
+- the launchd plist must be well-formed and carry the keys launchd needs;
+- the Task Scheduler script must use the documented registration form, keep its
+  self-bounding timeout wrapper, and embed a well-formed, correctly ordered Task
+  XML (the XSD rejects out-of-order trigger children).
+
+They do not replace the hardware run #104 asks for; they keep the templates from
+regressing before that run happens.
+"""
+
+import plistlib
+import re
+import xml.dom.minidom
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+import pytest
+
+TEMPLATES = Path(__file__).parent / "templates"
+PLIST = TEMPLATES / "launchd.plist.example"
+PS1 = TEMPLATES / "task-scheduler.ps1.example"
+
+
+def test_launchd_plist_is_well_formed_xml():
+    # Catches the class of defect that "--" inside an XML comment is: strict
+    # parsers (expat, libxml2) reject the whole document. A raw DOM parse is the
+    # spec-conformant check; plistlib below is the semantic one.
+    xml.dom.minidom.parse(str(PLIST))
+
+
+def test_launchd_plist_parses_and_has_required_keys():
+    data = plistlib.loads(PLIST.read_bytes())
+    for key in ("Label", "ProgramArguments", "StartCalendarInterval"):
+        assert key in data, f"launchd plist is missing {key}"
+    assert data["Label"], "Label must be non-empty"
+    assert isinstance(data["ProgramArguments"], list) and data["ProgramArguments"]
+
+
+def test_launchd_schedule_is_a_nonempty_list_of_hourly_dicts():
+    data = plistlib.loads(PLIST.read_bytes())
+    schedule = data["StartCalendarInterval"]
+    assert isinstance(schedule, list) and schedule, "StartCalendarInterval must be a non-empty array"
+    for entry in schedule:
+        assert isinstance(entry, dict) and "Hour" in entry
+
+
+def _ps1_text():
+    return PS1.read_text()
+
+
+def test_tasksched_uses_documented_xml_registration_form():
+    text = _ps1_text()
+    assert "Register-ScheduledTask" in text
+    assert "-Xml" in text, "registration must use the documented Register-ScheduledTask -Xml form"
+
+
+def test_tasksched_avoids_the_undocumented_repetition_idiom():
+    # The template's comment explains why the old idiom is wrong, so plain
+    # ".Repetition" appears in prose. What must not appear is an actual
+    # assignment onto a trigger object ($trigger.Repetition = ...), the pattern
+    # observed not to repeat for daily triggers.
+    text = _ps1_text()
+    assert not re.search(r"\$\w+\.Repetition\s*=", text), (
+        "found a .Repetition assignment; use the documented -Xml <Repetition> form instead"
+    )
+
+
+def test_tasksched_keeps_the_self_bounding_timeout_wrapper():
+    # Windows has no `timeout --foreground`, so the wake bounds itself with a
+    # job plus a kill timer that re-raises a bad exit (issue #104, PR #109).
+    text = _ps1_text()
+    for marker in ("Start-Job", "Wait-Job", "Stop-Job", "throw"):
+        assert marker in text, f"timeout wrapper is missing {marker}"
+
+
+def _localname(tag):
+    return tag.rsplit("}", 1)[-1]
+
+
+def _embedded_task_xml():
+    """Return the Task XML from the PowerShell here-string ($xml = @" ... "@)."""
+    match = re.search(r'@"\r?\n(.*?)\r?\n"@', _ps1_text(), re.DOTALL)
+    assert match, "could not find the $xml here-string in the template"
+    return match.group(1)
+
+
+def _embedded_task_root():
+    """Parse the embedded Task XML and return its root element.
+
+    ElementTree rejects a unicode string that carries an encoding declaration,
+    so parse the document body without the prolog; structure is what matters.
+    """
+    body = _embedded_task_xml()
+    body_without_prolog = re.sub(r"^\s*<\?xml.*?\?>", "", body, count=1, flags=re.DOTALL)
+    return ET.fromstring(body_without_prolog)
+
+
+def test_embedded_task_xml_is_well_formed():
+    body = _embedded_task_xml()
+    assert body.lstrip().startswith("<?xml"), "Task XML should keep its declaration"
+    _embedded_task_root()  # raises if the body is not well-formed
+
+
+def test_embedded_task_xml_trigger_children_are_in_xsd_order():
+    # The Task Scheduler XSD fixes the CalendarTrigger child order; out-of-order
+    # children make Register-ScheduledTask reject the whole task. The template's
+    # own comment pins this order, so pin it in a test too.
+    root = _embedded_task_root()
+
+    trigger = next(
+        (el for el in root.iter() if _localname(el.tag) == "CalendarTrigger"), None
+    )
+    assert trigger is not None, "no CalendarTrigger in the embedded Task XML"
+    order = [_localname(child.tag) for child in trigger]
+    assert order == ["Enabled", "StartBoundary", "Repetition", "ScheduleByDay"], (
+        f"CalendarTrigger children out of XSD order: {order}"
+    )
+
+
+def test_embedded_task_xml_action_context_names_a_defined_principal():
+    # The template warns that Actions Context must name a defined Principal id,
+    # or Register-ScheduledTask rejects the task (task-scheduler.ps1.example
+    # documents this next to the trigger-order rule). Guard it the same way:
+    # an unmatched Context is a silent, Windows-only failure otherwise.
+    root = _embedded_task_root()
+
+    principal_ids = {
+        el.get("id")
+        for el in root.iter()
+        if _localname(el.tag) == "Principal" and el.get("id")
+    }
+    contexts = [
+        el.get("Context")
+        for el in root.iter()
+        if _localname(el.tag) == "Actions" and el.get("Context")
+    ]
+    assert contexts, "the Actions element should name a Context"
+    for context in contexts:
+        assert context in principal_ids, (
+            f"Actions Context {context!r} names no defined Principal id {sorted(principal_ids)}"
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## What

Progresses #104 on the half that does not need Mac or Windows hardware: fix a real defect in the macOS template found statically, and add a selftest that pins both templates' structure so they cannot regress before someone runs them end to end.

## The defect

`docs/autonomy/kit/templates/launchd.plist.example` carried `` `gtimeout --foreground` `` inside its opening XML comment. A `--` is illegal inside an XML comment, so strict parsers reject the whole plist:

```
xml.parsers.expat.ExpatError: not well-formed (invalid token): line 15, column 52
```

`plistlib`, `xml.dom.minidom` (expat), and `libxml2` all reject it. Whether launchd's own lenient CoreFoundation parser also rejects it is exactly what the end-to-end macOS run in #104 would settle, but shipping spec-valid XML costs nothing and removes the ambiguity. The reword keeps the instruction (run `gtimeout` in foreground mode, not plain `timeout`) and adds the reason (so the kill signal reaches the agent and the log flushes before it dies, which is one of #104's acceptance criteria). The exact `--foreground` flag stays documented in the README and BUILD spec, where markdown makes it legal.

## The selftest (`docs/autonomy/kit/test_templates.py`)

Nine checks, standard library only:

- **launchd:** the plist is well-formed XML (this fails on the old template, a real red to green), parses via `plistlib`, carries `Label` / `ProgramArguments` / `StartCalendarInterval`, and the schedule is a non-empty list of hourly dicts.
- **Task Scheduler:** the template uses the documented `Register-ScheduledTask -Xml` form, has no `$trigger.Repetition = ...` assignment (the undocumented idiom #109 replaced), and keeps the job-plus-kill-timer wrapper (`Start-Job` / `Wait-Job` / `Stop-Job` / `throw`).
- **Embedded Task XML:** it is well-formed, its `CalendarTrigger` children are in XSD order (`Enabled`, `StartBoundary`, `Repetition`, `ScheduleByDay`), and its `Actions` `Context` names a defined `Principal` `id`. The last two are the two silent, Windows-only validation failures the template's own comment warns about; both are now guarded (a mismatched `Context` was proven to slip through before this check).

## Scope

This does not replace the hardware run #104 asks for. The macOS and Windows checklists (launchd loads, `gtimeout` flushes before the kill, the task repeats hourly, the wrapper kills a hung run, the secret store resolves) still need a real Mac and a real Windows box, and the "untested as of this version" wording stays until then. This change keeps the templates from regressing before that run and catches template-level defects for free.

## Not included: CI wiring

The kit's Python tests (`test_estimate_cost.py`, now `test_templates.py`) are not run by any workflow, so this selftest is not yet enforced in CI. Adding a workflow is a one-way-door change that this repo gates for human sign-off, so I did not add it in an unattended run; filed as a follow-up so it is tracked, not dropped.

codex 5.4 low: clean on the final diff. coach: applied (added the `Actions` `Context` to `Principal` `id` guard).

wake-20260701T1705-2805f9
