### PR TITLE
Read PEP 508 markers when checking a preserved requirements.txt for PyYAML

### DIFF
--- a/okf-wiki/scripts/scaffold.py
+++ b/okf-wiki/scripts/scaffold.py
@@ -341,24 +341,122 @@ def _canonical_req_name(line: str) -> str | None:
     return re.sub(r"[-_.]+", "-", name).lower()
 
 
+def _strip_pip_options(text: str) -> str:
+    """Drop pip's per-requirement options (`--hash`, `--global-option`, ...) from a
+    requirements line so packaging.requirements.Requirement, which accepts only PEP 508 and
+    rejects these options, can parse the requirement. Mirrors pip's own break_args_options:
+    split on spaces and keep tokens up to the first that starts with '-'. Rejoining the
+    original space-split tokens preserves the requirement's quotes (unlike shlex, which would
+    strip a marker string's quotes and make a valid marker unparseable); a hash digest and a
+    marker value never begin a bare '-' token, so the requirement is kept whole while the
+    trailing options are dropped."""
+    kept = []
+    for token in text.split(" "):
+        if token.startswith("-"):
+            break
+        kept.append(token)
+    return " ".join(kept)
+
+
+def _requirement_marker_selects_env(line: str) -> bool:
+    """True if a requirements line has no PEP 508 environment marker, or one that selects the
+    current interpreter, so pip would install it here. A marker that excludes this
+    environment returns False: pip installs nothing from that line, so a PyYAML declaration
+    gated to another platform (`PyYAML; sys_platform == "win32"` read on Linux) does not give
+    validate.py the yaml module it imports on every platform. The full PEP 508 grammar (name,
+    extras, direct-reference URL, marker) is parsed by `packaging`, so a '#' inside a quoted
+    marker or a ';' inside a URL is not mistaken for a comment or the marker separator; pip's
+    per-requirement options (`--hash` from a --generate-hashes lock file, etc.) are stripped
+    first, since packaging rejects them. A trailing pip inline comment (which PEP 508 does not
+    define) is only removed if the whole line fails to parse, so a '#' that is really inside a
+    quoted marker value survives. If packaging is absent or the line does not parse as a
+    requirement, returns True, so an unjudgeable line never becomes a false 'missing PyYAML'
+    note (the behavior from before markers were read)."""
+    # Drop pip per-requirement options (--hash, ...) first so packaging can parse the marker:
+    # each is a space-separated token starting with '-', never part of a name or marker value.
+    text = _strip_pip_options(line.strip())
+    if not text:
+        return True
+    try:
+        from packaging.requirements import Requirement, InvalidRequirement
+    except ImportError:
+        return True  # cannot parse without packaging: assume it installs, do not nag
+    # A '#' inside a quoted marker value is valid PEP 508, so parse the whole line first; only
+    # if that fails treat a trailing whitespace-'#' as a pip inline comment, strip it, and retry
+    # -- removing a real comment without corrupting a marker value that legitimately holds '#'.
+    try:
+        req = Requirement(text)
+    except InvalidRequirement:
+        stripped = re.sub(r"(^|\s)#.*$", "", text).strip()
+        if not stripped or stripped == text:
+            return True  # unparseable even without a trailing comment: do not nag
+        try:
+            req = Requirement(stripped)
+        except InvalidRequirement:
+            return True  # not a parseable requirement line: do not nag
+    if req.marker is None:
+        return True  # no marker: the line always applies
+    try:
+        return bool(req.marker.evaluate())
+    except Exception:
+        # Any evaluation failure means the marker cannot be judged in this context: an undefined
+        # variable or comparison, or a lock-file-only variable (dependency_groups) that raises a
+        # raw KeyError in the default metadata context. Fall back to treating the line as
+        # installable instead of crashing the --force path. The function is fail-open, so an
+        # unjudgeable line never becomes a false missing-PyYAML note.
+        return True
+
+
+def _join_continuations(text: str):
+    """Yield logical requirement lines, joining pip's backslash line-continuations the way
+    pip's requirements parser does: a physical line ending in '\\' continues onto the next, so
+    a hash-locked entry (its marker on the first physical line, indented `--hash` options on
+    the following lines) is reassembled into one logical line before its name, directives, and
+    marker are read. Without it, the first physical line keeps a trailing '\\' that breaks
+    marker parsing, and a marker split across the continuation would be missed entirely. A
+    full-line comment never continues, even when it ends in '\\': pip's parser treats it as a
+    standalone comment, so it is emitted on its own rather than swallowing the next line (which
+    would hide a PyYAML declaration or an -r/-e include directive)."""
+    buf = []
+    for raw in text.splitlines():
+        if raw.lstrip().startswith("#"):
+            if buf:  # flush a pending continuation before the standalone comment
+                yield "".join(buf)
+                buf = []
+            yield raw
+            continue
+        if raw.endswith("\\"):
+            buf.append(raw[:-1])
+            continue
+        buf.append(raw)
+        yield "".join(buf)
+        buf = []
+    if buf:  # a final physical line ending in '\' with nothing after it
+        yield "".join(buf)
+
+
 def _preserved_requirements_lacks_pyyaml(path: Path) -> bool:
     """True only when we can say with confidence that a preserved requirements.txt does
-    not declare PyYAML: it is readable, no line names PyYAML, and it carries no include or
-    editable directive (-r, -e) that could pull PyYAML from a file we do not read. An
-    unreadable file or such a directive returns False, so the targeted warning fires only
-    when the gap is certain and never nags a user who did declare it. A constraint file
-    (-c/--constraint) only pins versions of packages installed elsewhere and cannot supply
-    a missing one, so it does not suppress the note."""
+    not declare an installable PyYAML: it is readable, no line names PyYAML that would
+    install here, and it carries no include or editable directive (-r, -e) that could pull
+    PyYAML from a file we do not read. An unreadable file or such a directive returns False,
+    so the targeted warning fires only when the gap is certain and never nags a user who did
+    declare it. A constraint file (-c/--constraint) only pins versions of packages installed
+    elsewhere and cannot supply a missing one, so it does not suppress the note. A PyYAML
+    line gated by a PEP 508 environment marker counts only when the marker selects this
+    interpreter: one gated to another platform installs nothing here, so it does not (see
+    _requirement_marker_selects_env). Physical lines are first joined on pip's backslash
+    continuations, so a hash-locked entry split across lines is read as one requirement."""
     try:
         text = path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
         return False
-    for raw in text.splitlines():
+    for raw in _join_continuations(text):
         s = raw.strip()
         if s.startswith(("-r", "--requirement", "-e", "--editable")):
             return False  # PyYAML may live in the included (-r) or editable (-e) target
-        if _canonical_req_name(raw) == "pyyaml":
-            return False
+        if _canonical_req_name(raw) == "pyyaml" and _requirement_marker_selects_env(raw):
+            return False  # PyYAML declared and its marker (if any) installs here
     return True
 
 

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -32,6 +32,13 @@ _boot_spec = importlib.util.spec_from_file_location(
 gh_wiki_bootstrap = importlib.util.module_from_spec(_boot_spec)
 _boot_spec.loader.exec_module(gh_wiki_bootstrap)
 
+# The scaffolder evaluates a PEP 508 environment marker on a preserved requirements.txt's
+# PyYAML line only when `packaging` is importable; without it, it falls back to treating the
+# line as installable. Tests that assert an EXCLUDING marker warns therefore need packaging
+# present, so they guard on this. A matching or absent marker holds either way (the fallback
+# also selects the env), so those need no guard.
+HAS_PACKAGING = importlib.util.find_spec("packaging") is not None
+
 GOOD = """---
 type: Process
 title: good
