### PR TITLE
okf-wiki: accept an upstream ISO 8601 datetime for timestamp

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -447,7 +447,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                             <span class="text-[8px] bg-[#2563eb]/10 text-[#2563eb] px-2 py-1 rounded font-semibold">Provenance</span>
                             <span class="text-[8px] bg-[#2563eb]/10 text-[#2563eb] px-2 py-1 rounded font-semibold">Validator</span>
                         </div>
-                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-07-21T18:22:19-04:00" data-updated-slug="okf-wiki">Updated <time datetime="2026-07-21T18:22:19-04:00">Jul 21, 2026</time></p>
+                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-07-21T19:15:09-04:00" data-updated-slug="okf-wiki">Updated <time datetime="2026-07-21T19:15:09-04:00">Jul 21, 2026</time></p>
                     </a>
 
                     <a href="autocontext/" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">

--- a/docs/okf-wiki/index.html
+++ b/docs/okf-wiki/index.html
@@ -159,7 +159,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 Productivity skill
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">okf-wiki</h1>
-            <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-07-21T18:22:19-04:00" data-updated-slug="okf-wiki">Updated <time datetime="2026-07-21T18:22:19-04:00">Jul 21, 2026</time></p>
+            <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-07-21T19:15:09-04:00" data-updated-slug="okf-wiki">Updated <time datetime="2026-07-21T19:15:09-04:00">Jul 21, 2026</time></p>
             <p class="text-xl text-white/90 max-w-2xl">
                 One command scaffolds a knowledge base that Claude and your team can both read: small markdown files, one concept each, every fact carrying its own provenance. You get the spec, a validator that fails on a broken or stale concept, and session hooks that point Claude at the bundle before it touches anything.
             </p>

--- a/okf-wiki/SKILL.md
+++ b/okf-wiki/SKILL.md
@@ -88,7 +88,7 @@ making it here, up front, where it can steer the rest of the setup.
     hooks/okf-anchor.py   SessionStart: load the index into context
     hooks/okf-orient.py   PreToolUse: gate the first action on orientation
   bundle/                 the OKF bundle (the validated tree)
-    index.md              carries okf_version: "0.2"
+    index.md              carries okf_version: "0.3"
     <section>/
       index.md
       example-concept.md  a starter concept with full frontmatter

--- a/okf-wiki/example/SPEC.md
+++ b/okf-wiki/example/SPEC.md
@@ -54,8 +54,8 @@ upstream conventions will otherwise produce files this validator rejects.
   assignments and fails the bundle on a hit, so an upstream bundle that inlines a credential
   value passes upstream but is rejected here (see Security).
 
-The format version differs too: upstream is `0.1`, this spec's current version is `0.2`
-(the validator still accepts `0.1`). Every difference above pulls the same direction:
+The format version differs too: upstream is `0.1`, this spec's current version is `0.3`
+(the validator still accepts `0.1` and `0.2`). Every difference above pulls the same direction:
 upstream stays minimal and needs no tooling to stay portable, while this spec adds a
 validator that fails the build when a bundle drifts.
 
@@ -74,7 +74,7 @@ with an `index.md`. Larger bundles group concepts into subdirectories by subject
 
 ## Files
 
