### PR TITLE
gh-wiki-bootstrap: detect save by the editor path, not a "_new" substring

### DIFF
--- a/okf-wiki/scripts/gh-wiki-bootstrap.py
+++ b/okf-wiki/scripts/gh-wiki-bootstrap.py
@@ -29,8 +29,24 @@ import argparse
 import os
 import re
 import sys
+from urllib.parse import urlsplit
 
 DEFAULT_STATE = os.path.expanduser("~/.cache/gh_state.json")
+
+
+def _still_on_editor(url):
+    """True while the browser is still sitting on the new-page editor.
+
+    The new-wiki-page editor lives at the path `/<owner>/<repo>/wiki/_new` and,
+    on a successful save, GitHub redirects to `/<owner>/<repo>/wiki/<slug>`. The
+    save-success signal is leaving that editor path. Testing the whole URL for
+    the substring "_new" misfires whenever "_new" appears anywhere else in it —
+    the owner, the repo name (e.g. owner/service_new), or a saved page's slug:
+    the redirected URL still contains the substring, so a real save reads as a
+    failure and the tool wrongly reports it never saved. Match the editor by its
+    path suffix instead, ignoring a trailing slash and any query or fragment.
+    """
+    return urlsplit(url).path.rstrip("/").endswith("/wiki/_new")
 
 
 def parse_args():
@@ -130,7 +146,7 @@ def main():
         # slow-but-successful save is not mistaken for a failure.
         saved = True
         try:
-            page.wait_for_url(lambda u: "_new" not in u, timeout=20000)
+            page.wait_for_url(lambda u: not _still_on_editor(u), timeout=20000)
         except PWTimeout:
             saved = False
         final_url = page.url
@@ -140,7 +156,7 @@ def main():
 
     # If we never left the editor, the save was rejected (no wiki write access,
     # bad title, inline validation error) — do not report success.
-    if not saved or "_new" in final_url:
+    if not saved or _still_on_editor(final_url):
         print(f"error: wiki editor never redirected to a created page ({final_url}) — "
               "save not confirmed. Check the saved session has wiki write access and "
               "the title is valid.", file=sys.stderr)

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -23,6 +23,15 @@ TEMPLATE_ORIENT = SKILL / "templates" / "hooks" / "okf-orient.py"
 sys.path.insert(0, str(SKILL / "scripts"))
 import scaffold as scaffold_mod  # noqa: E402  the module under test; the local scaffold() helper below shadows the bare name
 
+# Load gh-wiki-bootstrap.py by path (its hyphenated name is not importable) so its
+# pure save-detection helper can be unit-tested without a browser. Its playwright
+# import lives inside main(), so importing the module top-level touches only stdlib.
+import importlib.util  # noqa: E402
+_boot_spec = importlib.util.spec_from_file_location(
+    "gh_wiki_bootstrap", SKILL / "scripts" / "gh-wiki-bootstrap.py")
+gh_wiki_bootstrap = importlib.util.module_from_spec(_boot_spec)
+_boot_spec.loader.exec_module(gh_wiki_bootstrap)
+
 GOOD = """---
 type: Process
 title: good
@@ -1364,3 +1373,23 @@ def test_dangling_uppercase_md_link_caught(tmp_path):
     rc, out = validate(b)
     assert rc == 1, out
     assert "ghost.MD" in out
+
+
+@pytest.mark.parametrize("url,on_editor", [
+    # Still on the editor: save has not completed.
+    ("https://github.com/owner/repo/wiki/_new", True),
+    ("https://github.com/owner/repo/wiki/_new/", True),
+    ("https://github.com/owner/repo/wiki/_new?foo=bar", True),
+    ("https://github.com/owner/repo/wiki/_new#section", True),
+    # Redirected to a saved page: save confirmed.
+    ("https://github.com/owner/repo/wiki/Home", False),
+    ("https://github.com/owner/repo/wiki/_new-notes", False),
+    # The regression: a repo whose NAME contains "_new" still redirects to a
+    # saved page, but the old whole-URL substring check read it as a failure.
+    ("https://github.com/owner/service_new/wiki/Home", False),
+    ("https://github.com/owner/service_new/wiki/service_new", False),
+    # ...and that same repo's editor URL is still correctly detected as unsaved.
+    ("https://github.com/owner/service_new/wiki/_new", True),
+])
+def test_still_on_editor_matches_the_editor_path_not_the_substring(url, on_editor):
+    assert gh_wiki_bootstrap._still_on_editor(url) is on_editor


### PR DESCRIPTION
Progresses one item of the okf-wiki Tier-5 minor/cosmetic backlog (#156): the wiki bootstrapper reported a false save-failure for any repo whose name contains `_new`.

## The bug
`gh-wiki-bootstrap.py` decided a save succeeded by checking the browser URL no longer contained the substring `_new`. The new-page editor is at path `/<owner>/<repo>/wiki/_new` and redirects to `/<owner>/<repo>/wiki/<slug>` on save — but `_new` can also appear in the owner, the repo name (e.g. `owner/service_new`), or a saved slug, so the redirected URL still matched the substring. A real save then read as a failure (exit 6) even though the write landed.

## The fix
- Extract a pure `_still_on_editor(url)` helper that matches the editor by its `/wiki/_new` path suffix, ignoring a trailing slash, query, and fragment.
- Route both the wait-for-redirect predicate and the final failure check through it (one source of truth).
- Add a parametrized unit test (loaded via `importlib`, since the hyphenated script name is not importable) covering the editor/saved cases, the `service_new` regression, the `_new-notes` slug that must not match, and the preserved positive (`service_new`'s own editor URL still reads as unsaved).

## Verification
- okf-wiki suite: `python3 -m pytest okf-wiki/tests/ -q` → 124 passed.
- codex 5.5/low review: clean, no findings.
- coach pass: applied (widened the docstring bug-class wording to match the tests; added the URL-fragment case).

No behavior change beyond the save-detection predicate; no other backlog items touched.

wake-20260710T1005-215cde