@@ -259,6 +266,203 @@ def test_force_preserve_warns_with_constraint_file_and_no_pyyaml(tmp_path):
     assert rc == 0, out
     assert "does not list PyYAML" in out
     assert "PyYAML>=5.1" in out
+
+
+@pytest.mark.skipif(not HAS_PACKAGING, reason="marker evaluation needs the packaging library")
+def test_force_preserve_warns_when_pyyaml_marker_excludes_env(tmp_path):
+    # #185: a PyYAML line gated by a PEP 508 marker to another environment installs nothing
+    # here, so the preserved file still lacks an importable PyYAML. The name sniffer alone
+    # reads it as declared and stays silent; the marker must be evaluated so the note fires
+    # when the declaration will not install for the interpreter that runs validate.py.
+    target = tmp_path / "kb"
+    scaffold(target)
+    (target / "requirements.txt").write_text(
+        'PyYAML; sys_platform == "no-such-platform"\n', encoding="utf-8")
+    rc, out = scaffold(target, "--force")
+    assert rc == 0, out
+    assert "does not list PyYAML" in out
+    assert "PyYAML>=5.1" in out
+
+
+def test_force_preserve_no_warning_when_pyyaml_marker_matches(tmp_path):
+    # the other side: a PyYAML line whose marker selects this interpreter installs normally,
+    # so the note must stay silent. Guards against over-nagging on a valid environment gate.
+    # Holds with or without packaging: the marker matches, and the no-packaging fallback also
+    # treats the line as installable.
+    target = tmp_path / "kb"
+    scaffold(target)
+    (target / "requirements.txt").write_text(
+        'PyYAML; python_version >= "3.0"\n', encoding="utf-8")
+    rc, out = scaffold(target, "--force")
+    assert rc == 0, out
+    assert "skipping validation" in out.lower()
+    assert "does not list PyYAML" not in out
+
+
+@pytest.mark.skipif(not HAS_PACKAGING, reason="marker evaluation needs the packaging library")
+def test_force_preserve_warns_when_pyyaml_hash_line_marker_excludes_env(tmp_path):
+    # #185 (review): pip-compile --generate-hashes writes a requirement as a backslash-
+    # continued block: the marker on the first physical line, indented `--hash` options on
+    # following lines. Read physically, the first line keeps a trailing '\' that breaks marker
+    # parsing, so an environment-excluded PyYAML read as installable and the note went silent.
+    # Joining continuations first reconstructs the logical line, drops the hash options, and
+    # the excluding marker fires the note.
+    target = tmp_path / "kb"
+    scaffold(target)
+    (target / "requirements.txt").write_text(
+        'pyyaml==6.0.1 ; sys_platform == "no-such-platform" \\\n'
+        '    --hash=sha256:aaaa \\\n'
+        '    --hash=sha256:bbbb\n', encoding="utf-8")
+    rc, out = scaffold(target, "--force")
+    assert rc == 0, out
+    assert "does not list PyYAML" in out
+
+
+def test_force_preserve_no_warning_when_pyyaml_hash_line_no_marker(tmp_path):
+    # guard on the join: a hash-locked PyYAML with no marker reconstructs to an installable
+    # line, so the note stays silent. Holds with or without packaging.
+    target = tmp_path / "kb"
+    scaffold(target)
+    (target / "requirements.txt").write_text(
+        'pyyaml==6.0.1 \\\n    --hash=sha256:aaaa \\\n    --hash=sha256:bbbb\n', encoding="utf-8")
+    rc, out = scaffold(target, "--force")
+    assert rc == 0, out
+    assert "does not list PyYAML" not in out
+
+
+def test_force_preserve_no_warning_when_comment_ends_in_backslash(tmp_path):
+    # #185 (review): pip does not continue a full-line comment even when it ends in '\'. If the
+    # join treated the comment as continuing, it would swallow the following PyYAML line into
+    # the comment, hiding the declaration and firing a false 'missing PyYAML' note. The comment
+    # must be emitted on its own so the real PyYAML line is read. Holds with or without packaging.
+    target = tmp_path / "kb"
+    scaffold(target)
+    (target / "requirements.txt").write_text(
+        "# a trailing note that ends in a backslash \\\n"
+        "PyYAML==6.0.1\n", encoding="utf-8")
+    rc, out = scaffold(target, "--force")
+    assert rc == 0, out
+    assert "does not list PyYAML" not in out
+
+
+def test_force_preserve_no_warning_when_comment_backslash_precedes_include(tmp_path):
+    # #185 (review): same join bug, higher-impact variant. A comment ending in '\' just before
+    # an `-r` include directive would swallow the directive, so the include (which may supply
+    # PyYAML from a file we do not read) goes unseen and the note wrongly fires. The comment
+    # must not continue, so the `-r` line is read and suppresses the note.
+    target = tmp_path / "kb"
+    scaffold(target)
+    (target / "requirements.txt").write_text(
+        "# via requirements.in \\\n"
+        "-r base.txt\n", encoding="utf-8")
+    rc, out = scaffold(target, "--force")
+    assert rc == 0, out
+    assert "does not list PyYAML" not in out
+
+
+@pytest.mark.parametrize("line,expected", [
+    ("PyYAML>=5.1", True),                       # no marker: installs here
+    ('PyYAML; python_version >= "3.0"', True),   # marker selects this interpreter
+    ("PyYAML  # just a note", True),             # inline comment, no marker
+    ("PyYAML; ", True),                          # empty marker after ';'
+])
+def test_requirement_marker_selects_env_true_cases(line, expected):
+    # a missing, empty, or matching marker selects the current environment. These hold with
+    # or without packaging, since the packaging-absent fallback also returns True, so no
+    # skip guard is needed here (only the excluding case below depends on packaging).
+    assert scaffold_mod._requirement_marker_selects_env(line) == expected
+
+
+@pytest.mark.skipif(not HAS_PACKAGING, reason="marker evaluation needs the packaging library")
+def test_requirement_marker_excludes_env():
+    # an excluding marker returns False only when packaging can evaluate it; the fallback
+    # (packaging absent) returns True, so this case is guarded on packaging being present.
+    assert scaffold_mod._requirement_marker_selects_env(
+        'PyYAML; sys_platform == "no-such-platform"') is False
+
+
+@pytest.mark.skipif(not HAS_PACKAGING, reason="marker evaluation needs the packaging library")
+def test_requirement_marker_hash_inside_quoted_marker_excludes():
+    # a '#' inside a quoted marker string is not a pip comment; stripping at the first '#'
+    # would corrupt the marker. Parsing the full requirement keeps it intact, so the
+    # excluding marker still evaluates (no implementation is named "cpython#not").
+    assert scaffold_mod._requirement_marker_selects_env(
+        'PyYAML; implementation_name == "cpython#not"') is False
+
+
+@pytest.mark.skipif(not HAS_PACKAGING, reason="marker evaluation needs the packaging library")
+def test_requirement_marker_semicolon_inside_url_excludes():
+    # a ';' inside a direct-reference URL is part of the URL, not the marker separator.
+    # Splitting on the first ';' would misread the URL as the marker; parsing the full
+    # requirement extracts the real trailing marker after ' ; ' and evaluates it.
+    assert scaffold_mod._requirement_marker_selects_env(
+        'PyYAML @ https://example.com/pkg;param ; sys_platform == "no-such-platform"') is False
+
+
+@pytest.mark.skipif(not HAS_PACKAGING, reason="marker evaluation needs the packaging library")
+def test_requirement_marker_hashed_requirement_excluded():
+    # a hash-pinned line (pip-compile --generate-hashes) carries pip's per-requirement
+    # `--hash` option, which packaging.requirements.Requirement rejects. The pip option must
+    # be stripped before parsing, or the excluding marker is never seen and the missing-PyYAML
+    # warning is wrongly suppressed. With the option dropped the marker evaluates and excludes.
+    assert scaffold_mod._requirement_marker_selects_env(
+        'PyYAML==6.0.1; sys_platform == "no-such-platform" '
+        '--hash=sha256:aaaa --hash=sha256:bbbb') is False
+
+
+def test_requirement_marker_hashed_requirement_matches():
+    # a hash-pinned PyYAML with no marker still counts as installable: dropping the `--hash`
+    # options leaves a bare, applicable requirement. Holds with or without packaging (the
+    # packaging-absent fallback also returns True), so no skip guard is needed.
+    assert scaffold_mod._requirement_marker_selects_env(
+        'PyYAML==6.0.1 --hash=sha256:aaaa') is True
+
+
+@pytest.mark.skipif(not HAS_PACKAGING, reason="marker evaluation needs the packaging library")
+def test_requirement_marker_whitespace_hash_inside_quoted_marker_excludes():
+    # #185 (review): a '#' preceded by whitespace *inside* a quoted marker value is part of the
+    # marker, not a pip inline comment. Stripping the comment before parsing (the earlier
+    # regex-first approach) corrupts the marker and the line reads as installable, wrongly
+    # suppressing the note. Parsing the whole line first keeps the '#' intact, so the excluding
+    # marker still evaluates (no implementation is named "cpython #not").
+    assert scaffold_mod._requirement_marker_selects_env(
+        'PyYAML; implementation_name == "cpython #not"') is False
+
+
+@pytest.mark.skipif(not HAS_PACKAGING, reason="marker evaluation needs the packaging library")
+def test_requirement_marker_trailing_comment_after_marker_excludes():
+    # guard on the parse-first change: a real pip inline comment after the marker must still be
+    # stripped so the marker evaluates. The whole-line parse fails on the trailing comment, then
+    # the comment is removed on retry and the excluding marker evaluates to False.
+    assert scaffold_mod._requirement_marker_selects_env(
+        'PyYAML; sys_platform == "no-such-platform"  # windows only') is False
+
+
+@pytest.mark.skipif(not HAS_PACKAGING, reason="marker evaluation needs the packaging library")
+def test_requirement_marker_unevaluable_lockfile_marker_does_not_crash():
+    # #185 (review): packaging 26 added lock-file-context marker variables. A line such as
+    # `PyYAML; dependency_groups == "docs"` parses, but Marker.evaluate() raises KeyError in the
+    # default metadata context because that variable is not defined there. Any evaluation failure
+    # must be treated as unjudgeable and fall back to installable, not crash. Asserts the outcome
+    # (True, no exception), which also holds on older packaging that rejects the marker at parse
+    # time (InvalidRequirement, then True via the parse fallback).
+    assert scaffold_mod._requirement_marker_selects_env(
+        'PyYAML; dependency_groups == "docs"') is True
+
+
+@pytest.mark.skipif(not HAS_PACKAGING, reason="marker evaluation needs the packaging library")
+def test_force_preserve_no_crash_on_unevaluable_marker(tmp_path):
+    # #185 (review): a preserved requirements.txt whose PyYAML line carries a marker that parses
+    # but cannot be evaluated in the default context (dependency_groups, a lock-file-only
+    # variable) must not crash the --force run. The marker is unjudgeable, so PyYAML counts as
+    # possibly installable and the note stays silent; the run exits 0.
+    target = tmp_path / "kb"
+    scaffold(target)
+    (target / "requirements.txt").write_text(
+        'PyYAML; dependency_groups == "docs"\n', encoding="utf-8")
+    rc, out = scaffold(target, "--force")
+    assert rc == 0, out
+    assert "does not list PyYAML" not in out
 
 
 @pytest.mark.parametrize("line,expected", [


### PR DESCRIPTION
## What

Closes #185. The scaffold's `--force` preserve path warns when a preserved `requirements.txt` omits PyYAML, the module `validate.py` imports. `_preserved_requirements_lacks_pyyaml` counted any line naming PyYAML as satisfying that need — but a line gated by a PEP 508 environment marker installs nothing when the marker excludes the running interpreter. `PyYAML; sys_platform == "win32"` read on Linux declares PyYAML on paper while leaving `validate.py` to fail with `ModuleNotFoundError`, so the note stayed silent in exactly the case it exists for.

## The fix

`_requirement_marker_selects_env`: a PyYAML line counts only when it has no marker or a marker that selects this interpreter. It parses the full PEP 508 line with `packaging.requirements.Requirement`, so a `#` inside a quoted marker or a `;` inside a direct-reference URL is not mistaken for a comment or the marker separator. When `packaging` is absent or the line does not parse, it falls back to treating the line as installable, so an unjudgeable line never becomes a false "missing PyYAML" note. Requirements are read as logical lines: `_join_continuations` reassembles pip's backslash continuations first, so a hash-locked entry from `pip-compile --generate-hashes` is read as one requirement.

## Edge cases handled (each with a test)

- **Environment marker** — a PyYAML line gated to another platform no longer suppresses the note; one that selects this interpreter still does.
- **`#` inside a quoted marker** — parsing the whole line first keeps it intact; a trailing pip inline comment is stripped only when the whole line fails to parse and is retried, so a marker value that legitimately contains `#` survives while a real comment is still removed.
- **`;` inside a direct-reference URL** — the real trailing marker is extracted, not the URL's semicolon.
- **pip `--hash` options** (`--generate-hashes` lock files) — stripped via `_strip_pip_options`, which mirrors pip's `break_args_options`, so `packaging` (which rejects the option) can parse the marker.
- **Backslash continuations** — reassembled before the name and marker are read.
- **Full-line comment ending in `\`** — pip never continues one, so `_join_continuations` emits it on its own instead of swallowing the next line, which would otherwise hide a PyYAML declaration or an `-r`/`-e` include directive on the following line and fire the note when it should stay silent.

## Tests

Unit tests on `_requirement_marker_selects_env` for each marker/option/comment shape (guarded on `packaging` being importable, with a fallback path that holds without it), plus scaffold-level `--force` tests for the include, constraint, hash-line, and comment-continuation cases, including an unevaluable lock-file marker (`dependency_groups`) that must not crash the run. Full suite: 143 passing.
