### PR TITLE
Reject aliased, merged, and duplicate source in okf-wiki's quoting check

### DIFF
--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -192,7 +192,108 @@ def _plain_scalar_dropped_comment(node, raw_fm):
     return j < len(raw_fm) and raw_fm[j] == "#"
 
 
-def check_source_quoting(rel, raw_fm, errors):
+# PyYAML resolves both `<<` and an explicit `!!merge` tag to this tag; a key carrying it is a
+# merge directive regardless of how it is spelled, so it is never a real mapping key.
+_MERGE_TAG = "tag:yaml.org,2002:merge"
+
+
+def _child_ref_counts(root):
+    """Map id(node) -> how many times it is referenced as a child across the tree.
+
+    A YAML alias makes the composer reuse the anchor's node object, so an alias TARGET
+    is the one node referenced 2+ times. Each unique node is traversed once (guarded by
+    a seen set) so a recursive anchor cannot loop; references are still counted with
+    multiplicity."""
+    counts: dict[int, int] = {}
+    seen: set[int] = set()
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        if id(node) in seen:
+            continue
+        seen.add(id(node))
+        children: list = []
+        if isinstance(node, yaml.MappingNode):
+            for k, v in node.value:
+                children += (k, v)
+        elif isinstance(node, yaml.SequenceNode):
+            children += list(node.value)
+        for c in children:
+            counts[id(c)] = counts.get(id(c), 0) + 1
+            stack.append(c)
+    return counts
+
+
+def _value_uses_alias(val_node, counts):
+    """True if any node in this value's subtree is reached via a YAML alias.
+
+    An alias target is the same node object referenced 2+ times in the whole frontmatter
+    (counts), or reached twice while walking this one subtree (a cycle). An unused anchor
+    is referenced once, so an anchored literal is not flagged — consistent with allowing
+    `source: [&p "x"]`. Rejecting alias USES closes #169: an aliased scalar shares its
+    anchor's position marks, so the end-mark quoting check cannot see a comment dropped
+    after the alias."""
+    seen: set[int] = set()
+    stack = [val_node]
+    while stack:
+        node = stack.pop()
+        if id(node) in seen:
+            return True  # reached twice within source -> an alias points back into it
+        seen.add(id(node))
+        if counts.get(id(node), 0) >= 2:
+            return True  # shared with another reference -> an alias target
+        if isinstance(node, yaml.MappingNode):
+            for k, v in node.value:
+                stack += (k, v)
+        elif isinstance(node, yaml.SequenceNode):
+            stack += list(node.value)
+    return False
+
+
+def _mapping_yields_source(node, seen):
+    """True if this mapping node's effective keys include 'source', counting keys reached
+    through its own (possibly nested) merge keys.
+
+    A merged mapping can itself merge in another mapping ('<<: *d' where d is '<<: {source:
+    ...}'), so checking only the immediate keys misses a source that safe_load still
+    materializes. Recurse through each merge key's mapping(s). The seen set guards a
+    recursive anchor (&d {<<: *d}) from looping."""
+    if not isinstance(node, yaml.MappingNode) or id(node) in seen:
+        return False
+    seen.add(id(node))
+    for key, val in node.value:
+        if not isinstance(key, yaml.ScalarNode):
+            continue
+        if key.tag == _MERGE_TAG:
+            for merged in (val.value if isinstance(val, yaml.SequenceNode) else [val]):
+                if _mapping_yields_source(merged, seen):
+                    return True
+        elif key.value == "source":
+            return True
+    return False
+
+
+def _merge_supplies_source(root):
+    """True if a top-level YAML merge key (<<) merges in a mapping that yields its own
+    'source' key, directly or through a further nested merge.
+
+    YAML lets a literal 'source:' override a merged one, so a source smuggled in through
+    '<<: {source: ...}' (or a chain of merges that resolves to source) beside a literal is
+    silently dropped and the top-level source-key scan (which keys on literal 'source'
+    nodes) never sees it. A merge value is a mapping, or a sequence of mappings ('<<: [*a,
+    *b]'); compose resolves an alias to the shared node, so an aliased merge map is a
+    MappingNode here. Detecting it lets a merge-supplied source be rejected whether or not
+    a literal source sits beside it."""
+    for key, val in root.value:
+        if not (isinstance(key, yaml.ScalarNode) and key.tag == _MERGE_TAG):
+            continue
+        for node in (val.value if isinstance(val, yaml.SequenceNode) else [val]):
+            if _mapping_yields_source(node, set()):
+                return True
+    return False
+
+
+def check_source_quoting(rel, fm, raw_fm, errors):
     """Enforce the SPEC 'source' quoting rule, where YAML's comment stripping would
     otherwise silently drop part of a provenance pointer.
 
@@ -205,8 +306,15 @@ def check_source_quoting(rel, raw_fm, errors):
     block items, single- and multi-line flow lists, wrapped scalars, quoted strings with
     escapes, anchors/tags, and block scalars — without re-implementing the parser. It is
     scoped to the top-level `source` key only (a nested `source:` under other metadata is
-    not the OKF provenance list) and inspects every top-level occurrence, since YAML keeps
-    the last of duplicate keys. A real parse error is reported by the schema check."""
+    not the OKF provenance list). A real parse error is reported by the schema check.
+
+    `fm` is the safe_load result the caller already parsed. A `source` can enter it through
+    a YAML merge key (`<<: {source: *r}`), a whole-node alias, an alias in key position, or a
+    duplicate `source` key — each materializes the field, but YAML keeps the LAST of duplicate
+    keys, so the value safe_load returns is not necessarily the first clean `source:` the scan
+    finds. OKF source must be one literal top-level list, so this requires the effective source
+    to come from exactly one literal, unshared `source:` key and rejects every indirection
+    (merge, alias, duplicate) up front — which also keeps the node-tree quoting scan total."""
     if not raw_fm:
         return
     try:
@@ -215,9 +323,46 @@ def check_source_quoting(rel, raw_fm, errors):
         return
     if not isinstance(root, yaml.MappingNode):
         return
-    for key_node, val_node in root.value:
-        if not (isinstance(key_node, yaml.ScalarNode) and key_node.value == "source"):
-            continue
+    counts = _child_ref_counts(root)
+    # YAML keeps the LAST of duplicate keys, so the value safe_load returns for `source` is
+    # decided by the last top-level key that resolves to "source" — not the first clean one.
+    # Collect every such key. An alias in key position (`*k` resolving to "source") makes
+    # compose reuse the anchor's node, so the key reads as a "source" scalar while the written
+    # key is an alias — count >= 2 marks that sharing, so an aliased key is not unshared. A key
+    # SPELLED "source" but carrying the explicit merge tag (`!!merge source:`) is a merge
+    # directive, not a source key — PyYAML classifies merge by the tag, not the spelling — so
+    # exclude it here: counting it would both falsely reject a file whose only real source is a
+    # separate literal, and let a source merged in through it bypass the scan below.
+    source_keys = [
+        (k, v) for k, v in root.value
+        if isinstance(k, yaml.ScalarNode) and k.value == "source"
+        and k.tag != _MERGE_TAG
+    ]
+    unshared = [(k, v) for k, v in source_keys if counts.get(id(k), 0) < 2]
+    if fm.get("source") is not None and (
+        len(source_keys) != 1 or not unshared or _merge_supplies_source(root)
+    ):
+        errors.append(
+            f"{rel}: 'source' is not a single literal top-level 'source:' key — it enters "
+            f"through a YAML merge key (<<), an alias, or a duplicate 'source' key; OKF "
+            f"'source' must be one literal top-level list of provenance pointers — declare "
+            f"it directly instead of merging, aliasing, or duplicating it")
+        return
+    for key_node, val_node in source_keys:
+        # A YAML anchor/alias that entangles source with the rest of the frontmatter
+        # shares node identity and position marks, so the dropped-comment scan below
+        # reads the anchor's definition line, not the use site, and can miss a truncated
+        # pointer (#169). OKF source is a flat list of literal, self-contained pointers
+        # anyway, so any anchor/alias SHARING is invalid here — reject it, which keeps the
+        # quoting scan total. An unused anchor definition (`[&p "x"]`) shares nothing and
+        # stays allowed.
+        if _value_uses_alias(val_node, counts):
+            errors.append(
+                f"{rel}: a top-level 'source' value shares a YAML anchor/alias (& or *) "
+                f"with the rest of the frontmatter; OKF 'source' must be a flat list of "
+                f"literal provenance pointers — write each pointer out literally instead "
+                f"of anchoring or aliasing it")
+            return
         if isinstance(val_node, yaml.SequenceNode):
             scalars = [n for n in val_node.value if isinstance(n, yaml.ScalarNode)]
         elif isinstance(val_node, yaml.ScalarNode):
@@ -384,7 +529,7 @@ def main() -> int:
 
         check_lists(rel, fm, errors)
         check_dates(rel, fm, errors)
-        check_source_quoting(rel, frontmatter_block(text), errors)
+        check_source_quoting(rel, fm, frontmatter_block(text), errors)
 
     # Link resolution: every internal link to a .md file must resolve to a file
     # that exists inside the bundle. A link escaping the bundle root or pointing at

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -192,7 +192,108 @@ def _plain_scalar_dropped_comment(node, raw_fm):
     return j < len(raw_fm) and raw_fm[j] == "#"
 
 
-def check_source_quoting(rel, raw_fm, errors):
+# PyYAML resolves both `<<` and an explicit `!!merge` tag to this tag; a key carrying it is a
+# merge directive regardless of how it is spelled, so it is never a real mapping key.
+_MERGE_TAG = "tag:yaml.org,2002:merge"
+
+
+def _child_ref_counts(root):
+    """Map id(node) -> how many times it is referenced as a child across the tree.
+
+    A YAML alias makes the composer reuse the anchor's node object, so an alias TARGET
+    is the one node referenced 2+ times. Each unique node is traversed once (guarded by
+    a seen set) so a recursive anchor cannot loop; references are still counted with
+    multiplicity."""
+    counts: dict[int, int] = {}
+    seen: set[int] = set()
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        if id(node) in seen:
+            continue
+        seen.add(id(node))
+        children: list = []
+        if isinstance(node, yaml.MappingNode):
+            for k, v in node.value:
+                children += (k, v)
+        elif isinstance(node, yaml.SequenceNode):
+            children += list(node.value)
+        for c in children:
+            counts[id(c)] = counts.get(id(c), 0) + 1
+            stack.append(c)
+    return counts
+
+
+def _value_uses_alias(val_node, counts):
+    """True if any node in this value's subtree is reached via a YAML alias.
+
+    An alias target is the same node object referenced 2+ times in the whole frontmatter
+    (counts), or reached twice while walking this one subtree (a cycle). An unused anchor
+    is referenced once, so an anchored literal is not flagged — consistent with allowing
+    `source: [&p "x"]`. Rejecting alias USES closes #169: an aliased scalar shares its
+    anchor's position marks, so the end-mark quoting check cannot see a comment dropped
+    after the alias."""
+    seen: set[int] = set()
+    stack = [val_node]
+    while stack:
+        node = stack.pop()
+        if id(node) in seen:
+            return True  # reached twice within source -> an alias points back into it
+        seen.add(id(node))
+        if counts.get(id(node), 0) >= 2:
+            return True  # shared with another reference -> an alias target
+        if isinstance(node, yaml.MappingNode):
+            for k, v in node.value:
+                stack += (k, v)
+        elif isinstance(node, yaml.SequenceNode):
+            stack += list(node.value)
+    return False
+
+
+def _mapping_yields_source(node, seen):
+    """True if this mapping node's effective keys include 'source', counting keys reached
+    through its own (possibly nested) merge keys.
+
+    A merged mapping can itself merge in another mapping ('<<: *d' where d is '<<: {source:
+    ...}'), so checking only the immediate keys misses a source that safe_load still
+    materializes. Recurse through each merge key's mapping(s). The seen set guards a
+    recursive anchor (&d {<<: *d}) from looping."""
+    if not isinstance(node, yaml.MappingNode) or id(node) in seen:
+        return False
+    seen.add(id(node))
+    for key, val in node.value:
+        if not isinstance(key, yaml.ScalarNode):
+            continue
+        if key.tag == _MERGE_TAG:
+            for merged in (val.value if isinstance(val, yaml.SequenceNode) else [val]):
+                if _mapping_yields_source(merged, seen):
+                    return True
+        elif key.value == "source":
+            return True
+    return False
+
+
+def _merge_supplies_source(root):
+    """True if a top-level YAML merge key (<<) merges in a mapping that yields its own
+    'source' key, directly or through a further nested merge.
+
+    YAML lets a literal 'source:' override a merged one, so a source smuggled in through
+    '<<: {source: ...}' (or a chain of merges that resolves to source) beside a literal is
+    silently dropped and the top-level source-key scan (which keys on literal 'source'
+    nodes) never sees it. A merge value is a mapping, or a sequence of mappings ('<<: [*a,
+    *b]'); compose resolves an alias to the shared node, so an aliased merge map is a
+    MappingNode here. Detecting it lets a merge-supplied source be rejected whether or not
+    a literal source sits beside it."""
+    for key, val in root.value:
+        if not (isinstance(key, yaml.ScalarNode) and key.tag == _MERGE_TAG):
+            continue
+        for node in (val.value if isinstance(val, yaml.SequenceNode) else [val]):
+            if _mapping_yields_source(node, set()):
+                return True
+    return False
+
+
+def check_source_quoting(rel, fm, raw_fm, errors):
     """Enforce the SPEC 'source' quoting rule, where YAML's comment stripping would
     otherwise silently drop part of a provenance pointer.
 