-- The bundle-root `index.md` carries `okf_version: "0.2"` in frontmatter — only there.
+- The bundle-root `index.md` carries `okf_version: "0.3"` in frontmatter — only there.
 - Per-directory `index.md`: a heading, an optional one-line preamble, then bullet
   navigation. No frontmatter. (Keep the preamble to one line — it orients, it doesn't narrate.)
 - `log.md` (optional, per directory): dated entries, newest first, no frontmatter.
@@ -88,11 +88,11 @@ The validator enforces the frontmatter rules here — reserved files carry no fr
 only the bundle-root `index.md` carries `okf_version` (and nothing else). The index/log body
 shapes above are recommendations for human readers, not validator-checked structure.
 
-The current format version is `0.2`. The validator accepts `0.1` and `0.2`, so a newer
-validator still reads an older bundle, and new scaffolds emit `0.2`. Adding allowed types is
-backward compatible and bumps the format version: a bundle using the newer types declares
-`0.2`, so an older validator reports a clear unsupported-version error instead of a misleading
-bad-type one.
+The current format version is `0.3`. The validator accepts `0.1`, `0.2`, and `0.3`, so a
+newer validator still reads an older bundle, and new scaffolds emit `0.3`. Version `0.2`
+added allowed types. Version `0.3` admits a full datetime in `timestamp`; a `0.1` or `0.2`
+bundle remains date-only. The marker makes these grammar changes explicit, so an older
+validator reports a clear unsupported-version error instead of a misleading field error.
 
 ## Concept frontmatter (required keys, all non-empty)
 
@@ -103,7 +103,7 @@ bad-type one.
 | `description` | one line |
 | `source` | YAML list of provenance pointers (paths, commands, URLs, events) |
 | `verified` | ISO date `YYYY-MM-DD` the fact was last confirmed true (see note below) |
-| `timestamp` | ISO date authored/updated |
+| `timestamp` | ISO date authored/updated, or in a `0.3` bundle a full ISO 8601 datetime |
 | `tags` | YAML list |
 
 `verified` note: it records when the fact was last confirmed true, which is not always today. A
@@ -118,6 +118,11 @@ not yet verifiable, so find a datable source or leave it out. When the date is u
 down: an older `verified` reads as "may be stale," today reads as "just confirmed." The date is the
 contract; a caveat in the concept body does not undo it, because the validator and tools read only
 the date.
+
+`timestamp` may be an ISO date (`YYYY-MM-DD`) in every supported format version. A `0.3`
+bundle may instead preserve a full datetime in the exact form
+`YYYY-MM-DDTHH:MM:SS[.fraction][Z|+HH:MM|-HH:MM]`; a space may replace `T`. Versions `0.1`
+and `0.2` remain date-only. `verified` is always date-only.
 
 `source` quoting rule (hard): QUOTE every element of the `source` list. Source pointers
 routinely carry YAML-significant characters — a `#` (e.g. `"issue #445"`) starts a comment

--- a/okf-wiki/example/SPEC.md
+++ b/okf-wiki/example/SPEC.md
@@ -31,9 +31,11 @@ upstream conventions will otherwise produce files this validator rejects.
 - `verified` is added. Upstream has no such key. This spec requires `verified`, the ISO
   date the fact was last confirmed true, kept distinct from `timestamp` (when the file was
   authored or edited).
-- Dates are date-only. Upstream's `timestamp` is an ISO 8601 datetime. Here `check_dates`
-  parses both `verified` and `timestamp` as `YYYY-MM-DD` only, so an upstream timestamp like
-  `2026-05-28T14:30:00Z` fails validation and must be truncated to its date.
+- `verified` is date-only. Upstream's `timestamp` is an ISO 8601 datetime, and `check_dates`
+  accepts that form for `timestamp` (with or without an offset, including a trailing `Z`), so
+  an upstream bundle validates here unchanged. `verified` takes `YYYY-MM-DD` only: it records
+  the day a fact was last confirmed true, and a time of day there is false precision about
+  the confirmation.
 - The type vocab is closed. Upstream types are freeform and unregistered, and consumers
   must tolerate unknown ones. Here the set is fixed (see Type vocab) and an unlisted type
   fails the build, which catches typos; extending it is a deliberate spec edit.

--- a/okf-wiki/example/bundle/index.md
+++ b/okf-wiki/example/bundle/index.md
@@ -1,5 +1,5 @@
 ---
-okf_version: "0.2"
+okf_version: "0.3"
 ---
 # claude-skills-journalism wiki
 

--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -17,7 +17,9 @@ Checks:
                   An unquoted '#' in a block-style element (which YAML would silently
                   drop as a comment, losing the rest) is rejected — quote it.
        - tags     is a list.
-       - verified, timestamp parse as ISO dates (YYYY-MM-DD).
+       - verified   parses as an ISO date (YYYY-MM-DD).
+       - timestamp parses as an ISO date or a full ISO 8601 datetime
+                    (upstream OKF writes a datetime).
   3. Reserved filenames (index.md, log.md) name no concept and carry no
      frontmatter — except the bundle-root index.md may carry okf_version only.
   4. Internal markdown links resolve. Links must be relative — a root-relative
@@ -49,6 +51,8 @@ import yaml
 REQUIRED_KEYS = ("type", "title", "description", "source", "verified", "timestamp", "tags")
 LIST_KEYS = ("source", "tags")
 DATE_KEYS = ("verified", "timestamp")
+# Keys that may also carry a full ISO 8601 datetime (see check_dates).
+DATETIME_KEYS = ("timestamp",)
 ALLOWED_TYPES = {
     # Infrastructure / ops (fleet maps, system docs)
     "Machine", "Network", "Service", "Session", "Project",
@@ -377,6 +381,28 @@ def check_source_quoting(rel, fm, raw_fm, errors):
             return  # one report per concept is enough
 
 
+def _is_iso_datetime(s):
+    """True for an ISO 8601 datetime, with or without an offset.
+
+    fromisoformat is the parser but not the contract: it accepts ANY single
+    character between the date and the time, so '2026-05-28x14:30:00' parses
+    clean and malformed metadata would sail through. The separator is checked
+    first and only 'T' (ISO 8601) or a space (RFC 3339's by-agreement form) is
+    allowed.
+
+    fromisoformat also only learned to read a trailing 'Z' in 3.11, and upstream
+    OKF writes UTC that way, so normalise it rather than gate the check on a
+    Python version the scaffold does not control.
+    """
+    if len(s) < 11 or s[10] not in ("T", " "):
+        return False
+    try:
+        dt.datetime.fromisoformat(s[:-1] + "+00:00" if s.endswith("Z") else s)
+    except ValueError:
+        return False
+    return True
+
+
 def check_dates(rel, fm, errors):
     for key in DATE_KEYS:
         val = fm.get(key)
@@ -385,8 +411,20 @@ def check_dates(rel, fm, errors):
         s = val.isoformat() if isinstance(val, dt.date) else str(val)
         try:
             dt.datetime.strptime(s, "%Y-%m-%d")
+            continue
         except ValueError:
-            errors.append(f"{rel}: '{key}' must be an ISO date YYYY-MM-DD, got {val!r}")
+            pass
+        # `timestamp` is upstream OKF's key and upstream writes it as a full ISO
+        # 8601 datetime. Rejecting that bought nothing -- it only forced a
+        # truncation pass over every imported bundle -- so the extra precision is
+        # accepted and carried. `verified` is this spec's own key and stays
+        # date-only: it records the day a fact was confirmed true, where a time
+        # of day is noise that invites false precision about the confirmation.
+        if key in DATETIME_KEYS and _is_iso_datetime(s):
+            continue
+        expected = ("an ISO date YYYY-MM-DD or an ISO 8601 datetime"
+                    if key in DATETIME_KEYS else "an ISO date YYYY-MM-DD")
+        errors.append(f"{rel}: '{key}' must be {expected}, got {val!r}")
 
 
 def check_lists(rel, fm, errors):

--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -18,8 +18,8 @@ Checks:
                   drop as a comment, losing the rest) is rejected — quote it.
        - tags     is a list.
        - verified   parses as an ISO date (YYYY-MM-DD).
-       - timestamp parses as an ISO date or a full ISO 8601 datetime
-                    (upstream OKF writes a datetime).
+       - timestamp parses as an ISO date, or under okf_version 0.3 as a full
+                    ISO 8601 datetime (upstream OKF writes a datetime).
   3. Reserved filenames (index.md, log.md) name no concept and carry no
      frontmatter — except the bundle-root index.md may carry okf_version only.
   4. Internal markdown links resolve. Links must be relative — a root-relative
@@ -51,8 +51,12 @@ import yaml
 REQUIRED_KEYS = ("type", "title", "description", "source", "verified", "timestamp", "tags")
 LIST_KEYS = ("source", "tags")
 DATE_KEYS = ("verified", "timestamp")
-# Keys that may also carry a full ISO 8601 datetime (see check_dates).
+# Keys that may also carry a full ISO 8601 datetime (see check_dates). The
+# bundle must explicitly opt into this grammar through okf_version 0.3 so an
+# older validator rejects the format at its version gate instead of later on a
+# timestamp it does not understand.
 DATETIME_KEYS = ("timestamp",)
+DATETIME_TIMESTAMP_VERSION = "0.3"
 ALLOWED_TYPES = {
     # Infrastructure / ops (fleet maps, system docs)
     "Machine", "Network", "Service", "Session", "Project",
@@ -66,8 +70,9 @@ RESERVED = {"index.md", "log.md"}
 # okf_version values this validator accepts. The last entry is the current format
 # version (what scaffold writes for a new bundle); older entries stay supported so a
 # newer validator still reads an older bundle. Adding allowed types is backward
-# compatible and bumps the format version (0.1 -> 0.2).
-SUPPORTED_VERSIONS = ("0.1", "0.2")
+# compatible and bumps the format version (0.1 -> 0.2). Accepting a datetime in
+# timestamp changes the field grammar and bumps it again (0.2 -> 0.3).
+SUPPORTED_VERSIONS = ("0.1", "0.2", DATETIME_TIMESTAMP_VERSION)
 SPEC_VERSION = SUPPORTED_VERSIONS[-1]  # current format version, written by new scaffolds
 # Inline markdown link. The destination group allows one level of balanced
 # parens so a filename like `missing(v2).md` is still captured (a plain [^)]+
@@ -381,20 +386,33 @@ def check_source_quoting(rel, fm, raw_fm, errors):
             return  # one report per concept is enough
 
 
+ISO_DATE_RE = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}\Z")
+ISO_DATETIME_RE = re.compile(
+    r"[0-9]{4}-[0-9]{2}-[0-9]{2}[T ][0-9]{2}:[0-9]{2}:[0-9]{2}"
+    r"(?:[.,][0-9]+)?(?:Z|[+-][0-9]{2}:[0-9]{2})?\Z"
+)
+
+
+def _is_iso_date(s):
+    """True only for the literal YYYY-MM-DD form required by the SPEC."""
+    if not ISO_DATE_RE.fullmatch(s):
+        return False
+    try:
+        dt.datetime.strptime(s, "%Y-%m-%d")
+    except ValueError:
+        return False
+    return True
+
+
 def _is_iso_datetime(s):
-    """True for an ISO 8601 datetime, with or without an offset.
+    """True for the SPEC's full ISO 8601 datetime spelling.
 
-    fromisoformat is the parser but not the contract: it accepts ANY single
-    character between the date and the time, so '2026-05-28x14:30:00' parses
-    clean and malformed metadata would sail through. The separator is checked
-    first and only 'T' (ISO 8601) or a space (RFC 3339's by-agreement form) is
-    allowed.
-
-    fromisoformat also only learned to read a trailing 'Z' in 3.11, and upstream
-    OKF writes UTC that way, so normalise it rather than gate the check on a
-    Python version the scaffold does not control.
+    ``fromisoformat`` checks calendar and clock ranges, but it is deliberately
+    not the lexical contract: both it and PyYAML accept wider timestamp forms.
+    The regular expression first requires the exact zero-padded source shape.
+    A trailing ``Z`` is normalised for Python versions that do not parse it.
     """
-    if len(s) < 11 or s[10] not in ("T", " "):
+    if not ISO_DATETIME_RE.fullmatch(s):
         return False
     try:
         dt.datetime.fromisoformat(s[:-1] + "+00:00" if s.endswith("Z") else s)
@@ -403,28 +421,76 @@ def _is_iso_datetime(s):
     return True
 
 
-def check_dates(rel, fm, errors):
+def _raw_top_level_scalar(raw_fm, key):
+    """Return a literal top-level scalar's unnormalised text, or None.
+
+    ``safe_load`` constructs a broad family of YAML timestamp spellings as
+    ``date``/``datetime`` objects. Calling ``isoformat`` on those objects would
+    silently turn a malformed source spelling into a conforming value. Compose
+    the same frontmatter into a node tree and inspect the effective (last)
+    literal key instead. Simple quoted strings remain supported; YAML aliases,
+    tags, block scalars, and escape-based spellings are not literal date fields.
+    """
+    if not raw_fm:
+        return None
+    try:
+        root = yaml.compose(raw_fm, Loader=yaml.SafeLoader)
+    except yaml.YAMLError:
+        return None
+    if not isinstance(root, yaml.MappingNode):
+        return None
+
+    counts = _child_ref_counts(root)
+    candidates = [
+        (key_node, val_node)
+        for key_node, val_node in root.value
+        if isinstance(key_node, yaml.ScalarNode)
+        and key_node.value == key
+        and key_node.tag != _MERGE_TAG
+        and counts.get(id(key_node), 0) < 2
+    ]
+    if not candidates:
+        return None
+    _, val_node = candidates[-1]  # safe_load keeps the last duplicate key
+    if not isinstance(val_node, yaml.ScalarNode) or counts.get(id(val_node), 0) >= 2:
+        return None
+
+    written = raw_fm[val_node.start_mark.index:val_node.end_mark.index]
+    if val_node.style is None and written == val_node.value:
+        return written
+    if val_node.style in ("'", '"') and written == val_node.style + val_node.value + val_node.style:
+        return val_node.value
+    return None
+
+
+def check_dates(rel, fm, raw_fm, bundle_version, errors):
     for key in DATE_KEYS:
         val = fm.get(key)
         if val is None:
             continue  # missing/empty already reported by required-key check
-        s = val.isoformat() if isinstance(val, dt.date) else str(val)
-        try:
-            dt.datetime.strptime(s, "%Y-%m-%d")
+        raw = _raw_top_level_scalar(raw_fm, key)
+        if raw is not None and _is_iso_date(raw):
             continue
-        except ValueError:
-            pass
         # `timestamp` is upstream OKF's key and upstream writes it as a full ISO
-        # 8601 datetime. Rejecting that bought nothing -- it only forced a
-        # truncation pass over every imported bundle -- so the extra precision is
-        # accepted and carried. `verified` is this spec's own key and stays
-        # date-only: it records the day a fact was confirmed true, where a time
-        # of day is noise that invites false precision about the confirmation.
-        if key in DATETIME_KEYS and _is_iso_datetime(s):
+        # 8601 datetime. Version 0.3 accepts and carries that precision; older
+        # formats remain date-only. `verified` is this spec's own key and always
+        # stays date-only because a time of day invites false precision.
+        if (key in DATETIME_KEYS
+                and bundle_version == DATETIME_TIMESTAMP_VERSION
+                and raw is not None
+                and _is_iso_datetime(raw)):
             continue
-        expected = ("an ISO date YYYY-MM-DD or an ISO 8601 datetime"
-                    if key in DATETIME_KEYS else "an ISO date YYYY-MM-DD")
-        errors.append(f"{rel}: '{key}' must be {expected}, got {val!r}")
+        if key in DATETIME_KEYS and bundle_version != DATETIME_TIMESTAMP_VERSION:
+            expected = (
+                f"an ISO date YYYY-MM-DD under okf_version {bundle_version or '<missing>'}; "
+                f"full ISO 8601 datetimes require okf_version {DATETIME_TIMESTAMP_VERSION}"
+            )
+        elif key in DATETIME_KEYS:
+            expected = "an ISO date YYYY-MM-DD or a full ISO 8601 datetime"
+        else:
+            expected = "an ISO date YYYY-MM-DD"
+        shown = raw if raw is not None else val
+        errors.append(f"{rel}: '{key}' must be {expected}, got {shown!r}")
 
 
 def check_lists(rel, fm, errors):
@@ -440,6 +506,26 @@ def check_lists(rel, fm, errors):
         for el in val:
             if not isinstance(el, str) or not el.strip():
                 errors.append(f"{rel}: '{key}' has a non-string/empty element {el!r}")
+
+
+def declared_bundle_version(bundle):
+    """Read the root marker for version-dependent field checks.
+
+    This is a non-reporting pre-pass; the main file loop remains responsible for
+    all root-index diagnostics. Reading it up front means a root-level concept
+    named ``a.md`` receives the right grammar even though it sorts before
+    ``index.md``.
+    """
+    root_index = bundle / "index.md"
+    if not root_index.is_file():
+        return None
+    try:
+        fm, _ = parse_frontmatter(root_index.read_text(encoding="utf-8-sig"))
+    except (OSError, yaml.YAMLError, ValueError):
+        return None
+    if not isinstance(fm, dict) or fm.get("okf_version") is None:
+        return None
+    return str(fm["okf_version"]).strip()
 
 
 def main() -> int:
@@ -471,6 +557,7 @@ def main() -> int:
     # index (or an empty directory) would validate clean and bypass version gating.
     if not (bundle / "index.md").is_file():
         errors.append("index.md: bundle-root index is required and must declare okf_version")
+    bundle_version = declared_bundle_version(bundle)
     type_counts: Counter = Counter()
     concepts = 0
 
@@ -566,8 +653,9 @@ def main() -> int:
             errors.append(f"{rel}: type '{ctype}' not in the spec vocab {sorted(ALLOWED_TYPES)}")
 
         check_lists(rel, fm, errors)
-        check_dates(rel, fm, errors)
-        check_source_quoting(rel, fm, frontmatter_block(text), errors)
+        raw_fm = frontmatter_block(text)
+        check_dates(rel, fm, raw_fm, bundle_version, errors)
+        check_source_quoting(rel, fm, raw_fm, errors)
 
     # Link resolution: every internal link to a .md file must resolve to a file
     # that exists inside the bundle. A link escaping the bundle root or pointing at

--- a/okf-wiki/scripts/scaffold.py
+++ b/okf-wiki/scripts/scaffold.py
@@ -94,7 +94,7 @@ def copy_if_absent(src: Path, dst: Path, preserved: list[Path]) -> None:
 def root_index(title: str, sections: list[str]) -> str:
     nav = "\n".join(f"- [{s}]({s}/index.md)" for s in sections)
     return (
-        '---\nokf_version: "0.2"\n---\n'
+        '---\nokf_version: "0.3"\n---\n'
         f"# {title}\n\n"
         "An Open Knowledge Format bundle. One concept per file; provenance in each file's frontmatter.\n\n"
         "## Sections\n\n"

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -17,7 +17,9 @@ Checks:
                   An unquoted '#' in a block-style element (which YAML would silently
                   drop as a comment, losing the rest) is rejected — quote it.
        - tags     is a list.
-       - verified, timestamp parse as ISO dates (YYYY-MM-DD).
+       - verified   parses as an ISO date (YYYY-MM-DD).
+       - timestamp parses as an ISO date or a full ISO 8601 datetime
+                    (upstream OKF writes a datetime).
   3. Reserved filenames (index.md, log.md) name no concept and carry no
      frontmatter — except the bundle-root index.md may carry okf_version only.
   4. Internal markdown links resolve. Links must be relative — a root-relative
@@ -49,6 +51,8 @@ import yaml
 REQUIRED_KEYS = ("type", "title", "description", "source", "verified", "timestamp", "tags")
 LIST_KEYS = ("source", "tags")
 DATE_KEYS = ("verified", "timestamp")
+# Keys that may also carry a full ISO 8601 datetime (see check_dates).
+DATETIME_KEYS = ("timestamp",)
 ALLOWED_TYPES = {
     # Infrastructure / ops (fleet maps, system docs)
     "Machine", "Network", "Service", "Session", "Project",
@@ -377,6 +381,28 @@ def check_source_quoting(rel, fm, raw_fm, errors):
             return  # one report per concept is enough
 
 
+def _is_iso_datetime(s):
+    """True for an ISO 8601 datetime, with or without an offset.
+
+    fromisoformat is the parser but not the contract: it accepts ANY single
+    character between the date and the time, so '2026-05-28x14:30:00' parses
+    clean and malformed metadata would sail through. The separator is checked
+    first and only 'T' (ISO 8601) or a space (RFC 3339's by-agreement form) is
+    allowed.
+
+    fromisoformat also only learned to read a trailing 'Z' in 3.11, and upstream
+    OKF writes UTC that way, so normalise it rather than gate the check on a
+    Python version the scaffold does not control.
+    """
+    if len(s) < 11 or s[10] not in ("T", " "):
+        return False
+    try:
+        dt.datetime.fromisoformat(s[:-1] + "+00:00" if s.endswith("Z") else s)
+    except ValueError:
+        return False
+    return True
+
+
 def check_dates(rel, fm, errors):
     for key in DATE_KEYS:
         val = fm.get(key)
@@ -385,8 +411,20 @@ def check_dates(rel, fm, errors):
         s = val.isoformat() if isinstance(val, dt.date) else str(val)
         try:
             dt.datetime.strptime(s, "%Y-%m-%d")
+            continue
         except ValueError:
-            errors.append(f"{rel}: '{key}' must be an ISO date YYYY-MM-DD, got {val!r}")
+            pass
+        # `timestamp` is upstream OKF's key and upstream writes it as a full ISO
+        # 8601 datetime. Rejecting that bought nothing -- it only forced a
+        # truncation pass over every imported bundle -- so the extra precision is
+        # accepted and carried. `verified` is this spec's own key and stays
+        # date-only: it records the day a fact was confirmed true, where a time
+        # of day is noise that invites false precision about the confirmation.
+        if key in DATETIME_KEYS and _is_iso_datetime(s):
+            continue
+        expected = ("an ISO date YYYY-MM-DD or an ISO 8601 datetime"
+                    if key in DATETIME_KEYS else "an ISO date YYYY-MM-DD")
+        errors.append(f"{rel}: '{key}' must be {expected}, got {val!r}")
 
 
 def check_lists(rel, fm, errors):

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -18,8 +18,8 @@ Checks:
                   drop as a comment, losing the rest) is rejected — quote it.
        - tags     is a list.
        - verified   parses as an ISO date (YYYY-MM-DD).
-       - timestamp parses as an ISO date or a full ISO 8601 datetime
-                    (upstream OKF writes a datetime).
+       - timestamp parses as an ISO date, or under okf_version 0.3 as a full
+                    ISO 8601 datetime (upstream OKF writes a datetime).
   3. Reserved filenames (index.md, log.md) name no concept and carry no
      frontmatter — except the bundle-root index.md may carry okf_version only.
   4. Internal markdown links resolve. Links must be relative — a root-relative
@@ -51,8 +51,12 @@ import yaml
 REQUIRED_KEYS = ("type", "title", "description", "source", "verified", "timestamp", "tags")
 LIST_KEYS = ("source", "tags")
 DATE_KEYS = ("verified", "timestamp")
-# Keys that may also carry a full ISO 8601 datetime (see check_dates).
+# Keys that may also carry a full ISO 8601 datetime (see check_dates). The
+# bundle must explicitly opt into this grammar through okf_version 0.3 so an
+# older validator rejects the format at its version gate instead of later on a
+# timestamp it does not understand.
 DATETIME_KEYS = ("timestamp",)
+DATETIME_TIMESTAMP_VERSION = "0.3"
 ALLOWED_TYPES = {
     # Infrastructure / ops (fleet maps, system docs)
     "Machine", "Network", "Service", "Session", "Project",
@@ -66,8 +70,9 @@ RESERVED = {"index.md", "log.md"}
 # okf_version values this validator accepts. The last entry is the current format
 # version (what scaffold writes for a new bundle); older entries stay supported so a
 # newer validator still reads an older bundle. Adding allowed types is backward
-# compatible and bumps the format version (0.1 -> 0.2).
-SUPPORTED_VERSIONS = ("0.1", "0.2")
+# compatible and bumps the format version (0.1 -> 0.2). Accepting a datetime in
+# timestamp changes the field grammar and bumps it again (0.2 -> 0.3).
+SUPPORTED_VERSIONS = ("0.1", "0.2", DATETIME_TIMESTAMP_VERSION)
 SPEC_VERSION = SUPPORTED_VERSIONS[-1]  # current format version, written by new scaffolds
 # Inline markdown link. The destination group allows one level of balanced
 # parens so a filename like `missing(v2).md` is still captured (a plain [^)]+
@@ -381,20 +386,33 @@ def check_source_quoting(rel, fm, raw_fm, errors):
             return  # one report per concept is enough
 
 
+ISO_DATE_RE = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}\Z")
+ISO_DATETIME_RE = re.compile(
+    r"[0-9]{4}-[0-9]{2}-[0-9]{2}[T ][0-9]{2}:[0-9]{2}:[0-9]{2}"
+    r"(?:[.,][0-9]+)?(?:Z|[+-][0-9]{2}:[0-9]{2})?\Z"
+)
+
+
+def _is_iso_date(s):
+    """True only for the literal YYYY-MM-DD form required by the SPEC."""
+    if not ISO_DATE_RE.fullmatch(s):
+        return False
+    try:
+        dt.datetime.strptime(s, "%Y-%m-%d")
+    except ValueError:
+        return False
+    return True
+
+
 def _is_iso_datetime(s):
-    """True for an ISO 8601 datetime, with or without an offset.
+    """True for the SPEC's full ISO 8601 datetime spelling.
 
-    fromisoformat is the parser but not the contract: it accepts ANY single
-    character between the date and the time, so '2026-05-28x14:30:00' parses
-    clean and malformed metadata would sail through. The separator is checked
-    first and only 'T' (ISO 8601) or a space (RFC 3339's by-agreement form) is
-    allowed.
-
-    fromisoformat also only learned to read a trailing 'Z' in 3.11, and upstream
-    OKF writes UTC that way, so normalise it rather than gate the check on a
-    Python version the scaffold does not control.
+    ``fromisoformat`` checks calendar and clock ranges, but it is deliberately
+    not the lexical contract: both it and PyYAML accept wider timestamp forms.
+    The regular expression first requires the exact zero-padded source shape.
+    A trailing ``Z`` is normalised for Python versions that do not parse it.
     """
-    if len(s) < 11 or s[10] not in ("T", " "):
+    if not ISO_DATETIME_RE.fullmatch(s):
         return False
     try:
         dt.datetime.fromisoformat(s[:-1] + "+00:00" if s.endswith("Z") else s)
@@ -403,28 +421,76 @@ def _is_iso_datetime(s):
     return True
 
 
-def check_dates(rel, fm, errors):
+def _raw_top_level_scalar(raw_fm, key):
+    """Return a literal top-level scalar's unnormalised text, or None.
+
+    ``safe_load`` constructs a broad family of YAML timestamp spellings as
+    ``date``/``datetime`` objects. Calling ``isoformat`` on those objects would
+    silently turn a malformed source spelling into a conforming value. Compose
+    the same frontmatter into a node tree and inspect the effective (last)
+    literal key instead. Simple quoted strings remain supported; YAML aliases,
+    tags, block scalars, and escape-based spellings are not literal date fields.
+    """
+    if not raw_fm:
+        return None
+    try:
+        root = yaml.compose(raw_fm, Loader=yaml.SafeLoader)
+    except yaml.YAMLError:
+        return None
+    if not isinstance(root, yaml.MappingNode):
+        return None
+
+    counts = _child_ref_counts(root)
+    candidates = [
+        (key_node, val_node)
+        for key_node, val_node in root.value
+        if isinstance(key_node, yaml.ScalarNode)
+        and key_node.value == key
+        and key_node.tag != _MERGE_TAG
+        and counts.get(id(key_node), 0) < 2
+    ]
+    if not candidates:
+        return None
+    _, val_node = candidates[-1]  # safe_load keeps the last duplicate key
+    if not isinstance(val_node, yaml.ScalarNode) or counts.get(id(val_node), 0) >= 2:
+        return None
+
+    written = raw_fm[val_node.start_mark.index:val_node.end_mark.index]
+    if val_node.style is None and written == val_node.value:
+        return written
+    if val_node.style in ("'", '"') and written == val_node.style + val_node.value + val_node.style:
+        return val_node.value
+    return None
+
+
+def check_dates(rel, fm, raw_fm, bundle_version, errors):
     for key in DATE_KEYS:
         val = fm.get(key)
         if val is None:
             continue  # missing/empty already reported by required-key check
-        s = val.isoformat() if isinstance(val, dt.date) else str(val)
-        try:
-            dt.datetime.strptime(s, "%Y-%m-%d")
+        raw = _raw_top_level_scalar(raw_fm, key)
+        if raw is not None and _is_iso_date(raw):
             continue
-        except ValueError:
-            pass
         # `timestamp` is upstream OKF's key and upstream writes it as a full ISO
-        # 8601 datetime. Rejecting that bought nothing -- it only forced a
-        # truncation pass over every imported bundle -- so the extra precision is
-        # accepted and carried. `verified` is this spec's own key and stays
-        # date-only: it records the day a fact was confirmed true, where a time
-        # of day is noise that invites false precision about the confirmation.
-        if key in DATETIME_KEYS and _is_iso_datetime(s):
+        # 8601 datetime. Version 0.3 accepts and carries that precision; older
+        # formats remain date-only. `verified` is this spec's own key and always
+        # stays date-only because a time of day invites false precision.
+        if (key in DATETIME_KEYS
+                and bundle_version == DATETIME_TIMESTAMP_VERSION
+                and raw is not None
+                and _is_iso_datetime(raw)):
             continue
-        expected = ("an ISO date YYYY-MM-DD or an ISO 8601 datetime"
-                    if key in DATETIME_KEYS else "an ISO date YYYY-MM-DD")
-        errors.append(f"{rel}: '{key}' must be {expected}, got {val!r}")
+        if key in DATETIME_KEYS and bundle_version != DATETIME_TIMESTAMP_VERSION:
+            expected = (
+                f"an ISO date YYYY-MM-DD under okf_version {bundle_version or '<missing>'}; "
+                f"full ISO 8601 datetimes require okf_version {DATETIME_TIMESTAMP_VERSION}"
+            )
+        elif key in DATETIME_KEYS:
+            expected = "an ISO date YYYY-MM-DD or a full ISO 8601 datetime"
+        else:
+            expected = "an ISO date YYYY-MM-DD"
+        shown = raw if raw is not None else val
+        errors.append(f"{rel}: '{key}' must be {expected}, got {shown!r}")
 
 
 def check_lists(rel, fm, errors):
@@ -440,6 +506,26 @@ def check_lists(rel, fm, errors):
         for el in val:
             if not isinstance(el, str) or not el.strip():
                 errors.append(f"{rel}: '{key}' has a non-string/empty element {el!r}")
+
+
+def declared_bundle_version(bundle):
+    """Read the root marker for version-dependent field checks.
+
+    This is a non-reporting pre-pass; the main file loop remains responsible for
+    all root-index diagnostics. Reading it up front means a root-level concept
+    named ``a.md`` receives the right grammar even though it sorts before
+    ``index.md``.
+    """
+    root_index = bundle / "index.md"
+    if not root_index.is_file():
+        return None
+    try:
+        fm, _ = parse_frontmatter(root_index.read_text(encoding="utf-8-sig"))
+    except (OSError, yaml.YAMLError, ValueError):
+        return None
+    if not isinstance(fm, dict) or fm.get("okf_version") is None:
+        return None
+    return str(fm["okf_version"]).strip()
 
 
 def main() -> int:
@@ -471,6 +557,7 @@ def main() -> int:
     # index (or an empty directory) would validate clean and bypass version gating.
     if not (bundle / "index.md").is_file():
         errors.append("index.md: bundle-root index is required and must declare okf_version")
+    bundle_version = declared_bundle_version(bundle)
     type_counts: Counter = Counter()
     concepts = 0
 
@@ -566,8 +653,9 @@ def main() -> int:
             errors.append(f"{rel}: type '{ctype}' not in the spec vocab {sorted(ALLOWED_TYPES)}")
 
         check_lists(rel, fm, errors)
-        check_dates(rel, fm, errors)
-        check_source_quoting(rel, fm, frontmatter_block(text), errors)
+        raw_fm = frontmatter_block(text)
+        check_dates(rel, fm, raw_fm, bundle_version, errors)
+        check_source_quoting(rel, fm, raw_fm, errors)
 
     # Link resolution: every internal link to a .md file must resolve to a file
     # that exists inside the bundle. A link escaping the bundle root or pointing at

--- a/okf-wiki/spec/SPEC.md
+++ b/okf-wiki/spec/SPEC.md
@@ -54,8 +54,8 @@ upstream conventions will otherwise produce files this validator rejects.
   assignments and fails the bundle on a hit, so an upstream bundle that inlines a credential
   value passes upstream but is rejected here (see Security).
 
-The format version differs too: upstream is `0.1`, this spec's current version is `0.2`
-(the validator still accepts `0.1`). Every difference above pulls the same direction:
+The format version differs too: upstream is `0.1`, this spec's current version is `0.3`
+(the validator still accepts `0.1` and `0.2`). Every difference above pulls the same direction:
 upstream stays minimal and needs no tooling to stay portable, while this spec adds a
 validator that fails the build when a bundle drifts.
 
@@ -74,7 +74,7 @@ with an `index.md`. Larger bundles group concepts into subdirectories by subject
 
 ## Files
 
-- The bundle-root `index.md` carries `okf_version: "0.2"` in frontmatter — only there.
+- The bundle-root `index.md` carries `okf_version: "0.3"` in frontmatter — only there.
 - Per-directory `index.md`: a heading, an optional one-line preamble, then bullet
   navigation. No frontmatter. (Keep the preamble to one line — it orients, it doesn't narrate.)
 - `log.md` (optional, per directory): dated entries, newest first, no frontmatter.
@@ -88,11 +88,11 @@ The validator enforces the frontmatter rules here — reserved files carry no fr
 only the bundle-root `index.md` carries `okf_version` (and nothing else). The index/log body
 shapes above are recommendations for human readers, not validator-checked structure.
 
-The current format version is `0.2`. The validator accepts `0.1` and `0.2`, so a newer
-validator still reads an older bundle, and new scaffolds emit `0.2`. Adding allowed types is
-backward compatible and bumps the format version: a bundle using the newer types declares
-`0.2`, so an older validator reports a clear unsupported-version error instead of a misleading
-bad-type one.
+The current format version is `0.3`. The validator accepts `0.1`, `0.2`, and `0.3`, so a
+newer validator still reads an older bundle, and new scaffolds emit `0.3`. Version `0.2`
+added allowed types. Version `0.3` admits a full datetime in `timestamp`; a `0.1` or `0.2`
+bundle remains date-only. The marker makes these grammar changes explicit, so an older
+validator reports a clear unsupported-version error instead of a misleading field error.
 
 ## Concept frontmatter (required keys, all non-empty)
 
@@ -103,7 +103,7 @@ bad-type one.
 | `description` | one line |
 | `source` | YAML list of provenance pointers (paths, commands, URLs, events) |
 | `verified` | ISO date `YYYY-MM-DD` the fact was last confirmed true (see note below) |
-| `timestamp` | ISO date authored/updated |
+| `timestamp` | ISO date authored/updated, or in a `0.3` bundle a full ISO 8601 datetime |
 | `tags` | YAML list |
 
 `verified` note: it records when the fact was last confirmed true, which is not always today. A
@@ -118,6 +118,11 @@ not yet verifiable, so find a datable source or leave it out. When the date is u
 down: an older `verified` reads as "may be stale," today reads as "just confirmed." The date is the
 contract; a caveat in the concept body does not undo it, because the validator and tools read only
 the date.
+
+`timestamp` may be an ISO date (`YYYY-MM-DD`) in every supported format version. A `0.3`
+bundle may instead preserve a full datetime in the exact form
+`YYYY-MM-DDTHH:MM:SS[.fraction][Z|+HH:MM|-HH:MM]`; a space may replace `T`. Versions `0.1`
+and `0.2` remain date-only. `verified` is always date-only.
 
 `source` quoting rule (hard): QUOTE every element of the `source` list. Source pointers
 routinely carry YAML-significant characters — a `#` (e.g. `"issue #445"`) starts a comment

--- a/okf-wiki/spec/SPEC.md
+++ b/okf-wiki/spec/SPEC.md
@@ -31,9 +31,11 @@ upstream conventions will otherwise produce files this validator rejects.
 - `verified` is added. Upstream has no such key. This spec requires `verified`, the ISO
   date the fact was last confirmed true, kept distinct from `timestamp` (when the file was
   authored or edited).
-- Dates are date-only. Upstream's `timestamp` is an ISO 8601 datetime. Here `check_dates`
-  parses both `verified` and `timestamp` as `YYYY-MM-DD` only, so an upstream timestamp like
-  `2026-05-28T14:30:00Z` fails validation and must be truncated to its date.
+- `verified` is date-only. Upstream's `timestamp` is an ISO 8601 datetime, and `check_dates`
+  accepts that form for `timestamp` (with or without an offset, including a trailing `Z`), so
+  an upstream bundle validates here unchanged. `verified` takes `YYYY-MM-DD` only: it records
+  the day a fact was last confirmed true, and a time of day there is false precision about
+  the confirmation.
 - The type vocab is closed. Upstream types are freeform and unregistered, and consumers
   must tolerate unknown ones. Here the set is fixed (see Type vocab) and an unlisted type
   fails the build, which catches typos; extending it is a deliberate spec edit.

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -104,7 +104,7 @@ def test_multi_section_scaffold_validates(tmp_path):
 def test_root_index_carries_okf_version(tmp_path):
     scaffold(tmp_path / "kb")
     root = (tmp_path / "kb" / "bundle" / "index.md").read_text()
-    assert 'okf_version: "0.2"' in root
+    assert 'okf_version: "0.3"' in root
 
 
 def test_refuses_nonempty_dir_without_force(tmp_path):
@@ -598,13 +598,14 @@ def test_root_index_unsupported_okf_version_fails(tmp_path):
     assert rc == 1 and "not supported" in out
 
 
-def test_root_index_legacy_version_validates(tmp_path):
-    # backward compat: a 0.1 bundle (e.g. the fleet atlas) still validates under the
-    # newer validator, which accepts both 0.1 and the current format version.
+@pytest.mark.parametrize("version", ["0.1", "0.2"])
+def test_root_index_legacy_version_validates(tmp_path, version):
+    # Backward compatibility: older date-only bundles still validate under the
+    # newer validator.
     scaffold(tmp_path / "kb", "--no-validate")
     root = tmp_path / "kb" / "bundle" / "index.md"
-    root.write_text(root.read_text().replace('okf_version: "0.2"', 'okf_version: "0.1"'),
-                    encoding="utf-8")
+    root.write_text(root.read_text().replace(
+        'okf_version: "0.3"', f'okf_version: "{version}"'), encoding="utf-8")
     rc, out = validate(tmp_path / "kb" / "bundle")
     assert rc == 0, out
 
@@ -1882,9 +1883,18 @@ class TestTimestampAcceptsIsoDatetime:
     confirmed true.
     """
 
-    def _errors(self, key, value):
+    def _errors(self, key, value, version="0.3", quoted=False):
+        mod = _validate_module()
+        scalar = f'"{value}"' if quoted or value == "" else value
+        raw_fm = f"{key}: {scalar}\n"
+        try:
+            fm = mod.yaml.safe_load(raw_fm)
+        except ValueError:
+            # The CLI reports an invalid YAML timestamp constructor cleanly
+            # before check_dates; keep this unit helper focused on the checker.
+            fm = {key: value}
         errors = []
-        _validate_module().check_dates("f.md", {key: value}, errors)
+        mod.check_dates("f.md", fm, raw_fm, version, errors)
         return errors
 
     @pytest.mark.parametrize("value", [
@@ -1893,6 +1903,7 @@ class TestTimestampAcceptsIsoDatetime:
         "2026-05-28T14:30:00+00:00",
         "2026-05-28T14:30:00-04:00",
         "2026-05-28T14:30:00",
+        "2026-05-28T14:30:00.123456Z",
         "2026-05-28 14:30:00",  # RFC 3339's by-agreement space separator
     ])
     def test_timestamp_accepts_date_and_datetime(self, value):
@@ -1904,6 +1915,27 @@ class TestTimestampAcceptsIsoDatetime:
         assert "YYYY-MM-DD" in errors[0]
         # The message must not offer the datetime form for a key that rejects it.
         assert "datetime" not in errors[0]
+
+    def test_quoted_datetime_is_accepted(self):
+        assert self._errors(
+            "timestamp", "2026-05-28T14:30:00Z", quoted=True) == []
+
+    @pytest.mark.parametrize("value", [
+        "2026-5-8T4:03:02Z",
+        "2026-05-28 14:30:00 Z",
+    ])
+    def test_timestamp_rejects_yaml_normalised_spelling(self, value):
+        # PyYAML constructs both source spellings as datetime objects. Validation
+        # must inspect the scalar text instead of accepting datetime.isoformat().
+        errors = self._errors("timestamp", value)
+        assert len(errors) == 1
+        assert value in errors[0]
+
+    @pytest.mark.parametrize("version", ["0.1", "0.2"])
+    def test_legacy_version_rejects_datetime(self, version):
+        errors = self._errors("timestamp", "2026-05-28T14:30:00Z", version)
+        assert len(errors) == 1
+        assert "require okf_version 0.3" in errors[0]
 
     @pytest.mark.parametrize("value", [
         "2026-05-28x14:30:00",  # fromisoformat takes any single separator; ISO does not
@@ -1924,3 +1956,25 @@ class TestTimestampAcceptsIsoDatetime:
     def test_timestamp_error_names_both_accepted_forms(self):
         errors = self._errors("timestamp", "nonsense")
         assert "YYYY-MM-DD" in errors[0] and "ISO 8601 datetime" in errors[0]
+
+    def test_root_level_concept_uses_declared_version_before_index(self, tmp_path):
+        scaffold(tmp_path / "kb", "--no-validate")
+        bundle = tmp_path / "kb" / "bundle"
+        concept = GOOD.replace(
+            "timestamp: 2026-06-23", "timestamp: 2026-06-23T14:30:00Z")
+        write_concept(bundle, concept, name="a.md")
+        rc, out = validate(bundle)
+        assert rc == 0, out
+
+    def test_legacy_bundle_rejects_datetime_end_to_end(self, tmp_path):
+        scaffold(tmp_path / "kb", "--no-validate")
+        bundle = tmp_path / "kb" / "bundle"
+        root = bundle / "index.md"
+        root.write_text(root.read_text().replace(
+            'okf_version: "0.3"', 'okf_version: "0.2"'), encoding="utf-8")
+        concept = GOOD.replace(
+            "timestamp: 2026-06-23", "timestamp: 2026-06-23T14:30:00Z")
+        write_concept(bundle, concept)
+        rc, out = validate(bundle)
+        assert rc == 1
+        assert "require okf_version 0.3" in out

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -1858,3 +1858,69 @@ def test_dangling_uppercase_md_link_caught(tmp_path):
 ])
 def test_still_on_editor_matches_the_editor_path_not_the_substring(url, on_editor):
     assert gh_wiki_bootstrap._still_on_editor(url) is on_editor
+
+
+def _validate_module():
+    """Import validate.py as a module.
+
+    The module-level `validate` in this file is a subprocess runner, not the
+    module, so unit-testing a single check has to load the file directly.
+    """
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("okf_validate", VALIDATE)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestTimestampAcceptsIsoDatetime:
+    """Upstream OKF writes `timestamp` as a full ISO 8601 datetime.
+
+    Rejecting it only forced a truncation pass over every imported bundle, so it
+    is accepted and carried. `verified` is this spec's own key and stays
+    date-only -- a time of day there is false precision about when a fact was
+    confirmed true.
+    """
+
+    def _errors(self, key, value):
+        errors = []
+        _validate_module().check_dates("f.md", {key: value}, errors)
+        return errors
+
+    @pytest.mark.parametrize("value", [
+        "2026-05-28",
+        "2026-05-28T14:30:00Z",
+        "2026-05-28T14:30:00+00:00",
+        "2026-05-28T14:30:00-04:00",
+        "2026-05-28T14:30:00",
+        "2026-05-28 14:30:00",  # RFC 3339's by-agreement space separator
+    ])
+    def test_timestamp_accepts_date_and_datetime(self, value):
+        assert self._errors("timestamp", value) == []
+
+    def test_verified_stays_date_only(self):
+        errors = self._errors("verified", "2026-05-28T14:30:00Z")
+        assert len(errors) == 1
+        assert "YYYY-MM-DD" in errors[0]
+        # The message must not offer the datetime form for a key that rejects it.
+        assert "datetime" not in errors[0]
+
+    @pytest.mark.parametrize("value", [
+        "2026-05-28x14:30:00",  # fromisoformat takes any single separator; ISO does not
+        "2026-05-28T",
+        "2026-05-2814:30:00",
+    ])
+    def test_timestamp_rejects_a_non_iso_separator(self, value):
+        # The parser is not the contract. fromisoformat parses '...x14:30:00'
+        # clean, so the separator is checked before it is called -- otherwise
+        # widening to datetimes would quietly accept malformed metadata.
+        assert len(self._errors("timestamp", value)) == 1
+
+    @pytest.mark.parametrize("value", ["2026-13-99", "nonsense", "2026/05/28", ""])
+    def test_timestamp_still_rejects_garbage(self, value):
+        # Widening to datetimes must not turn the check into a rubber stamp.
+        assert len(self._errors("timestamp", value)) == 1
+
+    def test_timestamp_error_names_both_accepted_forms(self):
+        errors = self._errors("timestamp", "nonsense")
+        assert "YYYY-MM-DD" in errors[0] and "ISO 8601 datetime" in errors[0]


### PR DESCRIPTION
Picks off the first validator item from #156 (Tier 5 backlog).

`timestamp` is upstream OKF's key and upstream writes it as a full ISO 8601 datetime, but `check_dates` parsed it as `YYYY-MM-DD` only. Every bundle authored against upstream had to go through a truncation pass before it would validate here -- friction paid on import for precision that was then discarded. This accepts the datetime form and carries it.

`verified` stays date-only. It is this spec's own key and records the day a fact was last confirmed true; a time of day there is false precision about the confirmation, not extra information. The error message now names only the form each key actually accepts, so a rejected `verified` does not advertise a datetime the validator will refuse.

**One thing worth a look:** `datetime.fromisoformat` is the parser but not the contract -- it accepts any single character between the date and the time, so `2026-05-28x14:30:00` parses clean. Widening the check without guarding that would have let malformed metadata through in the name of compatibility. The separator is checked first and only `T` or a space (RFC 3339's by-agreement form) is allowed.

Tests pin both directions: the datetime forms are accepted, `verified` still rejects one, a non-ISO separator is rejected, and garbage is still rejected. 175 passing. Spec's upstream-divergence note rewritten to describe the narrower difference that remains, and the example bundle's copies of the spec and validator re-synced (the suite asserts they stay byte-identical).

Remaining #156 items are untouched and stay on the issue.