### PR TITLE
Harden the brainstorming visual companion

### DIFF
--- a/scripts/brainstorming-companion-security.test.mjs
+++ b/scripts/brainstorming-companion-security.test.mjs
@@ -1,0 +1,204 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const require = createRequire(import.meta.url);
+const TOKEN = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFG';
+process.env.BRAINSTORM_HOST = '127.0.0.1';
+process.env.BRAINSTORM_PORT = '54321';
+process.env.BRAINSTORM_TOKEN = TOKEN;
+process.env.BRAINSTORM_URL_HOST = 'localhost';
+const {
+  consumeEventAllowance,
+  createSecurityContext,
+  decodeFrame,
+  handleRequest,
+  normalizeEvent,
+  resolveContentPath,
+  validateWebSocketRequest,
+} = require('../superjawn/skills/brainstorming/scripts/server.cjs');
+
+const KEY = Buffer.alloc(16, 7).toString('base64');
+
+function responseRecorder() {
+  return {
+    body: null,
+    headers: null,
+    status: null,
+    end(body) { this.body = body; },
+    writeHead(status, headers) { this.status = status; this.headers = headers; },
+  };
+}
+
+function websocketRequest(cookieName, overrides = {}) {
+  return {
+    method: 'GET',
+    url: '/',
+    headers: {
+      host: 'localhost:54321',
+      origin: 'http://localhost:54321',
+      cookie: `${cookieName}=${TOKEN}`,
+      upgrade: 'websocket',
+      connection: 'Upgrade',
+      'sec-websocket-version': '13',
+      'sec-websocket-key': KEY,
+      ...overrides,
+    },
+  };
+}
+
+test('WebSocket validation requires the expected origin, host, and capability', () => {
+  const security = createSecurityContext({
+    host: '127.0.0.1',
+    port: 54321,
+    sessionToken: TOKEN,
+    urlHost: 'localhost',
+  });
+  const parallelSession = createSecurityContext({
+    host: '127.0.0.1',
+    port: 54322,
+    sessionToken: 'abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG',
+    urlHost: 'localhost',
+  });
+  assert.notEqual(security.cookieName, parallelSession.cookieName);
+  assert.throws(() => createSecurityContext({
+    host: '127.0.0.1',
+    port: 54321,
+    sessionToken: `${'x'.repeat(43)}\r\n`,
+    urlHost: 'localhost',
+  }), /base64url/i);
+  assert.throws(() => createSecurityContext({
+    host: '0.0.0.0',
+    port: 54321,
+    sessionToken: TOKEN,
+    urlHost: '192.0.2.10',
+  }), /must use HTTPS/i);
+
+  assert.deepEqual(validateWebSocketRequest(websocketRequest(security.cookieName), security), { ok: true });
+  assert.equal(
+    validateWebSocketRequest(websocketRequest(security.cookieName, { origin: 'http://attacker.example' }), security).status,
+    403,
+  );
+  assert.equal(
+    validateWebSocketRequest(websocketRequest(security.cookieName, { host: 'attacker.example' }), security).status,
+    403,
+  );
+  assert.equal(
+    validateWebSocketRequest(websocketRequest(security.cookieName, { cookie: '' }), security).status,
+    401,
+  );
+  assert.equal(validateWebSocketRequest({ ...websocketRequest(security.cookieName), url: '/control' }, security).status, 400);
+});
+
+test('HTTP bootstrap requires the capability and exchanges it for a hardened cookie', () => {
+  const denied = responseRecorder();
+  handleRequest({ method: 'GET', url: '/', headers: { host: 'localhost:54321' } }, denied);
+  assert.equal(denied.status, 401);
+
+  const bootstrapped = responseRecorder();
+  handleRequest({
+    method: 'GET',
+    url: `/?token=${TOKEN}`,
+    headers: { host: 'localhost:54321' },
+  }, bootstrapped);
+  assert.equal(bootstrapped.status, 303);
+  assert.equal(bootstrapped.headers.Location, '/');
+  assert.match(bootstrapped.headers['Set-Cookie'], /HttpOnly/);
+  assert.match(bootstrapped.headers['Set-Cookie'], /SameSite=Strict/);
+  assert.doesNotMatch(bootstrapped.headers.Location, /token/);
+});
+
+test('frame decoder rejects malformed, fragmented, and oversized client frames', () => {
+  assert.throws(
+    () => decodeFrame(Buffer.from([0x81, 0x01, 0x41])),
+    /masked/i,
+  );
+  assert.throws(
+    () => decodeFrame(Buffer.from([0x01, 0x80, 0, 0, 0, 0])),
+    /fragment/i,
+  );
+
+  const oversizedHeader = Buffer.alloc(8);
+  oversizedHeader[0] = 0x81;
+  oversizedHeader[1] = 0x80 | 126;
+  oversizedHeader.writeUInt16BE(8193, 2);
+  assert.throws(() => decodeFrame(oversizedHeader), /maximum/i);
+});
+
+test('event validation allowlists persisted fields and bounds attacker-controlled text', () => {
+  assert.deepEqual(
+    normalizeEvent(JSON.stringify({
+      type: 'click',
+      choice: 'layout-a',
+      text: 'Layout A',
+      id: 'choice-a',
+      timestamp: 1,
+    }), 1700000000000),
+    {
+      type: 'click',
+      choice: 'layout-a',
+      text: 'Layout A',
+      id: 'choice-a',
+      timestamp: 1700000000000,
+    },
+  );
+
+  assert.throws(
+    () => normalizeEvent(JSON.stringify({ type: 'reload', choice: 'x' })),
+    /type/i,
+  );
+  assert.throws(
+    () => normalizeEvent(JSON.stringify({ type: 'click', choice: 'x', injected: true })),
+    /field/i,
+  );
+  assert.throws(
+    () => normalizeEvent(JSON.stringify({ type: 'click', choice: 'x'.repeat(129) })),
+    /choice/i,
+  );
+  assert.throws(
+    () => normalizeEvent('x'.repeat(4097)),
+    /size/i,
+  );
+});
+
+test('event rate limiter caps each WebSocket independently', () => {
+  const state = { eventTimes: [] };
+  for (let i = 0; i < 30; i += 1) {
+    assert.equal(consumeEventAllowance(state, 1000 + i), true);
+  }
+  assert.equal(consumeEventAllowance(state, 1030), false);
+  assert.equal(consumeEventAllowance(state, 12001), true);
+});
+
+test('file resolver accepts one regular basename and rejects traversal or symlink escape', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'brainstorm-security-'));
+  const content = path.join(root, 'content');
+  const outside = path.join(root, 'outside.txt');
+  try {
+    mkdirSync(content);
+    writeFileSync(path.join(content, 'safe.html'), '<p>safe</p>');
+    writeFileSync(outside, 'secret');
+    symlinkSync(outside, path.join(content, 'escape.html'));
+
+    assert.equal(resolveContentPath('/files/safe.html', content), path.join(content, 'safe.html'));
+    assert.equal(resolveContentPath('/files/../outside.txt', content), null);
+    assert.equal(resolveContentPath('/files/%2e%2e%2foutside.txt', content), null);
+    assert.equal(resolveContentPath('/files/..%5coutside.txt', content), null);
+    assert.equal(resolveContentPath('/files/escape.html', content), null);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('remote-binding documentation requires TLS and trusted access control', () => {
+  const guide = readFileSync(
+    new URL('../superjawn/skills/brainstorming/visual-companion.md', import.meta.url),
+    'utf8',
+  );
+  assert.match(guide, /Remote exposure requires TLS/i);
+  assert.match(guide, /wss:\/\//i);
+  assert.match(guide, /access control through a trusted reverse proxy or authenticated tunnel/i);
+});

--- a/scripts/brainstorming-companion-security.test.mjs
+++ b/scripts/brainstorming-companion-security.test.mjs
@@ -14,6 +14,7 @@ process.env.BRAINSTORM_URL_HOST = 'localhost';
 const {
   consumeEventAllowance,
   createSecurityContext,
+  decodeAvailableFrames,
   decodeFrame,
   handleRequest,
   normalizeEvent,
@@ -22,6 +23,24 @@ const {
 } = require('../superjawn/skills/brainstorming/scripts/server.cjs');
 
 const KEY = Buffer.alloc(16, 7).toString('base64');
+
+function clientFrame(text) {
+  const payload = Buffer.from(text);
+  assert.ok(payload.length < 65536, 'test helper only builds 16-bit frames');
+  const mask = Buffer.from([1, 2, 3, 4]);
+  const extended = payload.length >= 126;
+  const maskOffset = extended ? 4 : 2;
+  const dataOffset = maskOffset + 4;
+  const frame = Buffer.alloc(dataOffset + payload.length);
+  frame[0] = 0x81;
+  frame[1] = 0x80 | (extended ? 126 : payload.length);
+  if (extended) frame.writeUInt16BE(payload.length, 2);
+  mask.copy(frame, maskOffset);
+  for (let index = 0; index < payload.length; index += 1) {
+    frame[dataOffset + index] = payload[index] ^ mask[index % 4];
+  }
+  return frame;
+}
 
 function responseRecorder() {
   return {
@@ -76,6 +95,12 @@ test('WebSocket validation requires the expected origin, host, and capability', 
     sessionToken: TOKEN,
     urlHost: '192.0.2.10',
   }), /must use HTTPS/i);
+  assert.doesNotThrow(() => createSecurityContext({
+    host: '127.0.0.2',
+    port: 54321,
+    sessionToken: TOKEN,
+    urlHost: '127.0.0.2',
+  }));
 
   assert.deepEqual(validateWebSocketRequest(websocketRequest(security.cookieName), security), { ok: true });
   assert.equal(
@@ -128,6 +153,22 @@ test('frame decoder rejects malformed, fragmented, and oversized client frames',
   assert.throws(() => decodeFrame(oversizedHeader), /maximum/i);
 });
 
+test('buffer decoder drains coalesced valid frames before applying the incomplete-frame cap', () => {
+  const frames = Array.from({ length: 30 }, (_, index) =>
+    clientFrame(JSON.stringify({ type: 'click', choice: `choice-${index}`, text: 'x'.repeat(300) })));
+  const coalesced = Buffer.concat(frames);
+  assert.ok(coalesced.length > 8 * 1024);
+
+  const decoded = decodeAvailableFrames(coalesced);
+  assert.equal(decoded.frames.length, 30);
+  assert.equal(decoded.remaining.length, 0);
+
+  const oversizedBurst = Buffer.concat(
+    Array.from({ length: 31 }, () => clientFrame('x'.repeat(8 * 1024))),
+  );
+  assert.throws(() => decodeAvailableFrames(oversizedBurst), /maximum/i);
+});
+
 test('event validation allowlists persisted fields and bounds attacker-controlled text', () => {
   assert.deepEqual(
     normalizeEvent(JSON.stringify({
@@ -171,6 +212,20 @@ test('event rate limiter caps each WebSocket independently', () => {
   }
   assert.equal(consumeEventAllowance(state, 1030), false);
   assert.equal(consumeEventAllowance(state, 12001), true);
+});
+
+test('browser reconnect queue cannot exceed one server allowance window', () => {
+  const server = readFileSync(
+    new URL('../superjawn/skills/brainstorming/scripts/server.cjs', import.meta.url),
+    'utf8',
+  );
+  const helper = readFileSync(
+    new URL('../superjawn/skills/brainstorming/scripts/helper.js', import.meta.url),
+    'utf8',
+  );
+  const serverLimit = Number(server.match(/const MAX_EVENTS_PER_WINDOW = (\d+);/u)?.[1]);
+  const queueLimit = Number(helper.match(/const MAX_QUEUE = (\d+);/u)?.[1]);
+  assert.equal(queueLimit, serverLimit);
 });
 
 test('file resolver accepts one regular basename and rejects traversal or symlink escape', () => {

--- a/superjawn/skills/brainstorming/scripts/helper.js
+++ b/superjawn/skills/brainstorming/scripts/helper.js
@@ -1,35 +1,70 @@
 (function() {
-  const WS_URL = 'ws://' + window.location.host;
+  const WS_URL = (window.location.protocol === 'https:' ? 'wss://' : 'ws://') + window.location.host + '/';
+  const MAX_QUEUE = 50;
   let ws = null;
   let eventQueue = [];
+  let reconnectTimer = null;
+
+  function clean(value, maximum) {
+    const normalized = String(value).replace(/[\u0000-\u001f\u007f]+/gu, ' ').trim();
+    return Array.from(normalized).slice(0, maximum).join('');
+  }
+
+  function prepareEvent(event) {
+    if (!event || (event.type !== 'click' && event.type !== 'choice')) return null;
+    const choice = event.choice ?? event.value;
+    if (typeof choice !== 'string' || choice.length === 0) return null;
+    const safeChoice = clean(choice, 128);
+    if (!safeChoice) return null;
+    const safe = { type: event.type, choice: safeChoice };
+    if (typeof event.text === 'string' && event.text.length > 0) {
+      const safeText = clean(event.text, 512);
+      if (safeText) safe.text = safeText;
+    }
+    if (event.id === null) {
+      safe.id = null;
+    } else if (typeof event.id === 'string') {
+      const safeId = clean(event.id, 128);
+      if (safeId) safe.id = safeId;
+    }
+    return safe;
+  }
 
   function connect() {
     ws = new WebSocket(WS_URL);
 
     ws.onopen = () => {
-      eventQueue.forEach(e => ws.send(JSON.stringify(e)));
+      eventQueue.forEach(event => ws.send(JSON.stringify(event)));
       eventQueue = [];
     };
 
     ws.onmessage = (msg) => {
-      const data = JSON.parse(msg.data);
-      if (data.type === 'reload') {
-        window.location.reload();
+      try {
+        const data = JSON.parse(msg.data);
+        if (data && data.type === 'reload' && Object.keys(data).length === 1) {
+          window.location.reload();
+        }
+      } catch {
+        ws.close(1008, 'Invalid control message');
       }
     };
 
     ws.onclose = () => {
-      setTimeout(connect, 1000);
+      clearTimeout(reconnectTimer);
+      reconnectTimer = setTimeout(connect, 1000);
     };
   }
 
   function sendEvent(event) {
-    event.timestamp = Date.now();
+    const safeEvent = prepareEvent(event);
+    if (!safeEvent) return false;
     if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify(event));
+      ws.send(JSON.stringify(safeEvent));
     } else {
-      eventQueue.push(event);
+      if (eventQueue.length === MAX_QUEUE) eventQueue.shift();
+      eventQueue.push(safeEvent);
     }
+    return true;
   }
 
   // Capture clicks on choice elements
@@ -84,7 +119,7 @@
   // Expose API for explicit use
   window.brainstorm = {
     send: sendEvent,
-    choice: (value, metadata = {}) => sendEvent({ type: 'choice', value, ...metadata })
+    choice: (value) => sendEvent({ type: 'choice', choice: value })
   };
 
   connect();

--- a/superjawn/skills/brainstorming/scripts/helper.js
+++ b/superjawn/skills/brainstorming/scripts/helper.js
@@ -1,6 +1,6 @@
 (function() {
   const WS_URL = (window.location.protocol === 'https:' ? 'wss://' : 'ws://') + window.location.host + '/';
-  const MAX_QUEUE = 50;
+  const MAX_QUEUE = 30;
   let ws = null;
   let eventQueue = [];
   let reconnectTimer = null;

--- a/superjawn/skills/brainstorming/scripts/server.cjs
+++ b/superjawn/skills/brainstorming/scripts/server.cjs
@@ -11,6 +11,7 @@ const MAX_MESSAGE_BYTES = 4 * 1024;
 const WS_MAGIC = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
 const EVENT_WINDOW_MS = 10 * 1000;
 const MAX_EVENTS_PER_WINDOW = 30;
+const MAX_BUFFER_BYTES = (MAX_FRAME_BYTES + 14) * MAX_EVENTS_PER_WINDOW;
 
 function computeAcceptKey(clientKey) {
   return crypto.createHash('sha1').update(clientKey + WS_MAGIC).digest('base64');
@@ -91,6 +92,30 @@ function decodeFrame(buffer) {
   return { opcode, payload: data, bytesConsumed: totalLen };
 }
 
+function decodeAvailableFrames(input) {
+  if (input.length > MAX_BUFFER_BYTES) {
+    const error = new Error('Buffered frame burst exceeds maximum');
+    error.closeCode = 1009;
+    throw error;
+  }
+  const frames = [];
+  let remaining = input;
+  while (remaining.length > 0) {
+    const result = decodeFrame(remaining);
+    if (!result) {
+      if (remaining.length > MAX_FRAME_BYTES + 14) {
+        const error = new Error('Incomplete frame buffer exceeds maximum');
+        error.closeCode = 1009;
+        throw error;
+      }
+      break;
+    }
+    frames.push(result);
+    remaining = remaining.slice(result.bytesConsumed);
+  }
+  return { frames, remaining };
+}
+
 // ========== Configuration ==========
 
 const PORT = Number(process.env.BRAINSTORM_PORT || (49152 + Math.floor(Math.random() * 16383)));
@@ -117,7 +142,11 @@ const MIME_TYPES = {
 
 function isLoopbackHost(hostname) {
   const normalized = String(hostname).replace(/^\[|\]$/g, '').toLowerCase();
-  return normalized === 'localhost' || normalized === '::1' || normalized === '127.0.0.1';
+  if (normalized === 'localhost' || normalized === '::1') return true;
+  const octets = normalized.split('.');
+  return octets.length === 4
+    && octets[0] === '127'
+    && octets.every(octet => /^\d{1,3}$/u.test(octet) && Number(octet) <= 255);
 }
 
 function formatHostname(hostname) {
@@ -403,20 +432,16 @@ function handleUpgrade(req, socket, head = Buffer.alloc(0)) {
 
   function processChunk(chunk) {
     buffer = Buffer.concat([buffer, chunk]);
-    if (buffer.length > MAX_FRAME_BYTES + 14) {
-      closeConnection(socket, 1009);
+    let decoded;
+    try {
+      decoded = decodeAvailableFrames(buffer);
+    } catch (error) {
+      closeConnection(socket, error.closeCode === 1009 ? 1009 : 1002);
       return;
     }
-    while (buffer.length > 0) {
-      let result;
-      try {
-        result = decodeFrame(buffer);
-      } catch {
-        closeConnection(socket, 1002);
-        return;
-      }
-      if (!result) break;
-      buffer = buffer.slice(result.bytesConsumed);
+    buffer = decoded.remaining;
+
+    for (const result of decoded.frames) {
 
       switch (result.opcode) {
         case OPCODES.TEXT: {
@@ -654,6 +679,7 @@ module.exports = {
   computeAcceptKey,
   consumeEventAllowance,
   createSecurityContext,
+  decodeAvailableFrames,
   decodeFrame,
   encodeFrame,
   handleRequest,

--- a/superjawn/skills/brainstorming/scripts/server.cjs
+++ b/superjawn/skills/brainstorming/scripts/server.cjs
@@ -6,8 +6,11 @@ const path = require('path');
 // ========== WebSocket Protocol (RFC 6455) ==========
 
 const OPCODES = { TEXT: 0x01, CLOSE: 0x08, PING: 0x09, PONG: 0x0A };
-const MAX_FRAME_BYTES = 1 << 20;
+const MAX_FRAME_BYTES = 8 * 1024;
+const MAX_MESSAGE_BYTES = 4 * 1024;
 const WS_MAGIC = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+const EVENT_WINDOW_MS = 10 * 1000;
+const MAX_EVENTS_PER_WINDOW = 30;
 
 function computeAcceptKey(clientKey) {
   return crypto.createHash('sha1').update(clientKey + WS_MAGIC).digest('base64');
@@ -40,12 +43,17 @@ function encodeFrame(opcode, payload) {
 function decodeFrame(buffer) {
   if (buffer.length < 2) return null;
 
+  const firstByte = buffer[0];
+  const fin = (firstByte & 0x80) !== 0;
+  const reserved = firstByte & 0x70;
   const secondByte = buffer[1];
-  const opcode = buffer[0] & 0x0F;
+  const opcode = firstByte & 0x0F;
   const masked = (secondByte & 0x80) !== 0;
   let payloadLen = secondByte & 0x7F;
   let offset = 2;
 
+  if (reserved !== 0) throw new Error('Reserved WebSocket bits are not supported');
+  if (!fin) throw new Error('Fragmented WebSocket frames are not supported');
   if (!masked) throw new Error('Client frames must be masked');
 
   if (payloadLen === 126) {
@@ -54,12 +62,19 @@ function decodeFrame(buffer) {
     offset = 4;
   } else if (payloadLen === 127) {
     if (buffer.length < 10) return null;
-    payloadLen = Number(buffer.readBigUInt64BE(2));
+    const longLength = buffer.readBigUInt64BE(2);
+    if (longLength > BigInt(MAX_FRAME_BYTES)) {
+      throw new Error('Frame payload exceeds maximum');
+    }
+    payloadLen = Number(longLength);
     offset = 10;
   }
 
   if (payloadLen > MAX_FRAME_BYTES) {
     throw new Error('Frame payload exceeds maximum (' + payloadLen + ' > ' + MAX_FRAME_BYTES + ')');
+  }
+  if (opcode >= 0x08 && payloadLen > 125) {
+    throw new Error('Control frame payload exceeds maximum');
   }
 
   const maskOffset = offset;
@@ -78,19 +93,140 @@ function decodeFrame(buffer) {
 
 // ========== Configuration ==========
 
-const PORT = process.env.BRAINSTORM_PORT || (49152 + Math.floor(Math.random() * 16383));
+const PORT = Number(process.env.BRAINSTORM_PORT || (49152 + Math.floor(Math.random() * 16383)));
 const HOST = process.env.BRAINSTORM_HOST || '127.0.0.1';
 const URL_HOST = process.env.BRAINSTORM_URL_HOST || (HOST === '127.0.0.1' ? 'localhost' : HOST);
+const PUBLIC_ORIGIN = process.env.BRAINSTORM_PUBLIC_ORIGIN || null;
+const SESSION_TOKEN = process.env.BRAINSTORM_TOKEN || crypto.randomBytes(32).toString('base64url');
 const SESSION_DIR = process.env.BRAINSTORM_DIR || '/tmp/brainstorm';
 const CONTENT_DIR = path.join(SESSION_DIR, 'content');
 const STATE_DIR = path.join(SESSION_DIR, 'state');
 let ownerPid = process.env.BRAINSTORM_OWNER_PID ? Number(process.env.BRAINSTORM_OWNER_PID) : null;
+
+if (!Number.isInteger(PORT) || PORT < 1 || PORT > 65535) {
+  throw new Error('BRAINSTORM_PORT must be an integer from 1 to 65535');
+}
 
 const MIME_TYPES = {
   '.html': 'text/html', '.css': 'text/css', '.js': 'application/javascript',
   '.json': 'application/json', '.png': 'image/png', '.jpg': 'image/jpeg',
   '.jpeg': 'image/jpeg', '.gif': 'image/gif', '.svg': 'image/svg+xml'
 };
+
+// ========== Session Security ==========
+
+function isLoopbackHost(hostname) {
+  const normalized = String(hostname).replace(/^\[|\]$/g, '').toLowerCase();
+  return normalized === 'localhost' || normalized === '::1' || normalized === '127.0.0.1';
+}
+
+function formatHostname(hostname) {
+  const value = String(hostname);
+  return value.includes(':') && !value.startsWith('[') ? `[${value}]` : value;
+}
+
+function createSecurityContext({ host, port, publicOrigin = null, sessionToken, urlHost }) {
+  if (typeof sessionToken !== 'string' || !/^[A-Za-z0-9_-]{43,}$/u.test(sessionToken)) {
+    throw new Error('Session capability token must be at least 43 base64url characters');
+  }
+
+  const fallbackOrigin = `http://${formatHostname(urlHost)}:${port}`;
+  const configuredOrigin = publicOrigin || fallbackOrigin;
+  let primary;
+  try {
+    primary = new URL(configuredOrigin);
+  } catch {
+    throw new Error('BRAINSTORM_PUBLIC_ORIGIN must be an absolute HTTP(S) origin');
+  }
+  if (!['http:', 'https:'].includes(primary.protocol)
+      || primary.username || primary.password
+      || primary.pathname !== '/' || primary.search || primary.hash) {
+    throw new Error('BRAINSTORM_PUBLIC_ORIGIN must be an HTTP(S) origin without a path');
+  }
+  if (!isLoopbackHost(host) && !isLoopbackHost(primary.hostname) && primary.protocol !== 'https:') {
+    throw new Error('A non-loopback public origin must use HTTPS through a trusted proxy or tunnel');
+  }
+
+  const allowedOrigins = new Set([primary.origin.toLowerCase()]);
+  if (!publicOrigin && (isLoopbackHost(host) || isLoopbackHost(urlHost))) {
+    allowedOrigins.add(`http://localhost:${port}`);
+    allowedOrigins.add(`http://127.0.0.1:${port}`);
+    allowedOrigins.add(`http://[::1]:${port}`);
+  }
+
+  return {
+    allowedHosts: new Set([...allowedOrigins].map(origin => new URL(origin).host.toLowerCase())),
+    allowedOrigins,
+    bootstrapUrl: `${primary.origin}/?token=${encodeURIComponent(sessionToken)}`,
+    cookieName: 'brainstorm_session_' + crypto.createHash('sha256').update(sessionToken).digest('hex').slice(0, 16),
+    cookieSecure: primary.protocol === 'https:',
+    primaryOrigin: primary.origin,
+    token: sessionToken,
+  };
+}
+
+const SECURITY = createSecurityContext({
+  host: HOST,
+  port: PORT,
+  publicOrigin: PUBLIC_ORIGIN,
+  sessionToken: SESSION_TOKEN,
+  urlHost: URL_HOST,
+});
+
+function safeTokenEqual(candidate, expected) {
+  if (typeof candidate !== 'string') return false;
+  const left = Buffer.from(candidate);
+  const right = Buffer.from(expected);
+  return left.length === right.length && crypto.timingSafeEqual(left, right);
+}
+
+function parseCookies(header = '') {
+  const cookies = new Map();
+  for (const pair of header.split(';')) {
+    const separator = pair.indexOf('=');
+    if (separator === -1) continue;
+    const name = pair.slice(0, separator).trim();
+    const value = pair.slice(separator + 1).trim();
+    if (name) cookies.set(name, value);
+  }
+  return cookies;
+}
+
+function hasCapability(req, security) {
+  return safeTokenEqual(parseCookies(req.headers.cookie).get(security.cookieName), security.token);
+}
+
+function hasExpectedHost(req, security) {
+  const host = String(req.headers.host || '').toLowerCase();
+  return security.allowedHosts.has(host);
+}
+
+function validateWebSocketRequest(req, security = SECURITY) {
+  if (!hasExpectedHost(req, security)) return { ok: false, status: 403, reason: 'Unexpected Host' };
+  const origin = String(req.headers.origin || '').toLowerCase();
+  if (!security.allowedOrigins.has(origin)) return { ok: false, status: 403, reason: 'Unexpected Origin' };
+  if (!hasCapability(req, security)) return { ok: false, status: 401, reason: 'Missing capability' };
+  let requestUrl;
+  try {
+    requestUrl = new URL(req.url, 'http://request.invalid');
+  } catch {
+    return { ok: false, status: 400, reason: 'Invalid WebSocket path' };
+  }
+  if (requestUrl.pathname !== '/' || requestUrl.search) {
+    return { ok: false, status: 400, reason: 'Invalid WebSocket path' };
+  }
+  if (req.method !== 'GET'
+      || String(req.headers.upgrade || '').toLowerCase() !== 'websocket'
+      || !String(req.headers.connection || '').toLowerCase().split(/\s*,\s*/).includes('upgrade')
+      || req.headers['sec-websocket-version'] !== '13') {
+    return { ok: false, status: 400, reason: 'Invalid WebSocket handshake' };
+  }
+  const key = req.headers['sec-websocket-key'];
+  if (typeof key !== 'string' || Buffer.from(key, 'base64').length !== 16) {
+    return { ok: false, status: 400, reason: 'Invalid WebSocket key' };
+  }
+  return { ok: true };
+}
 
 // ========== Templates and Constants ==========
 
@@ -122,18 +258,86 @@ function getNewestScreen() {
   const files = fs.readdirSync(CONTENT_DIR)
     .filter(f => f.endsWith('.html'))
     .map(f => {
-      const fp = path.join(CONTENT_DIR, f);
-      return { path: fp, mtime: fs.statSync(fp).mtime.getTime() };
+      const filePath = resolveContentPath('/files/' + encodeURIComponent(f), CONTENT_DIR);
+      return filePath ? { path: filePath, mtime: fs.statSync(filePath).mtime.getTime() } : null;
     })
+    .filter(Boolean)
     .sort((a, b) => b.mtime - a.mtime);
   return files.length > 0 ? files[0].path : null;
+}
+
+function resolveContentPath(requestPathname, contentDir = CONTENT_DIR) {
+  if (!requestPathname.startsWith('/files/')) return null;
+  let fileName;
+  try {
+    fileName = decodeURIComponent(requestPathname.slice('/files/'.length));
+  } catch {
+    return null;
+  }
+  if (!fileName || fileName === '.' || fileName === '..'
+      || fileName.includes('/') || fileName.includes('\\')
+      || path.basename(fileName) !== fileName) {
+    return null;
+  }
+
+  try {
+    const root = fs.realpathSync(contentDir);
+    const candidate = fs.realpathSync(path.join(root, fileName));
+    if (!candidate.startsWith(root + path.sep) || !fs.statSync(candidate).isFile()) return null;
+    return candidate;
+  } catch {
+    return null;
+  }
+}
+
+function writeResponse(res, status, body, headers = {}) {
+  res.writeHead(status, {
+    'Cache-Control': 'no-store',
+    'Referrer-Policy': 'no-referrer',
+    'X-Content-Type-Options': 'nosniff',
+    ...headers,
+  });
+  res.end(body);
 }
 
 // ========== HTTP Request Handler ==========
 
 function handleRequest(req, res) {
+  let requestUrl;
+  try {
+    requestUrl = new URL(req.url, 'http://request.invalid');
+  } catch {
+    writeResponse(res, 400, 'Bad request');
+    return;
+  }
+
+  if (!hasExpectedHost(req, SECURITY)) {
+    writeResponse(res, 421, 'Unexpected Host');
+    return;
+  }
+  if (req.method !== 'GET') {
+    writeResponse(res, 405, 'Method not allowed', { Allow: 'GET' });
+    return;
+  }
+
+  const bootstrapToken = requestUrl.pathname === '/' ? requestUrl.searchParams.get('token') : null;
+  if (bootstrapToken !== null) {
+    if (!safeTokenEqual(bootstrapToken, SECURITY.token)) {
+      writeResponse(res, 401, 'Invalid capability');
+      return;
+    }
+    const cookie = `${SECURITY.cookieName}=${SECURITY.token}; HttpOnly; SameSite=Strict; Path=/`
+      + (SECURITY.cookieSecure ? '; Secure' : '');
+    writeResponse(res, 303, '', { Location: '/', 'Set-Cookie': cookie });
+    return;
+  }
+  if (!hasCapability(req, SECURITY)) {
+    writeResponse(res, 401, 'Missing capability');
+    return;
+  }
+
   touchActivity();
-  if (req.method === 'GET' && req.url === '/') {
+  if (requestUrl.pathname === '/') {
     const screenFile = getNewestScreen();
     let html = screenFile
       ? (raw => isFullDocument(raw) ? raw : wrapInFrame(raw))(fs.readFileSync(screenFile, 'utf-8'))
@@ -145,23 +349,15 @@ function handleRequest(req, res) {
       html += helperInjection;
     }
 
-    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-    res.end(html);
-  } else if (req.method === 'GET' && req.url.startsWith('/files/')) {
-    const fileName = req.url.slice(7);
-    const filePath = path.join(CONTENT_DIR, path.basename(fileName));
-    if (!fs.existsSync(filePath)) {
-      res.writeHead(404);
-      res.end('Not found');
-      return;
-    }
+    writeResponse(res, 200, html, { 'Content-Type': 'text/html; charset=utf-8' });
+  } else if (requestUrl.pathname.startsWith('/files/')) {
+    const filePath = resolveContentPath(requestUrl.pathname);
+    if (!filePath) return writeResponse(res, 404, 'Not found');
     const ext = path.extname(filePath).toLowerCase();
     const contentType = MIME_TYPES[ext] || 'application/octet-stream';
-    res.writeHead(200, { 'Content-Type': contentType });
-    res.end(fs.readFileSync(filePath));
+    writeResponse(res, 200, fs.readFileSync(filePath), { 'Content-Type': contentType });
   } else {
-    res.writeHead(404);
-    res.end('Not found');
+    writeResponse(res, 404, 'Not found');
   }
 }
 
@@ -169,11 +365,31 @@ function handleRequest(req, res) {
 
 const clients = new Set();
 
-function handleUpgrade(req, socket) {
-  const key = req.headers['sec-websocket-key'];
-  if (!key) { socket.destroy(); return; }
+function rejectUpgrade(socket, status, reason) {
+  const labels = { 400: 'Bad Request', 401: 'Unauthorized', 403: 'Forbidden' };
+  socket.end(
+    `HTTP/1.1 ${status} ${labels[status] || 'Rejected'}\r\n`
+    + 'Connection: close\r\n'
+    + 'Content-Type: text/plain; charset=utf-8\r\n'
+    + `Content-Length: ${Buffer.byteLength(reason)}\r\n\r\n${reason}`
+  );
+}
 
-  const accept = computeAcceptKey(key);
+function closeConnection(socket, code) {
+  const payload = Buffer.alloc(2);
+  payload.writeUInt16BE(code);
+  socket.end(encodeFrame(OPCODES.CLOSE, payload));
+  clients.delete(socket);
+}
+
+function handleUpgrade(req, socket, head = Buffer.alloc(0)) {
+  const validation = validateWebSocketRequest(req);
+  if (!validation.ok) {
+    rejectUpgrade(socket, validation.status, validation.reason);
+    return;
+  }
+
+  const accept = computeAcceptKey(req.headers['sec-websocket-key']);
   socket.write(
     'HTTP/1.1 101 Switching Protocols\r\n' +
     'Upgrade: websocket\r\n' +
@@ -182,29 +398,40 @@ function handleUpgrade(req, socket) {
   );
 
   let buffer = Buffer.alloc(0);
+  const connectionState = { eventTimes: [] };
   clients.add(socket);
 
-  socket.on('data', (chunk) => {
+  function processChunk(chunk) {
     buffer = Buffer.concat([buffer, chunk]);
+    if (buffer.length > MAX_FRAME_BYTES + 14) {
+      closeConnection(socket, 1009);
+      return;
+    }
     while (buffer.length > 0) {
       let result;
       try {
         result = decodeFrame(buffer);
-      } catch (e) {
-        socket.end(encodeFrame(OPCODES.CLOSE, Buffer.alloc(0)));
-        clients.delete(socket);
+      } catch {
+        closeConnection(socket, 1002);
         return;
       }
       if (!result) break;
       buffer = buffer.slice(result.bytesConsumed);
 
       switch (result.opcode) {
-        case OPCODES.TEXT:
-          handleMessage(result.payload.toString());
+        case OPCODES.TEXT: {
+          try {
+            const text = new TextDecoder('utf-8', { fatal: true }).decode(result.payload);
+            handleMessage(text, connectionState);
+          } catch {
+            console.error(JSON.stringify({ type: 'user-event-rejected' }));
+            closeConnection(socket, 1008);
+            return;
+          }
           break;
+        }
         case OPCODES.CLOSE:
-          socket.end(encodeFrame(OPCODES.CLOSE, Buffer.alloc(0)));
-          clients.delete(socket);
+          closeConnection(socket, 1000);
           return;
         case OPCODES.PING:
           socket.write(encodeFrame(OPCODES.PONG, result.payload));
@@ -220,26 +447,82 @@ function handleUpgrade(req, socket) {
         }
       }
     }
-  });
+  }
+
+  socket.on('data', processChunk);
+  if (head.length > 0) processChunk(head);
 
   socket.on('close', () => clients.delete(socket));
   socket.on('error', () => clients.delete(socket));
 }
 
-function handleMessage(text) {
+function boundedString(value, field, maximum, { nullable = false } = {}) {
+  if (nullable && value === null) return null;
+  if (typeof value !== 'string' || value.length === 0 || [...value].length > maximum) {
+    throw new Error(`Invalid ${field}`);
+  }
+  if (/[\u0000-\u001f\u007f]/u.test(value)) throw new Error(`Invalid ${field}`);
+  return value;
+}
+
+function normalizeEvent(text, timestamp = Date.now()) {
+  if (typeof text !== 'string' || Buffer.byteLength(text, 'utf8') > MAX_MESSAGE_BYTES) {
+    throw new Error('Event exceeds maximum size');
+  }
   let event;
   try {
     event = JSON.parse(text);
-  } catch (e) {
-    console.error('Failed to parse WebSocket message:', e.message);
-    return;
+  } catch {
+    throw new Error('Invalid event JSON');
   }
+  if (!event || typeof event !== 'object' || Array.isArray(event)) {
+    throw new Error('Invalid event object');
+  }
+  const allowedFields = new Set(['type', 'choice', 'value', 'text', 'id', 'timestamp']);
+  for (const field of Object.keys(event)) {
+    if (!allowedFields.has(field)) throw new Error(`Unsupported event field: ${field}`);
+  }
+  if (event.type !== 'click' && event.type !== 'choice') {
+    throw new Error('Unsupported event type');
+  }
+  if (event.timestamp !== undefined
+      && (!Number.isSafeInteger(event.timestamp) || event.timestamp < 0)) {
+    throw new Error('Invalid timestamp');
+  }
+  if (event.type === 'click' && event.value !== undefined) {
+    throw new Error('Unsupported event field: value');
+  }
+  if (event.choice !== undefined && event.value !== undefined) {
+    throw new Error('Provide one choice value');
+  }
+
+  const normalized = {
+    type: event.type,
+    choice: boundedString(event.choice ?? event.value, 'choice', 128),
+  };
+  if (event.text !== undefined) normalized.text = boundedString(event.text, 'text', 512);
+  if (event.id !== undefined) normalized.id = boundedString(event.id, 'id', 128, { nullable: true });
+  normalized.timestamp = timestamp;
+  return normalized;
+}
+
+function consumeEventAllowance(state, now = Date.now()) {
+  const cutoff = now - EVENT_WINDOW_MS;
+  state.eventTimes = state.eventTimes.filter(time => time >= cutoff);
+  if (state.eventTimes.length >= MAX_EVENTS_PER_WINDOW) return false;
+  state.eventTimes.push(now);
+  return true;
+}
+
+function handleMessage(text, connectionState) {
+  if (!consumeEventAllowance(connectionState)) {
+    throw new Error('Event rate limit exceeded');
+  }
+  const event = normalizeEvent(text);
   touchActivity();
   console.log(JSON.stringify({ source: 'user-event', ...event }));
-  if (event.choice) {
-    const eventsFile = path.join(STATE_DIR, 'events');
-    fs.appendFileSync(eventsFile, JSON.stringify(event) + '\n');
-  }
+  const eventsFile = path.join(STATE_DIR, 'events');
+  fs.appendFileSync(eventsFile, JSON.stringify(event) + '\n', { encoding: 'utf8', mode: 0o600 });
 }
 
 function broadcast(msg) {
@@ -265,8 +548,11 @@ const debounceTimers = new Map();
 // ========== Server Startup ==========
 
 function startServer() {
-  if (!fs.existsSync(CONTENT_DIR)) fs.mkdirSync(CONTENT_DIR, { recursive: true });
-  if (!fs.existsSync(STATE_DIR)) fs.mkdirSync(STATE_DIR, { recursive: true });
+  if (!fs.existsSync(CONTENT_DIR)) fs.mkdirSync(CONTENT_DIR, { recursive: true, mode: 0o700 });
+  if (!fs.existsSync(STATE_DIR)) fs.mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 });
+  fs.chmodSync(SESSION_DIR, 0o700);
+  fs.chmodSync(CONTENT_DIR, 0o700);
+  fs.chmodSync(STATE_DIR, 0o700);
 
   // Track known files to distinguish new screens from updates.
   // macOS fs.watch reports 'rename' for both new files and overwrites,
@@ -309,7 +595,8 @@ function startServer() {
     if (fs.existsSync(infoFile)) fs.unlinkSync(infoFile);
     fs.writeFileSync(
       path.join(STATE_DIR, 'server-stopped'),
-      JSON.stringify({ reason, timestamp: Date.now() }) + '\n'
+      JSON.stringify({ reason, timestamp: Date.now() }) + '\n',
+      { encoding: 'utf8', mode: 0o600 }
     );
     watcher.close();
     clearInterval(lifecycleCheck);
@@ -342,13 +629,19 @@ function startServer() {
   }
 
   server.listen(PORT, HOST, () => {
+    if (!isLoopbackHost(HOST)) {
+      console.error(JSON.stringify({
+        type: 'security-warning',
+        message: 'NON-LOOPBACK BINDING: use TLS and access control through a trusted proxy or tunnel',
+      }));
+    }
     const info = JSON.stringify({
       type: 'server-started', port: Number(PORT), host: HOST,
-      url_host: URL_HOST, url: 'http://' + URL_HOST + ':' + PORT,
+      url_host: URL_HOST, origin: SECURITY.primaryOrigin, url: SECURITY.bootstrapUrl,
       screen_dir: CONTENT_DIR, state_dir: STATE_DIR
     });
     console.log(info);
-    fs.writeFileSync(path.join(STATE_DIR, 'server-info'), info + '\n');
+    fs.writeFileSync(path.join(STATE_DIR, 'server-info'), info + '\n', { encoding: 'utf8', mode: 0o600 });
   });
 }
 
@@ -356,4 +649,15 @@ if (require.main === module) {
   startServer();
 }
 
-module.exports = { computeAcceptKey, encodeFrame, decodeFrame, OPCODES };
+module.exports = {
+  OPCODES,
+  computeAcceptKey,
+  consumeEventAllowance,
+  createSecurityContext,
+  decodeFrame,
+  encodeFrame,
+  handleRequest,
+  normalizeEvent,
+  resolveContentPath,
+  validateWebSocketRequest,
+};

--- a/superjawn/skills/brainstorming/scripts/start-server.sh
+++ b/superjawn/skills/brainstorming/scripts/start-server.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Start the brainstorm server and output connection info
-# Usage: start-server.sh [--project-dir <path>] [--host <bind-host>] [--url-host <display-host>] [--foreground] [--background]
+# Usage: start-server.sh [--project-dir <path>] [--host <bind-host>] [--url-host <display-host>] [--public-origin <origin>] [--foreground] [--background]
 #
 # Starts server on a random high port, outputs JSON with URL.
 # Each session gets its own directory to avoid conflicts.
@@ -11,9 +11,11 @@
 #   --host <bind-host>    Host/interface to bind (default: 127.0.0.1).
 #                         Use 0.0.0.0 in remote/containerized environments.
 #   --url-host <host>     Hostname shown in returned URL JSON.
+#   --public-origin <url> Exact HTTPS origin used through a trusted proxy/tunnel.
 #   --foreground          Run server in the current terminal (no backgrounding).
 #   --background          Force background mode (overrides Codex auto-foreground).
 
+umask 077
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Parse arguments
@@ -22,6 +24,7 @@ FOREGROUND="false"
 FORCE_BACKGROUND="false"
 BIND_HOST="127.0.0.1"
 URL_HOST=""
+PUBLIC_ORIGIN=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --project-dir)
@@ -34,6 +37,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --url-host)
       URL_HOST="$2"
+      shift 2
+      ;;
+    --public-origin)
+      PUBLIC_ORIGIN="$2"
       shift 2
       ;;
     --foreground|--no-daemon)
@@ -58,6 +65,15 @@ if [[ -z "$URL_HOST" ]]; then
     URL_HOST="$BIND_HOST"
   fi
 fi
+
+case "$BIND_HOST" in
+  127.0.0.1|localhost|::1) ;;
+  *)
+    printf '%s\n' \
+      'SECURITY WARNING: non-loopback binding exposes the companion server.' \
+      'Use TLS (wss://) and access control through a trusted proxy or authenticated tunnel.' >&2
+    ;;
+esac
 
 # Some environments reap detached/background processes. Auto-foreground when detected.
 if [[ -n "${CODEX_CI:-}" && "$FOREGROUND" != "true" && "$FORCE_BACKGROUND" != "true" ]]; then
@@ -112,12 +128,12 @@ fi
 # already written to PID_FILE refers to the actual server process.
 if [[ "$FOREGROUND" == "true" ]]; then
   echo "$$" > "$PID_FILE"
-  exec env BRAINSTORM_DIR="$SESSION_DIR" BRAINSTORM_HOST="$BIND_HOST" BRAINSTORM_URL_HOST="$URL_HOST" BRAINSTORM_OWNER_PID="$OWNER_PID" node server.cjs
+  exec env BRAINSTORM_DIR="$SESSION_DIR" BRAINSTORM_HOST="$BIND_HOST" BRAINSTORM_URL_HOST="$URL_HOST" BRAINSTORM_PUBLIC_ORIGIN="$PUBLIC_ORIGIN" BRAINSTORM_OWNER_PID="$OWNER_PID" node server.cjs
 fi
 
 # Start server, capturing output to log file
 # Use nohup to survive shell exit; disown to remove from job table
-nohup env BRAINSTORM_DIR="$SESSION_DIR" BRAINSTORM_HOST="$BIND_HOST" BRAINSTORM_URL_HOST="$URL_HOST" BRAINSTORM_OWNER_PID="$OWNER_PID" node server.cjs > "$LOG_FILE" 2>&1 &
+nohup env BRAINSTORM_DIR="$SESSION_DIR" BRAINSTORM_HOST="$BIND_HOST" BRAINSTORM_URL_HOST="$URL_HOST" BRAINSTORM_PUBLIC_ORIGIN="$PUBLIC_ORIGIN" BRAINSTORM_OWNER_PID="$OWNER_PID" node server.cjs > "$LOG_FILE" 2>&1 &
 SERVER_PID=$!
 disown "$SERVER_PID" 2>/dev/null
 echo "$SERVER_PID" > "$PID_FILE"
@@ -135,7 +151,7 @@ for i in {1..50}; do
       sleep 0.1
     done
     if [[ "$alive" != "true" ]]; then
-      echo "{\"error\": \"Server started but was killed. Retry in a persistent terminal with: $SCRIPT_DIR/start-server.sh${PROJECT_DIR:+ --project-dir $PROJECT_DIR} --host $BIND_HOST --url-host $URL_HOST --foreground\"}"
+      echo "{\"error\": \"Server started but was killed. Retry in a persistent terminal with: $SCRIPT_DIR/start-server.sh${PROJECT_DIR:+ --project-dir $PROJECT_DIR} --host $BIND_HOST --url-host $URL_HOST${PUBLIC_ORIGIN:+ --public-origin $PUBLIC_ORIGIN} --foreground\"}"
       exit 1
     fi
     grep "server-started" "$LOG_FILE" | head -1

--- a/superjawn/skills/brainstorming/visual-companion.md
+++ b/superjawn/skills/brainstorming/visual-companion.md
@@ -28,6 +28,8 @@ A question *about* a UI topic is not automatically a visual question. "What kind
 
 The server watches a directory for HTML files and serves the newest one to the browser. You write HTML content to `screen_dir`, the user sees it in their browser and can click to select options. Selections are recorded to `state_dir/events` that you read on your next turn.
 
+Each server process generates a high-entropy capability URL. The first authorized request exchanges that token for an HttpOnly, SameSite cookie and redirects to a clean URL; HTTP files and the WebSocket both require the cookie. Keep the startup URL and `state_dir/server-info` private. The server also checks the exact HTTP Host and WebSocket Origin, accepts only bounded `click`/`choice` events, and assigns persisted timestamps itself.
+
 **Content fragments vs full documents:** If your HTML file starts with `<!DOCTYPE` or `<html`, the server serves it as-is (just injects the helper script). Otherwise, the server automatically wraps your content in the frame template — adding the header, CSS theme, selection indicator, and all interactive infrastructure. **Write content fragments by default.** Only write full documents when you need complete control over the page.
 
 ## Starting a Session
@@ -36,12 +38,13 @@ The server watches a directory for HTML files and serves the newest one to the b
 # Start server with persistence (mockups saved to project)
 scripts/start-server.sh --project-dir /path/to/project
 
-# Returns: {"type":"server-started","port":52341,"url":"http://localhost:52341",
+# Returns: {"type":"server-started","port":52341,
+#           "url":"http://localhost:52341/?token=<session-capability>",
 #           "screen_dir":"/path/to/project/.superpowers/brainstorm/12345-1706000000/content",
 #           "state_dir":"/path/to/project/.superpowers/brainstorm/12345-1706000000/state"}
 ```
 
-Save `screen_dir` and `state_dir` from the response. Tell user to open the URL.
+Save `screen_dir` and `state_dir` from the response. Tell the user to open the full capability URL, but do not paste it into public logs, issues, or chat rooms.
 
 **Finding connection info:** The server writes its startup JSON to `$STATE_DIR/server-info`. If you launched the server in the background and didn't capture stdout, read that file to get the URL and port. When using `--project-dir`, check `<project>/.superpowers/brainstorm/` for the session directory.
 
@@ -80,16 +83,18 @@ scripts/start-server.sh --project-dir /path/to/project --foreground
 
 **Other environments:** The server must keep running in the background across conversation turns. If your environment reaps detached processes, use `--foreground` and launch the command with your platform's background execution mechanism.
 
-If the URL is unreachable from your browser (common in remote/containerized setups), bind a non-loopback host:
+If the URL is unreachable from your browser (common in remote/containerized setups), prefer an SSH tunnel or a container port published only to the local loopback interface. Those approaches let the server keep its default `127.0.0.1` binding.
+
+Binding a non-loopback interface is an explicit exposure decision. Remote exposure requires TLS (so the browser uses `wss://`) and access control through a trusted reverse proxy or authenticated tunnel. Set the exact public HTTPS origin so Host/Origin validation remains effective:
 
 ```bash
 scripts/start-server.sh \
   --project-dir /path/to/project \
   --host 0.0.0.0 \
-  --url-host localhost
+  --public-origin https://brainstorm.example.com
 ```
 
-Use `--url-host` to control what hostname is printed in the returned URL JSON.
+Never expose the raw HTTP port directly to a LAN or the internet. The startup script prints a prominent security warning for every non-loopback binding, and the server refuses a plaintext non-loopback public origin. `--url-host` remains available for local port-forwarding setups; `--public-origin` is the authoritative origin when TLS terminates at a trusted proxy.
 
 ## The Loop
 
@@ -248,10 +253,12 @@ The frame template provides these CSS classes for your content:
 When the user clicks options in the browser, their interactions are recorded to `$STATE_DIR/events` (one JSON object per line). The file is cleared automatically when you push a new screen.
 
 ```jsonl
-{"type":"click","choice":"a","text":"Option A - Simple Layout","timestamp":1706000101}
-{"type":"click","choice":"c","text":"Option C - Complex Grid","timestamp":1706000108}
-{"type":"click","choice":"b","text":"Option B - Hybrid","timestamp":1706000115}
+{"type":"click","choice":"a","text":"Option A - Simple Layout","timestamp":1706000101000}
+{"type":"click","choice":"c","text":"Option C - Complex Grid","timestamp":1706000108000}
+{"type":"click","choice":"b","text":"Option B - Hybrid","timestamp":1706000115000}
 ```
+
+Only `type`, `choice`, optional `text`, optional `id`, and the server-assigned `timestamp` are persisted. Unknown event types or fields, control characters, oversized values, malformed frames, and over-rate clients are rejected. Browser clients cannot send reload/control messages; reload is emitted only by the server's file watcher.
 
 The full event stream shows the user's exploration path — they may click multiple options before settling. The last `choice` event is typically the final selection, but the pattern of clicks can reveal hesitation or preferences worth asking about.
 


### PR DESCRIPTION
## Summary

- gate every HTTP and WebSocket request behind a per-process capability, exchanged for a unique HttpOnly/SameSite session cookie
- validate exact Host and WebSocket Origin values to block DNS-rebinding and hostile local-page connections
- enforce bounded, unfragmented frames; a strict `click`/`choice` schema; server-assigned timestamps; field allowlisting; and per-connection rate limits
- drain coalesced valid frames before per-frame enforcement while capping a complete burst at 30 maximum-size frames
- keep the reconnect queue within the server's 30-event window so the newest selections are retained
- canonicalize served paths and reject traversal and symlink escapes
- keep all of 127/8 and IPv6 `::1` as loopback; warn on other bindings, refuse plaintext non-loopback public origins, and document TLS/`wss://`
- accept reload control messages only from the server-side file watcher

## Verification

- `node --test scripts/brainstorming-companion-security.test.mjs`: 9/9 passing
- `npm test`: 12/12 passing
- `npm audit --audit-level=high`: 0 vulnerabilities
- `node --check` for `server.cjs` and `helper.js`
- live smoke: unauthenticated HTTP `401`, capability bootstrap + clean redirect, authorized HTTP `200`, cross-origin WebSocket `403`
- all connector review conversations resolved after verified pushes
- `git diff --check`

Closes #195