@@ -205,8 +306,15 @@ def check_source_quoting(rel, raw_fm, errors):
     block items, single- and multi-line flow lists, wrapped scalars, quoted strings with
     escapes, anchors/tags, and block scalars — without re-implementing the parser. It is
     scoped to the top-level `source` key only (a nested `source:` under other metadata is
-    not the OKF provenance list) and inspects every top-level occurrence, since YAML keeps
-    the last of duplicate keys. A real parse error is reported by the schema check."""
+    not the OKF provenance list). A real parse error is reported by the schema check.
+
+    `fm` is the safe_load result the caller already parsed. A `source` can enter it through
+    a YAML merge key (`<<: {source: *r}`), a whole-node alias, an alias in key position, or a
+    duplicate `source` key — each materializes the field, but YAML keeps the LAST of duplicate
+    keys, so the value safe_load returns is not necessarily the first clean `source:` the scan
+    finds. OKF source must be one literal top-level list, so this requires the effective source
+    to come from exactly one literal, unshared `source:` key and rejects every indirection
+    (merge, alias, duplicate) up front — which also keeps the node-tree quoting scan total."""
     if not raw_fm:
         return
     try:
@@ -215,9 +323,46 @@ def check_source_quoting(rel, raw_fm, errors):
         return
     if not isinstance(root, yaml.MappingNode):
         return
