### PR TITLE
fix(okf-wiki): warn when --force preserves a requirements.txt that omits PyYAML

### DIFF
--- a/okf-wiki/scripts/scaffold.py
+++ b/okf-wiki/scripts/scaffold.py
@@ -343,18 +343,20 @@ def _canonical_req_name(line: str) -> str | None:
 
 def _preserved_requirements_lacks_pyyaml(path: Path) -> bool:
     """True only when we can say with confidence that a preserved requirements.txt does
-    not declare PyYAML: it is readable, no line names PyYAML, and it carries no include,
-    constraint, or editable directive (-r, -c, -e) that could pull PyYAML from a file we
-    do not read. An unreadable file or such a directive returns False, so the targeted
-    warning fires only when the gap is certain and never nags a user who did declare it."""
+    not declare PyYAML: it is readable, no line names PyYAML, and it carries no include or
+    editable directive (-r, -e) that could pull PyYAML from a file we do not read. An
+    unreadable file or such a directive returns False, so the targeted warning fires only
+    when the gap is certain and never nags a user who did declare it. A constraint file
+    (-c/--constraint) only pins versions of packages installed elsewhere and cannot supply
+    a missing one, so it does not suppress the note."""
     try:
         text = path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
         return False
     for raw in text.splitlines():
         s = raw.strip()
-        if s.startswith(("-r", "--requirement", "-c", "--constraint", "-e", "--editable")):
-            return False  # PyYAML may live in the included/constraint/editable target
+        if s.startswith(("-r", "--requirement", "-e", "--editable")):
+            return False  # PyYAML may live in the included (-r) or editable (-e) target
         if _canonical_req_name(raw) == "pyyaml":
             return False
     return True

--- a/okf-wiki/scripts/scaffold.py
+++ b/okf-wiki/scripts/scaffold.py
@@ -40,6 +40,7 @@ import datetime as dt
 import importlib.util
 import json
 import platform
+import re
 import shlex
 import shutil
 import stat
@@ -324,6 +325,41 @@ def write_claude_hooks(target: Path, hooks_os: str) -> None:
     settings_path.write_text(json.dumps(new_settings, indent=2) + "\n", encoding="utf-8")
 
 
+def _canonical_req_name(line: str) -> str | None:
+    """The PEP 503-normalized distribution name a requirements.txt line pins, or None
+    when the line names no installable package (blank, comment, option, URL, or path).
+    Used only to spot whether PyYAML is declared, so it is a name sniffer, not a full
+    requirements parser."""
+    s = line.split("#", 1)[0].strip()  # drop full-line and inline comments
+    if not s or s.startswith("-") or s.startswith("."):
+        return None  # option/include (-r, -e, ...) or a local path, not a bare name
+    # The project name is the leading token, ending at the first version specifier,
+    # marker, extras bracket, whitespace, or "@" direct-reference separator.
+    name = re.split(r"[<>=!~;,@\[ (]", s, maxsplit=1)[0].strip()
+    if not name or "://" in name or "/" in name:
+        return None  # a bare URL or path names no distribution we can normalize
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _preserved_requirements_lacks_pyyaml(path: Path) -> bool:
+    """True only when we can say with confidence that a preserved requirements.txt does
+    not declare PyYAML: it is readable, no line names PyYAML, and it carries no include,
+    constraint, or editable directive (-r, -c, -e) that could pull PyYAML from a file we
+    do not read. An unreadable file or such a directive returns False, so the targeted
+    warning fires only when the gap is certain and never nags a user who did declare it."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return False
+    for raw in text.splitlines():
+        s = raw.strip()
+        if s.startswith(("-r", "--requirement", "-c", "--constraint", "-e", "--editable")):
+            return False  # PyYAML may live in the included/constraint/editable target
+        if _canonical_req_name(raw) == "pyyaml":
+            return False
+    return True
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="Generate a conforming OKF starter bundle.")
     ap.add_argument("target", help="directory to create the project in")
