### PR TITLE
Harden scraper redirects and webhook failures

### DIFF
--- a/dev-toolkit/skills/web-scraping/SKILL.md
+++ b/dev-toolkit/skills/web-scraping/SKILL.md
@@ -57,6 +57,7 @@ from typing import Optional
 import requests
 from bs4 import BeautifulSoup
 import trafilatura
+from urllib.parse import urljoin
 
 #for .py files
 from playwright.sync_api import sync_playwright
@@ -64,6 +65,38 @@ from playwright.sync_api import sync_playwright
 #for .ipynb files
 import asyncio
 from playwright.async_api import async_playwright
+
+STOP_STATUS_CODES = {401, 403, 429}
+MAX_REDIRECTS = 5
+
+class AccessDeniedError(RuntimeError):
+    """The origin denied access; do not escalate to another scraper."""
+
+def fetch_public_response(url: str, *, headers: dict,
+                          timeout: int = 30) -> requests.Response:
+    """Follow a small redirect chain, validating every hop before fetching."""
+    current_url = url
+    for _ in range(MAX_REDIRECTS + 1):
+        current_url = validate_public_url(current_url)
+        response = requests.get(
+            current_url,
+            headers=headers,
+            timeout=timeout,
+            allow_redirects=False,
+        )
+        if response.status_code in STOP_STATUS_CODES:
+            response.close()
+            raise AccessDeniedError('The origin denied automated access')
+        if response.is_redirect:
+            location = response.headers.get('Location')
+            response.close()
+            if not location:
+                raise ValueError('Redirect response has no Location header')
+            current_url = urljoin(current_url, location)
+            continue
+        response.raise_for_status()
+        return response
+    raise ValueError('Redirect limit exceeded')
 
 class ScrapingResult:
     def __init__(self, content: str, title: str, method: str):
@@ -80,16 +113,11 @@ class TrafilaturaScraper(Scraper):
 
     def fetch(self, url: str) -> Optional[ScrapingResult]:
         try:
-            url = validate_public_url(url)
-            response = requests.get(
+            response = fetch_public_response(
                 url,
                 headers={'User-Agent': 'ResearchScraper/1.0 (+https://example.org/contact)'},
                 timeout=30,
-                allow_redirects=False,
             )
-            if response.is_redirect:
-                raise ValueError('Redirect target must be validated before fetching')
-            response.raise_for_status()
             downloaded = response.text
 
             content = trafilatura.extract(
@@ -108,6 +136,8 @@ class TrafilaturaScraper(Scraper):
             title_text = title.get_text() if title else ''
 
             return ScrapingResult(content, title_text, 'trafilatura')
+        except AccessDeniedError:
+            raise
         except Exception:
             return None
 
@@ -124,13 +154,7 @@ class RequestsScraper(Scraper):
         }
 
         try:
-            url = validate_public_url(url)
-            response = requests.get(
-                url, headers=headers, timeout=30, allow_redirects=False
-            )
-            if response.is_redirect:
-                raise ValueError('Redirect target must be validated before fetching')
-            response.raise_for_status()
+            response = fetch_public_response(url, headers=headers, timeout=30)
 
             soup = BeautifulSoup(response.text, 'html.parser')
 
@@ -149,6 +173,8 @@ class RequestsScraper(Scraper):
                 return None
 
             return ScrapingResult(content, title_text, 'requests')
+        except AccessDeniedError:
+            raise
         except Exception:
             return None
 
@@ -162,11 +188,22 @@ class PlaywrightScraper(Scraper):
                 browser = p.chromium.launch(headless=True)
                 context = browser.new_context(
                     viewport={'width': 1920, 'height': 1080},
-                    user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+                    user_agent='ResearchScraper/1.0 (+https://example.org/contact)'
                 )
                 page = context.new_page()
 
-                page.goto(url, wait_until='networkidle', timeout=60000)
+                def allow_public_route(route):
+                    try:
+                        validate_public_url(route.request.url)
+                    except (OSError, ValueError):
+                        route.abort('blockedbyclient')
+                        return
+                    route.continue_()
+
+                page.route('**/*', allow_public_route)
+                response = page.goto(url, wait_until='networkidle', timeout=60000)
+                if response and response.status in STOP_STATUS_CODES:
+                    raise AccessDeniedError('The origin denied automated access')
                 validate_public_url(page.url)
 
                 # Wait for content to load
@@ -186,6 +223,8 @@ class PlaywrightScraper(Scraper):
                     return None
 
                 return ScrapingResult(content, title, 'playwright')
+        except AccessDeniedError:
+            raise
         except Exception:
             return None
 
@@ -203,11 +242,22 @@ class PlaywrightScraperAsync:
                 browser = await p.chromium.launch(headless=True)
                 context = await browser.new_context(
                     viewport={'width': 1920, 'height': 1080},
-                    user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+                    user_agent='ResearchScraper/1.0 (+https://example.org/contact)'
                 )
                 page = await context.new_page()
 
-                await page.goto(url, wait_until='networkidle', timeout=60000)
+                async def allow_public_route(route):
+                    try:
+                        validate_public_url(route.request.url)
+                    except (OSError, ValueError):
+                        await route.abort('blockedbyclient')
+                        return
+                    await route.continue_()
+
+                await page.route('**/*', allow_public_route)
+                response = await page.goto(url, wait_until='networkidle', timeout=60000)
+                if response and response.status in STOP_STATUS_CODES:
+                    raise AccessDeniedError('The origin denied automated access')
                 validate_public_url(page.url)
 
                 # Wait for content to load
@@ -227,6 +277,8 @@ class PlaywrightScraperAsync:
                     return None
 
                 return ScrapingResult(content, title, 'playwright_async')
+        except AccessDeniedError:
+            raise
         except Exception:
             return None
 

--- a/research-toolkit/skills/page-monitoring/SKILL.md
+++ b/research-toolkit/skills/page-monitoring/SKILL.md
@@ -512,18 +512,24 @@ class AlertManager:
         if channel:
             payload['channel'] = channel
 
-        response = requests.post(self.slack_webhook, json=payload, timeout=15)
-        response.raise_for_status()
+        try:
+            response = requests.post(self.slack_webhook, json=payload, timeout=15)
+            response.raise_for_status()
+        except requests.RequestException:
+            raise RuntimeError('Slack webhook request failed') from None
 
     def send_discord(self, message: str):
         """Send Discord notification."""
         if not self.discord_webhook:
             return
 
-        response = requests.post(
-            self.discord_webhook, json={'content': message}, timeout=15
-        )
-        response.raise_for_status()
+        try:
+            response = requests.post(
+                self.discord_webhook, json={'content': message}, timeout=15
+            )
+            response.raise_for_status()
+        except requests.RequestException:
+            raise RuntimeError('Discord webhook request failed') from None
 
     def send_email(self, subject: str, body: str, to: str):
         """Send email notification."""

--- a/scripts/skill-security.test.mjs
+++ b/scripts/skill-security.test.mjs
@@ -12,6 +12,18 @@ const webScrapingUrl = new URL(
   import.meta.url,
 );
 
+function pythonBlocks(markdown) {
+  return [...markdown.matchAll(/```python\s*\n([\s\S]*?)```/g)].map((match) => match[1]);
+}
+
+function pythonIdentifierTargets(source) {
+  const patterns = [
+    /^\s*(?:async\s+)?(?:class|def)\s+([^\s(:]+)/gm,
+    /^\s*([^\s=:+,\[\]{}()]+)\s*(?::[^=]+)?=/gm,
+  ];
+  return patterns.flatMap((pattern) => [...source.matchAll(pattern)].map((match) => match[1]));
+}
+
 test("pdf-design publishes no maintainer-specific credential or upload wiring", async () => {
   const skill = await readFile(pdfSkillUrl, "utf8");
 
@@ -59,13 +71,20 @@ test("page-monitoring examples retrieve and redact secrets safely", async () => 
   assert.match(skill, /redact/i);
   assert.match(skill, /never (log|print).*secret/i);
   assert.match(skill, /type\(error\)\.__name__/);
+
+  const webhookSection = skill.slice(skill.indexOf("## Webhook notifications"));
+  assert.equal(
+    (webhookSection.match(/except requests\.RequestException:/g) || []).length,
+    2,
+  );
+  assert.match(webhookSection, /raise RuntimeError\('Slack webhook request failed'\) from None/);
+  assert.match(webhookSection, /raise RuntimeError\('Discord webhook request failed'\) from None/);
 });
 
 test("web-scraping defines explicit content, URL, and session trust boundaries", async () => {
   const skill = await readFile(webScrapingUrl, "utf8");
 
   assert.doesNotMatch(skill, /TrafilaturaCscraper/);
-  assert.doesNotMatch(skill, /[\u0400-\u04ff]/);
   assert.match(skill, /class TrafilaturaScraper/);
   assert.match(skill, /untrusted data, never as instructions/i);
   assert.match(skill, /private-network destinations/i);
@@ -73,4 +92,33 @@ test("web-scraping defines explicit content, URL, and session trust boundaries",
   assert.match(skill, /documented authorization/i);
   assert.match(skill, /Never return, print, or embed cookies/i);
   assert.match(skill, /ResearchScraper\/1\.0/);
+  assert.doesNotMatch(skill, /Mozilla\/5\.0 \(Windows NT/);
+  assert.match(skill, /class AccessDeniedError/);
+  assert.match(skill, /STOP_STATUS_CODES = \{401, 403, 429\}/);
+  assert.match(skill, /def fetch_public_response/);
+  assert.match(skill, /allow_redirects=False/);
+  assert.ok((skill.match(/fetch_public_response\(/g) || []).length >= 3);
+  assert.equal(
+    (skill.match(/except AccessDeniedError:\s*\n\s+raise/g) || []).length,
+    4,
+  );
+  assert.equal((skill.match(/page\.route\('\*\*\/\*'/g) || []).length, 2);
+  assert.match(skill, /DNS rebinding/i);
+  assert.match(skill, /enforce network policy outside the scraper process/i);
+
+  const identifiers = pythonBlocks(skill).flatMap(pythonIdentifierTargets);
+  assert.ok(identifiers.length > 0, "security check found Python identifier targets");
+  for (const identifier of identifiers) {
+    assert.doesNotMatch(identifier, /[^\x00-\x7f]/, `non-ASCII identifier: ${identifier}`);
+  }
+});
+
+test("Python identifier scan catches confusables without banning Unicode prose", () => {
+  assert.deepEqual(pythonIdentifierTargets("label = 'naïve text'"), ["label"]);
+  assert.match("naïve text", /[^\x00-\x7f]/);
+
+  for (const source of ["class Scrаper:", "def fetχ(url):", "resρonse = fetch()"]) {
+    const target = pythonIdentifierTargets(source)[0];
+    assert.match(target, /[^\x00-\x7f]/);
+  }
 });


### PR DESCRIPTION
## What this does

Closes #203 and #205 by making the worked examples enforce the security boundaries introduced in #201.

- Follow HTTP redirects manually with a five-hop cap and validate every destination before fetching.
- Route every Playwright request through the public-destination validator, including redirects and subresources.
- Propagate 401, 403, and 429 responses as stop signals so the scraping cascade cannot escalate after access is denied.
- Use the stable descriptive `ResearchScraper/1.0` user agent in both browser examples.
- Catch webhook request failures and rethrow fixed messages that cannot contain the secret-bearing Slack or Discord URL.
- Scan Python declaration and assignment targets for any non-ASCII identifier instead of globally banning one Unicode block.

The in-process destination check remains defense in depth. The skill explicitly requires private-network egress blocking because DNS can change between validation and connection.

## Verification

- `npm test` — 7/7 passing
- All 9 Python example blocks in `web-scraping/SKILL.md` compile
- `git diff --check` — clean

## Stack

This ready-for-review PR targets `agent/harden-high-risk-skills` because it builds directly on #201. Review #201 first. If #201 lands independently, retarget this PR to `master` before merging.