-    for key_node, val_node in root.value:
-        if not (isinstance(key_node, yaml.ScalarNode) and key_node.value == "source"):
-            continue
+    counts = _child_ref_counts(root)
+    # YAML keeps the LAST of duplicate keys, so the value safe_load returns for `source` is
+    # decided by the last top-level key that resolves to "source" — not the first clean one.
+    # Collect every such key. An alias in key position (`*k` resolving to "source") makes
+    # compose reuse the anchor's node, so the key reads as a "source" scalar while the written
+    # key is an alias — count >= 2 marks that sharing, so an aliased key is not unshared. A key
+    # SPELLED "source" but carrying the explicit merge tag (`!!merge source:`) is a merge
+    # directive, not a source key — PyYAML classifies merge by the tag, not the spelling — so
+    # exclude it here: counting it would both falsely reject a file whose only real source is a
+    # separate literal, and let a source merged in through it bypass the scan below.
+    source_keys = [
+        (k, v) for k, v in root.value
+        if isinstance(k, yaml.ScalarNode) and k.value == "source"
+        and k.tag != _MERGE_TAG
+    ]
+    unshared = [(k, v) for k, v in source_keys if counts.get(id(k), 0) < 2]
+    if fm.get("source") is not None and (
+        len(source_keys) != 1 or not unshared or _merge_supplies_source(root)
+    ):
+        errors.append(
+            f"{rel}: 'source' is not a single literal top-level 'source:' key — it enters "
+            f"through a YAML merge key (<<), an alias, or a duplicate 'source' key; OKF "
+            f"'source' must be one literal top-level list of provenance pointers — declare "
+            f"it directly instead of merging, aliasing, or duplicating it")
+        return
+    for key_node, val_node in source_keys:
+        # A YAML anchor/alias that entangles source with the rest of the frontmatter
+        # shares node identity and position marks, so the dropped-comment scan below
+        # reads the anchor's definition line, not the use site, and can miss a truncated
+        # pointer (#169). OKF source is a flat list of literal, self-contained pointers
+        # anyway, so any anchor/alias SHARING is invalid here — reject it, which keeps the
+        # quoting scan total. An unused anchor definition (`[&p "x"]`) shares nothing and
+        # stays allowed.
+        if _value_uses_alias(val_node, counts):
+            errors.append(
+                f"{rel}: a top-level 'source' value shares a YAML anchor/alias (& or *) "
+                f"with the rest of the frontmatter; OKF 'source' must be a flat list of "
+                f"literal provenance pointers — write each pointer out literally instead "
+                f"of anchoring or aliasing it")
+            return
         if isinstance(val_node, yaml.SequenceNode):
             scalars = [n for n in val_node.value if isinstance(n, yaml.ScalarNode)]
         elif isinstance(val_node, yaml.ScalarNode):
