### PR TITLE
Fix WCAG AA contrast on the okf-wiki docs page (#132)

### DIFF
--- a/docs/okf-wiki/index.html
+++ b/docs/okf-wiki/index.html
@@ -225,21 +225,21 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <div class="bg-white rounded-xl p-5 border border-mist/30">
                     <div class="flex items-center gap-2 mb-2">
                         <span class="bg-accent text-white text-xs font-bold w-6 h-6 rounded-full flex items-center justify-center flex-shrink-0">1</span>
-                        <span class="font-mono text-xs text-clay/60">SessionStart</span>
+                        <span class="font-mono text-xs text-clay/70">SessionStart</span>
                     </div>
                     <p class="text-sm text-clay/70"><strong>okf-anchor.py</strong> prints the bundle index into Claude's context, so work starts from the map, not from memory.</p>
                 </div>
                 <div class="bg-white rounded-xl p-5 border border-mist/30">
                     <div class="flex items-center gap-2 mb-2">
                         <span class="bg-accent text-white text-xs font-bold w-6 h-6 rounded-full flex items-center justify-center flex-shrink-0">2</span>
-                        <span class="font-mono text-xs text-clay/60">PreToolUse</span>
+                        <span class="font-mono text-xs text-clay/70">PreToolUse</span>
                     </div>
                     <p class="text-sm text-clay/70"><strong>okf-orient.py</strong> blocks the first action once, until Claude confirms it read the index, then unblocks for the rest of the session.</p>
                 </div>
                 <div class="bg-white rounded-xl p-5 border border-mist/30">
                     <div class="flex items-center gap-2 mb-2">
                         <span class="bg-green-600 text-white text-xs font-bold w-6 h-6 rounded-full flex items-center justify-center flex-shrink-0">3</span>
-                        <span class="font-mono text-xs text-clay/60">on edit / in CI</span>
+                        <span class="font-mono text-xs text-clay/70">on edit / in CI</span>
                     </div>
                     <p class="text-sm text-clay/70"><strong>validate.py</strong> checks schema, dates, links, and secrets, and exits non-zero so a broken or stale concept never merges.</p>
                 </div>
@@ -460,7 +460,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <img src="example-screenshot.png" width="1770" height="770"
                      alt="A concept page from the example wiki: a file tree of the bundle on the left, and on the right the okf-wiki plugin concept with its type, source files, verified date, and tags shown above the rendered text."
                      class="rounded-xl border border-mist/30 w-full h-auto" loading="lazy">
-                <figcaption class="text-clay/60 text-sm mt-2">The okf-wiki plugin, documented in the example wiki of this repo.</figcaption>
+                <figcaption class="text-clay/75 text-sm mt-2">The okf-wiki plugin, documented in the example wiki of this repo.</figcaption>
             </figure>
             <p class="text-clay/70 text-sm">
                 Browse the full example, 16 concepts across two sections, on


### PR DESCRIPTION
## What

axe-core (`node scripts/verify_a11y.mjs`) flagged one serious WCAG 1.4.3 violation
on `docs/okf-wiki/index.html`:

| Element | Ratio | Need |
|---|---|---|
| `text-clay/60` card labels (`SessionStart`, `PreToolUse`, `on edit / in CI`) on white | 3.98 | 4.5 |
| `text-clay/60` figcaption on cream `#ede6d4` | 3.67 | 4.5 |

## Fix

Bump the clay opacity per background, the same approach as #122:

- white-backed labels: `text-clay/60` to `text-clay/70` (5.40:1)
- cream-backed figcaption: `text-clay/60` to `text-clay/75` (5.60:1), since the
  darker-on-lighter cream case needs a heavier bump than white to clear

`verify_a11y.mjs` now reports **0 serious** on okf-wiki (was 1). No copy or layout
change, only the label color weight.

Closes #132.

While verifying I found a separate, pre-existing serious contrast violation on the
autonomy page (`.stat__label` / `.hero__meta`, page-local CSS greys rather than the
clay token) and filed it as #182 rather than pulling it into this PR.

wake-20260708T0805-836b98