@@ -425,6 +461,15 @@ def main() -> int:
         print("\nScaffold written, but skipping validation: existing files were "
               "preserved, so the bundle is not guaranteed valid by construction and "
               "scripts/validate.py may be your own.", file=sys.stderr)
+        # A preserved requirements.txt is the user's own (#142), so we never edit it. But
+        # if it omits PyYAML, the validate step below fails with ModuleNotFoundError, so
+        # name the exact dependency here rather than leaving them to decode the traceback.
+        req = target / "requirements.txt"
+        if req in preserved and _preserved_requirements_lacks_pyyaml(req):
+            print("  note: the preserved requirements.txt does not list PyYAML, which "
+                  "scripts/validate.py imports. Add PyYAML>=5.1 to it (or run "
+                  "`pip install pyyaml`) before validating. Without it, validation "
+                  "fails with ModuleNotFoundError.", file=sys.stderr)
         print("  reconcile the preserved files, then validate when ready:", file=sys.stderr)
         print(f"    cd {target} && {interpreter_for(hooks_os)} scripts/validate.py --bundle bundle", file=sys.stderr)
         return 0

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -17,6 +17,12 @@ VALIDATE = SKILL / "scripts" / "validate.py"
 TEMPLATE_ANCHOR = SKILL / "templates" / "hooks" / "okf-anchor.py"
 TEMPLATE_ORIENT = SKILL / "templates" / "hooks" / "okf-orient.py"
 