@@ -384,7 +529,7 @@ def main() -> int:
 
         check_lists(rel, fm, errors)
         check_dates(rel, fm, errors)
-        check_source_quoting(rel, frontmatter_block(text), errors)
+        check_source_quoting(rel, fm, frontmatter_block(text), errors)
 
     # Link resolution: every internal link to a .md file must resolve to a file
     # that exists inside the bundle. A link escaping the bundle root or pointing at

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -1220,14 +1220,31 @@ def test_source_trailing_comment_after_quoted_block_item_ok(tmp_path):
 
 def test_source_duplicate_key_later_unquoted_hash_fails(tmp_path):
     # YAML keeps the LAST of duplicate keys, so a valid first source followed by a later
-    # source that drops "#445" must still fail — scan every top-level source occurrence.
+    # duplicate that drops "#445" must still fail. A duplicate `source:` key is malformed
+    # regardless of whether the later value is lossy — the effective source must come from
+    # exactly one literal key — so this is rejected as a duplicate, closing the gap where two
+    # clean duplicate source keys used to pass silently.
     scaffold(tmp_path / "kb", "--no-validate")
     b = tmp_path / "kb" / "bundle"
     write_concept(b, _concept_with_source(
         'source: ["README.md"]\nsource:\n  - issue #445'))
     rc, out = validate(b)
     assert rc == 1, out
-    assert "source" in out and "#" in out
+    assert "source" in out and "duplicate" in out
+
+
+def test_source_two_clean_duplicate_keys_rejected(tmp_path):
+    # regression: two literal `source:` keys that are BOTH clean used to pass silently —
+    # safe_load kept the last and discarded the first with no warning, so a lost provenance
+    # list went unreported. The "exactly one source key" invariant now rejects any duplicate,
+    # lossy or not.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_source(
+        'source: ["README.md"]\nsource: ["LICENSE"]'))
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "source" in out and "duplicate" in out
 
 
 def test_source_unquoted_with_apostrophe_then_hash_fails(tmp_path):
@@ -1338,6 +1355,250 @@ def test_source_anchored_quoted_value_passes(tmp_path):
     write_concept(b, _concept_with_source('source: [&p "issue #445"]'))
     rc, out = validate(b)
     assert rc == 0, out
+
+
+# --- #169: a YAML alias in source defeats the quoting check, so reject it -----
+
+def _concept_with_frontmatter(fm_body):
+    # a concept whose whole frontmatter body is given verbatim (for shapes the fixed
+    # `source:` slot in _concept_with_source cannot express, e.g. an extra anchor key).
+    return f"---\n{fm_body}\n---\n# good\n"
+
+
+def test_source_alias_drops_comment_now_rejected(tmp_path):
+    # #169 false-negative: an aliased block item (`*p`) shares its anchor's node, whose
+    # end mark sits at the anchor definition — so the dropped `#445` after the alias was
+    # never inspected and the lossy bundle passed. An alias in source is now a hard error.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_source("source:\n  - &p README.md\n  - *p #445"))
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "source" in out and "alias" in out
+
+
+def test_source_flow_alias_rejected(tmp_path):
+    # #169 false-positive shape: `source: [*p]` reads the same node as the anchor def on
+    # another key, so the quoting check flagged that line's comment instead of the real
+    # problem. The alias use itself is what's wrong — reject it, with an honest message.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_frontmatter(
+        "type: Process\ntitle: good\ndescription: a good concept\n"
+        "ptr: &p README.md\nsource: [*p]\n"
+        'verified: 2026-06-23\ntimestamp: 2026-06-23\ntags: ["x"]'))
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "source" in out and "alias" in out
+
+
+def test_source_anchor_defined_and_aliased_in_source_rejected(tmp_path):
+    # an anchor defined and aliased entirely within source is still an alias use.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_source('source:\n  - &p "README.md"\n  - *p'))
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "alias" in out
+
+
+def test_source_whole_value_alias_rejected(tmp_path):
+    # the entire source value can be an alias: `source: *p`. That resolves to a list and
+    # would otherwise pass the list/quoting checks, so it must be caught here.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_frontmatter(
+        "type: Process\ntitle: good\ndescription: a good concept\n"
+        'refs: &p ["README.md"]\nsource: *p\n'
+        'verified: 2026-06-23\ntimestamp: 2026-06-23\ntags: ["x"]'))
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "alias" in out
+
+
+def test_source_anchor_definition_still_passes(tmp_path):
+    # regression guard for the existing contract: an anchor DEFINITION on a literal
+    # source element (never aliased) is harmless and must keep passing. Only alias USES
+    # are rejected. (Mirrors test_source_anchored_quoted_value_passes.)
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_source('source: [&p "README.md"]'))
+    rc, out = validate(b)
+    assert rc == 0, out
+
+
+def test_alias_outside_source_with_clean_source_passes(tmp_path):
+    # an anchor/alias used OUTSIDE source must not fail a bundle whose top-level source
+    # is clean and literal — the check is scoped to the source value only.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_frontmatter(
+        "type: Process\ntitle: good\ndescription: a good concept\n"
+        "note: &n reused\nother: *n\n"
+        'source: ["README.md"]\n'
+        'verified: 2026-06-23\ntimestamp: 2026-06-23\ntags: ["x"]'))
+    rc, out = validate(b)
+    assert rc == 0, out
+
+
+def test_source_anchor_shared_with_other_key_rejected(tmp_path):
+    # the other direction: an anchor DEFINED in source but aliased elsewhere entangles
+    # source with the rest of the frontmatter. source must be self-contained literals, so
+    # this is rejected too (the shared node's marks are ambiguous, per #169). Deliberate.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_frontmatter(
+        "type: Process\ntitle: good\ndescription: a good concept\n"
+        'source: [&p "README.md"]\nother: *p\n'
+        'verified: 2026-06-23\ntimestamp: 2026-06-23\ntags: ["x"]'))
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "source" in out and ("anchor" in out or "alias" in out)
+
+
+def test_source_via_merge_key_drops_comment_now_rejected(tmp_path):
+    # #169 sibling: `source` supplied through a YAML merge key (`<<`) is materialized by
+    # safe_load but leaves no literal `source:` key node, so the quoting scan (which keys
+    # on that node) never runs and a dropped `#445` slips through. The merged source must
+    # be rejected: OKF source must be a literal top-level list, not merged in.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_frontmatter(
+        "type: Process\ntitle: good\ndescription: a good concept\n"
+        "refs: &r\n  - issue #445\n<<: {source: *r}\n"
+        'verified: 2026-06-23\ntimestamp: 2026-06-23\ntags: ["x"]'))
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "source" in out and "merge" in out
+
+
+def test_source_via_merge_key_clean_still_rejected(tmp_path):
+    # even a merge-supplied source with no dropped comment is rejected — the indirection
+    # itself is invalid, so the check does not depend on the merged value being lossy.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_frontmatter(
+        "type: Process\ntitle: good\ndescription: a good concept\n"
+        'refs: &r ["README.md"]\n<<: {source: *r}\n'
+        'verified: 2026-06-23\ntimestamp: 2026-06-23\ntags: ["x"]'))
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "source" in out and "merge" in out
+
+
+def test_source_via_merge_key_with_literal_source_rejected(tmp_path):
+    # codex-connector P2: a merge whose mapping carries its own `source` (`<<: {source: ...}`)
+    # sitting beside a literal `source:` key used to pass. YAML lets the literal override the
+    # merged value, so the top-level scan counted only the literal (len 1) and the merged
+    # provenance was silently dropped: the same lost-provenance shape the duplicate-key check
+    # rejects. A merge that supplies source is now rejected whether or not a literal source
+    # sits beside it (the earlier merge tests only covered merge-supplied source with no literal).
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_frontmatter(
+        "type: Process\ntitle: good\ndescription: a good concept\n"
+        '<<: {source: ["LICENSE"]}\nsource: ["README.md"]\n'
+        'verified: 2026-06-23\ntimestamp: 2026-06-23\ntags: ["x"]'))
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "source" in out and "merge" in out
+
+
+def test_source_via_nested_merge_key_with_literal_source_rejected(tmp_path):
+    # codex 5.5 round 1: the merge-supplied-source check must look at the merged mapping's
+    # EFFECTIVE keys, not just its immediate ones. A merge that imports a mapping whose own
+    # `source` arrives through a further nested merge (`defaults: &d {<<: {source: [...]}}`
+    # then `<<: *d`) still materializes source in safe_load, and a literal `source:` overrides
+    # it, dropping the merged provenance. Recursing through nested merges closes that bypass.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_frontmatter(
+        "type: Process\ntitle: good\ndescription: a good concept\n"
+        'defaults: &d {<<: {source: ["LICENSE"]}}\n<<: *d\nsource: ["README.md"]\n'
+        'verified: 2026-06-23\ntimestamp: 2026-06-23\ntags: ["x"]'))
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "source" in out and "merge" in out
+
+
+def test_source_alias_as_key_rejected(tmp_path):
+    # #169 sibling (review): an alias in KEY position (`*k` resolving to "source") makes
+    # compose reuse the anchor's node, so the key reads as a literal "source" while the real
+    # key is an alias. safe_load still materializes source, so this must be rejected like any
+    # other non-literal source key — even when the aliased key's value is itself clean.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_frontmatter(
+        "type: Process\ntitle: good\ndescription: a good concept\n"
+        'source_key: &k source\n*k: ["README.md"]\n'
+        'verified: 2026-06-23\ntimestamp: 2026-06-23\ntags: ["x"]'))
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "source" in out and ("merge" in out or "alias" in out)
+
+
+def test_merge_key_outside_source_with_clean_source_passes(tmp_path):
+    # scope guard: a merge key that supplies OTHER fields, with a literal clean source,
+    # must still pass — the check rejects merged/aliased source only, not every merge key.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_frontmatter(
+        "type: Process\ntitle: good\ndescription: a good concept\n"
+        "defaults: &d\n  note: x\n<<: *d\nsource: [\"README.md\"]\n"
+        'verified: 2026-06-23\ntimestamp: 2026-06-23\ntags: ["x"]'))
+    rc, out = validate(b)
+    assert rc == 0, out
+
+
+def test_source_explicit_merge_tag_key_with_clean_source_passes(tmp_path):
+    # #169 sibling (review round 2): a key SPELLED "source" but carrying the explicit !!merge
+    # tag is a merge directive, not a source key — PyYAML identifies merge by the key's tag,
+    # not its scalar spelling. safe_load merges it and the effective mapping has only the
+    # separate literal `source:`, so the file is valid. Classifying by spelling alone counts
+    # the merge-tagged key as a second "source" key and falsely rejects it.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_frontmatter(
+        "type: Process\ntitle: good\ndescription: a good concept\n"
+        'defaults: &d {note: x}\n!!merge source: *d\nsource: ["README.md"]\n'
+        'verified: 2026-06-23\ntimestamp: 2026-06-23\ntags: ["x"]'))
+    rc, out = validate(b)
+    assert rc == 0, out
+
+
+def test_source_explicit_merge_tag_supplies_lossy_source_rejected(tmp_path):
+    # #169 sibling (review round 2): the other direction — a merge key written with the
+    # explicit !!merge tag but spelled "source" merges a nested source in, so safe_load's
+    # effective source is lossy ("issue", #445 dropped) while no literal source key exists.
+    # Classifying by spelling counts the merge-tagged key as the one literal source and lets
+    # the lossy pointer bypass the scan; the tag must exclude it, so this is rejected.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_frontmatter(
+        "type: Process\ntitle: good\ndescription: a good concept\n"
+        '!!merge source:\n  source:\n    - issue #445\n'
+        'verified: 2026-06-23\ntimestamp: 2026-06-23\ntags: ["x"]'))
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "source" in out
+
+
+def test_source_literal_then_aliased_duplicate_key_rejected(tmp_path):
+    # #169 sibling (review round 2): a clean literal `source:` FIRST, then a second key that
+    # is an alias resolving to "source" (`*k`). YAML keeps the last of duplicate keys, so
+    # safe_load's effective source is the aliased duplicate ("issue", with #445 dropped), yet
+    # the earlier clean literal made the old "at least one clean source key" check pass. The
+    # effective source must come from exactly one literal source key, so the duplicate is
+    # rejected.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, _concept_with_frontmatter(
+        "type: Process\ntitle: good\ndescription: a good concept\n"
+        'source: ["README.md"]\nsource_key: &k source\n*k:\n  - issue #445\n'
+        'verified: 2026-06-23\ntimestamp: 2026-06-23\ntags: ["x"]'))
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "source" in out and "duplicate" in out
 
 
 # --- uppercase .md extension handling (#150 sub-item 2) ----------------------