+# Import the scaffolder module to unit-test its pure helpers directly. The CLI tests
+# below drive scaffold.py as a subprocess; the requirements name-sniffing contract is
+# fine-grained enough to pin here without a subprocess round-trip.
+sys.path.insert(0, str(SKILL / "scripts"))
+import scaffold as scaffold_mod  # noqa: E402  the module under test; the local scaffold() helper below shadows the bare name
+
 GOOD = """---
 type: Process
 title: good
@@ -190,6 +196,66 @@ def test_missing_pyyaml_skips_validation(tmp_path):
     assert (target / "bundle" / "index.md").exists()
     # the printed validate command must cd into the target, not the caller's cwd
     assert f"cd {target}" in out
+
+
+def test_force_preserve_warns_when_requirements_lacks_pyyaml(tmp_path):
+    # A preserved requirements.txt is the user's own and stays untouched (#142). When it
+    # omits PyYAML, the skip-validation message must name the exact missing dependency so
+    # the user is not left to decode a later ModuleNotFoundError from validate.py.
+    target = tmp_path / "kb"
+    scaffold(target)
+    (target / "requirements.txt").write_text("requests>=2\n", encoding="utf-8")
+    rc, out = scaffold(target, "--force")
+    assert rc == 0, out
+    assert (target / "requirements.txt").read_text() == "requests>=2\n"  # never edited
+    assert "does not list PyYAML" in out
+    assert "PyYAML>=5.1" in out
+
+
+def test_force_preserve_no_pyyaml_warning_when_declared(tmp_path):
+    # If the preserved requirements.txt already declares PyYAML (any case or pin), the
+    # targeted warning must not fire: validation is still skipped for the preserve, but we
+    # do not nag a user who did the right thing. Lowercase + pin proves name normalization.
+    target = tmp_path / "kb"
+    scaffold(target)
+    (target / "requirements.txt").write_text("pyyaml==6.0.1\n", encoding="utf-8")
+    rc, out = scaffold(target, "--force")
+    assert rc == 0, out
+    assert "skipping validation" in out.lower()  # the preserve still skips validation
+    assert "does not list PyYAML" not in out
+
+
+def test_force_preserve_no_pyyaml_warning_with_include(tmp_path):
+    # A "-r base.txt" include can declare PyYAML in a file the scaffolder does not read, so
+    # an uncertain requirements.txt suppresses the targeted warning rather than making a
+    # false "missing" claim.
+    target = tmp_path / "kb"
+    scaffold(target)
+    (target / "requirements.txt").write_text("-r base.txt\nrequests\n", encoding="utf-8")
+    rc, out = scaffold(target, "--force")
+    assert rc == 0, out
+    assert "skipping validation" in out.lower()
+    assert "does not list PyYAML" not in out
+
+
+@pytest.mark.parametrize("line,expected", [
+    ("PyYAML>=5.1", "pyyaml"),              # version specifier stripped, lowercased
+    ("pyyaml==6.0.1  # pinned", "pyyaml"),  # pin and inline comment stripped
+    ("PyYAML[extra]", "pyyaml"),            # extras bracket stripped
+    ("pyyaml @ https://example.com/p.whl", "pyyaml"),  # direct reference: name kept
+    ("ruamel.yaml", "ruamel-yaml"),         # PEP 503 separator collapse (not PyYAML)
+    ("# a comment", None),                  # comment names no package
+    ("-r base.txt", None),                  # include option names no package
+    ("https://example.com/p.whl", None),    # bare URL names no distribution
+    ("./local/pkg", None),                  # local path names no distribution
+    ("", None),                             # blank line
+])
+def test_canonical_req_name(line, expected):
+    # The pure name sniffer the preserved-requirements PyYAML check relies on: PEP 503
+    # normalization of the leading distribution name, and None for any line that names no
+    # bare package (comment, option, include, URL, or path). Pinned here so a future edit
+    # to the normalization cannot silently break PyYAML detection.
+    assert scaffold_mod._canonical_req_name(line) == expected
 
 
 # --- validator (negative cases) ---------------------------------------------

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -238,6 +238,20 @@ def test_force_preserve_no_pyyaml_warning_with_include(tmp_path):
     assert "does not list PyYAML" not in out
 
 
+def test_force_preserve_warns_with_constraint_file_and_no_pyyaml(tmp_path):
+    # A "-c constraints.txt" only pins versions of packages installed elsewhere; unlike an
+    # include it cannot supply a missing package, so a preserved file that carries only a
+    # constraint and no PyYAML declaration must still warn. Guards against treating -c as an
+    # include and silently suppressing the note (pip: -c "Constrain versions", not install).
+    target = tmp_path / "kb"
+    scaffold(target)
+    (target / "requirements.txt").write_text("-c constraints.txt\nrequests\n", encoding="utf-8")
+    rc, out = scaffold(target, "--force")
+    assert rc == 0, out
+    assert "does not list PyYAML" in out
+    assert "PyYAML>=5.1" in out
+
+
 @pytest.mark.parametrize("line,expected", [
     ("PyYAML>=5.1", "pyyaml"),              # version specifier stripped, lowercased
     ("pyyaml==6.0.1  # pinned", "pyyaml"),  # pin and inline comment stripped


### PR DESCRIPTION
Closes #151.

When `scaffold.py --force` preserves an existing user-owned `requirements.txt` (the skip-if-exists path from #148, kept because #142 says the scaffolder must not modify files the user owns), and that file omits PyYAML, a later `validate.py` run fails with an opaque `ModuleNotFoundError` even though the scaffold itself succeeded.

## Fix
Name the exact dependency in the skip-validation message, rather than mutating the user's file (which #142 forbids) or adding a second requirements file:

- `_canonical_req_name` normalizes a requirements line's distribution name (PEP 503).
- `_preserved_requirements_lacks_pyyaml` returns true only when PyYAML is confidently absent. An unreadable file, or an `-r`/`-c`/`-e` include that could pull PyYAML from a file the scaffolder does not read, suppresses the warning, so a user who already declared the dependency is never nagged.

The message names `PyYAML>=5.1`, matching the pin the scaffold itself writes, so there is no drift between what the scaffold declares and what the warning tells the user to add.

## Tests
114 pass. New coverage: the warn, suppress (include), and declared paths through the CLI, plus a direct unit test pinning the name-normalization contract (extras brackets, `@` direct references, inline comments, URLs, local paths).

Considered and rejected per the issue: auto-appending PyYAML to the preserved file (violates #142) and a parallel `okf-requirements.txt` (a confusing second requirements file). This combines the issue's option 1 (name the dependency) and option 2 (warn only when absent).

wake-20260709T0805-9ba297