### PR DESCRIPTION
## What

Closes #169. `check_source_quoting` in okf-wiki's validator walks the composed YAML node tree and reads each `source` scalar's `end_mark` to catch a `#` comment that YAML silently drops. YAML indirection defeated that check: several shapes let a lossy `source` pass validation because the effective value (what `safe_load` returns) no longer came from the literal node the scan inspected.

## The shapes that slipped through

- **Value alias** — `source: *p`: the composer resolves `*p` to the same node object as its anchor, so the aliased element's `end_mark` points at the anchor definition, not the use site, and a comment dropped after the alias was never inspected (the case in #169).
- **Merge key** — `<<: {source: *r}`: `source` materializes in `safe_load`'s output but leaves no literal top-level `source:` key node, so the scan never runs on it.
- **Duplicate `source:` key** (including one written as an alias in key position): YAML keeps the last, so the effective `source` is the later, possibly lossy value while the scan trusted the earlier clean one.
- **Explicit `!!merge source:`** — a key spelled `source` but carrying the merge tag both falsely rejected a valid file and, in another shape, let a merged lossy `source` bypass.

## The fix

OKF `source` is one flat list of literal, self-contained provenance pointers, so none of these is ever valid. Require the effective `source` to come from **exactly one literal, unshared `source:` key**:

- Collect every top-level key that resolves to `source`, classifying by node (not spelling): an aliased key reads as a `source` scalar via `compose`, and a key carrying the explicit merge tag (`tag:yaml.org,2002:merge`) is a merge directive, not a source key, so it is excluded.
- If `safe_load` has a `source` but there is not exactly one such key, or the one key is shared (an alias, detected by child-reference count ≥ 2), reject up front.
- The surviving single literal `source` is still scanned for an alias in its value subtree and for a dropped `#` comment. An unused anchor definition shares nothing and stays allowed.

Defining the rule by outcome rather than structure closes the whole indirection class — merge (`<<` or explicit `!!merge`), whole-node alias, aliased key, and duplicate key — in one predicate, including the latent gap where two clean duplicate `source` keys passed silently.

## Tests

Added rejection tests for the value-alias, merge-key, aliased-key, duplicate-key, and explicit-merge-tag shapes, plus false-rejection guards (a valid file with an unrelated `!!merge`, an unused anchor). The vendored `example/scripts/validate.py` copy is re-synced byte-for-byte. Full suite: 139 passing.
