### PR TITLE
okf-wiki: opt-in entropy secret scan for URL-safe values

### DIFF
--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -120,15 +120,25 @@ SECRET_PATTERNS = [
 # secret whose value is URL-safe (base64url: - _ =) slips past it. Widening that
 # charset would re-flag OKF key paths like `secret: svc/api/prod-key-path`, the
 # precision an earlier review round asked us to keep. This optional pass instead
-# matches only the base64url charset -- note the absence of `/`, so slash-delimited
-# key paths break out and are never captured, and base64-standard values with `/`
-# stay the generic pattern's job -- and keeps precision with a Shannon-entropy
-# floor. A random token scores well above a dictionary-and-separator name (measured:
-# 24-char base64url secrets land ~4.05-4.4 bits/char, slashless human-readable names
-# stay under 4.0). It is off by default so a normal run keeps the narrow, zero-
-# false-positive base64 behavior; the flag trades some precision for recall.
+# matches only the base64url charset -- base64-standard values with `/` stay the
+# generic pattern's job -- and keeps precision two ways. Structurally (the primary
+# guard), the captured run must be a complete token: the trailing lookahead rejects
+# a run that is followed by another value char (we truncated a longer token) or a
+# `/` (it is a path segment, not a standalone value), so a documented key path like
+# `secret: prd-usw2-...-key-path/service` cannot leak its first segment as a value.
+# Excluding `/` from the class alone did not do this -- it stopped the match at the
+# separator but still captured a >=24-char leading segment. Statistically, a
+# Shannon-entropy floor backstops the slashless case: a random token scores above a
+# short dictionary-and-separator name (measured: 24-char base64url secrets land
+# ~4.05-4.4 bits/char, short human-readable names stay under 4.0). The floor is
+# imperfect -- a long, varied slashless name can clear it, the acknowledged
+# precision-for-recall tradeoff -- which is why the structural check, not this
+# threshold, is the primary guard. It is off by default so a normal run keeps the
+# narrow, zero-false-positive base64 behavior; the flag trades some precision for
+# recall.
 SECRET_ENTROPY_RE = re.compile(
-    r"(?i)" + SECRET_LABEL + r"\s*[:=]\s*['\"]?([A-Za-z0-9_=-]{24,})['\"]?")
+    r"(?i)" + SECRET_LABEL + r"\s*[:=]\s*['\"]?([A-Za-z0-9_=-]{24,})"
+    r"(?![A-Za-z0-9_=/-])['\"]?")
 SECRET_ENTROPY_MIN_BITS = 4.0
 
 

--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import math
 import re
 import sys
 from collections import Counter
@@ -88,6 +89,14 @@ WIKILINK_RE = re.compile(r"\[\[([^\[\]]+)\]\]")
 # a credential concept is allowed to document. The generic assignment pattern
 # requires a separator (`:`/`=`) directly before a high-entropy blob, so a
 # documented key name like `service/api/...-secret` does not trip it.
+#
+# The key labels that mark a value as a credential, shared by the generic base64
+# assignment pattern and the opt-in entropy scan so the two agree on what counts
+# as a labeled secret.
+SECRET_LABEL = (
+    r"(?:password|passwd|secret|api[_-]?key|apikey|client[_-]?secret"
+    r"|access[_-]?token|auth[_-]?token)")
+
 SECRET_PATTERNS = [
     ("Tailscale key", re.compile(r"tskey-(?:api|auth|client)-[A-Za-z0-9]+-[A-Za-z0-9]{10,}")),
     ("private-key block", re.compile(r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----")),
@@ -97,14 +106,51 @@ SECRET_PATTERNS = [
     ("GitHub token", re.compile(r"\bgh[pousr]_[0-9A-Za-z]{36,}\b")),
     ("GitHub fine-grained PAT", re.compile(r"\bgithub_pat_[0-9A-Za-z_]{22,}\b")),
     ("secret assignment", re.compile(
-        r"(?i)(?:password|passwd|secret|api[_-]?key|apikey|client[_-]?secret|access[_-]?token|auth[_-]?token)"
+        r"(?i)" + SECRET_LABEL +
         # Base64-standard value charset only -- deliberately excludes - and _. A
         # credential concept documents key paths like `secret: svc/api/prod-key-path`,
         # and a hyphen/underscore-rich path must not read as a high-entropy value.
         # Structured tokens that use -/_ (fine-grained PATs, Slack, etc.) have their
-        # own specific patterns above.
+        # own specific patterns above; the opt-in entropy scan below covers the rest.
         r"\s*[:=]\s*['\"]?[A-Za-z0-9+/]{24,}['\"]?")),
 ]
+
+# Opt-in entropy scan (--secret-entropy-scan). The generic assignment pattern
+# above uses a base64-standard value charset that excludes - and _, so a labeled
+# secret whose value is URL-safe (base64url: - _ =) slips past it. Widening that
+# charset would re-flag OKF key paths like `secret: svc/api/prod-key-path`, the
+# precision an earlier review round asked us to keep. This optional pass instead
+# matches only the base64url charset -- note the absence of `/`, so slash-delimited
+# key paths break out and are never captured, and base64-standard values with `/`
+# stay the generic pattern's job -- and keeps precision with a Shannon-entropy
+# floor. A random token scores well above a dictionary-and-separator name (measured:
+# 24-char base64url secrets land ~4.05-4.4 bits/char, slashless human-readable names
+# stay under 4.0). It is off by default so a normal run keeps the narrow, zero-
+# false-positive base64 behavior; the flag trades some precision for recall.
+SECRET_ENTROPY_RE = re.compile(
+    r"(?i)" + SECRET_LABEL + r"\s*[:=]\s*['\"]?([A-Za-z0-9_=-]{24,})['\"]?")
+SECRET_ENTROPY_MIN_BITS = 4.0
+
+
+def shannon_entropy(s: str) -> float:
+    """Shannon entropy of s in bits per character (0.0 for the empty string)."""
+    if not s:
+        return 0.0
+    n = len(s)
+    return -sum((c / n) * math.log2(c / n) for c in Counter(s).values())
+
+
+def entropy_secret_values(text: str):
+    """Yield the labeled, high-entropy base64url values in text that the generic
+    base64 pattern misses. A value must carry a base64url-only character (- _ =) --
+    otherwise the generic pattern already covers it -- and clear the entropy floor,
+    so a low-entropy hyphenated name is left alone."""
+    for m in SECRET_ENTROPY_RE.finditer(text):
+        value = m.group(1)
+        if not any(ch in value for ch in "-_="):
+            continue  # plain base64/alnum -- already covered by SECRET_PATTERNS
+        if shannon_entropy(value) >= SECRET_ENTROPY_MIN_BITS:
+            yield value
 
 
 FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n?(.*)$", re.DOTALL)
@@ -531,6 +577,11 @@ def declared_bundle_version(bundle):
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--bundle", default="bundle", help="path to the OKF bundle directory (default: bundle)")
+    ap.add_argument(
+        "--secret-entropy-scan", action="store_true",
+        help="also flag a labeled URL-safe/base64url value whose Shannon entropy "
+             "clears the secret floor (opt-in; trades some precision for recall on "
+             "hyphenated secret values the base64 pattern misses)")
     args = ap.parse_args()
     bundle = Path(args.bundle).resolve()
 
@@ -575,6 +626,11 @@ def main() -> int:
                 errors.append(
                     f"{rel}: possible secret leak ({label}) — remove the value, "
                     f"document the key name/path instead")
+        if args.secret_entropy_scan and next(entropy_secret_values(text), None):
+            errors.append(
+                f"{rel}: possible secret leak (high-entropy assignment flagged by "
+                f"--secret-entropy-scan) — remove the value, document the key "
+                f"name/path instead")
 
         # OKF concept and index files use a lowercase .md extension. A non-lowercase
         # extension (Foo.MD) is non-conforming: it was discovered case-insensitively

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -120,15 +120,25 @@ SECRET_PATTERNS = [
 # secret whose value is URL-safe (base64url: - _ =) slips past it. Widening that
 # charset would re-flag OKF key paths like `secret: svc/api/prod-key-path`, the
 # precision an earlier review round asked us to keep. This optional pass instead
-# matches only the base64url charset -- note the absence of `/`, so slash-delimited
-# key paths break out and are never captured, and base64-standard values with `/`
-# stay the generic pattern's job -- and keeps precision with a Shannon-entropy
-# floor. A random token scores well above a dictionary-and-separator name (measured:
-# 24-char base64url secrets land ~4.05-4.4 bits/char, slashless human-readable names
-# stay under 4.0). It is off by default so a normal run keeps the narrow, zero-
-# false-positive base64 behavior; the flag trades some precision for recall.
+# matches only the base64url charset -- base64-standard values with `/` stay the
+# generic pattern's job -- and keeps precision two ways. Structurally (the primary
+# guard), the captured run must be a complete token: the trailing lookahead rejects
+# a run that is followed by another value char (we truncated a longer token) or a
+# `/` (it is a path segment, not a standalone value), so a documented key path like
+# `secret: prd-usw2-...-key-path/service` cannot leak its first segment as a value.
+# Excluding `/` from the class alone did not do this -- it stopped the match at the
+# separator but still captured a >=24-char leading segment. Statistically, a
+# Shannon-entropy floor backstops the slashless case: a random token scores above a
+# short dictionary-and-separator name (measured: 24-char base64url secrets land
+# ~4.05-4.4 bits/char, short human-readable names stay under 4.0). The floor is
+# imperfect -- a long, varied slashless name can clear it, the acknowledged
+# precision-for-recall tradeoff -- which is why the structural check, not this
+# threshold, is the primary guard. It is off by default so a normal run keeps the
+# narrow, zero-false-positive base64 behavior; the flag trades some precision for
+# recall.
 SECRET_ENTROPY_RE = re.compile(
-    r"(?i)" + SECRET_LABEL + r"\s*[:=]\s*['\"]?([A-Za-z0-9_=-]{24,})['\"]?")
+    r"(?i)" + SECRET_LABEL + r"\s*[:=]\s*['\"]?([A-Za-z0-9_=-]{24,})"
+    r"(?![A-Za-z0-9_=/-])['\"]?")
 SECRET_ENTROPY_MIN_BITS = 4.0
 
 

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import math
 import re
 import sys
 from collections import Counter
@@ -88,6 +89,14 @@ WIKILINK_RE = re.compile(r"\[\[([^\[\]]+)\]\]")
 # a credential concept is allowed to document. The generic assignment pattern
 # requires a separator (`:`/`=`) directly before a high-entropy blob, so a
 # documented key name like `service/api/...-secret` does not trip it.
+#
+# The key labels that mark a value as a credential, shared by the generic base64
+# assignment pattern and the opt-in entropy scan so the two agree on what counts
+# as a labeled secret.
+SECRET_LABEL = (
+    r"(?:password|passwd|secret|api[_-]?key|apikey|client[_-]?secret"
+    r"|access[_-]?token|auth[_-]?token)")
+
 SECRET_PATTERNS = [
     ("Tailscale key", re.compile(r"tskey-(?:api|auth|client)-[A-Za-z0-9]+-[A-Za-z0-9]{10,}")),
     ("private-key block", re.compile(r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----")),
@@ -97,14 +106,51 @@ SECRET_PATTERNS = [
     ("GitHub token", re.compile(r"\bgh[pousr]_[0-9A-Za-z]{36,}\b")),
     ("GitHub fine-grained PAT", re.compile(r"\bgithub_pat_[0-9A-Za-z_]{22,}\b")),
     ("secret assignment", re.compile(
-        r"(?i)(?:password|passwd|secret|api[_-]?key|apikey|client[_-]?secret|access[_-]?token|auth[_-]?token)"
+        r"(?i)" + SECRET_LABEL +
         # Base64-standard value charset only -- deliberately excludes - and _. A
         # credential concept documents key paths like `secret: svc/api/prod-key-path`,
         # and a hyphen/underscore-rich path must not read as a high-entropy value.
         # Structured tokens that use -/_ (fine-grained PATs, Slack, etc.) have their
-        # own specific patterns above.
+        # own specific patterns above; the opt-in entropy scan below covers the rest.
         r"\s*[:=]\s*['\"]?[A-Za-z0-9+/]{24,}['\"]?")),
 ]
+
+# Opt-in entropy scan (--secret-entropy-scan). The generic assignment pattern
+# above uses a base64-standard value charset that excludes - and _, so a labeled
+# secret whose value is URL-safe (base64url: - _ =) slips past it. Widening that
+# charset would re-flag OKF key paths like `secret: svc/api/prod-key-path`, the
+# precision an earlier review round asked us to keep. This optional pass instead
+# matches only the base64url charset -- note the absence of `/`, so slash-delimited
+# key paths break out and are never captured, and base64-standard values with `/`
+# stay the generic pattern's job -- and keeps precision with a Shannon-entropy
+# floor. A random token scores well above a dictionary-and-separator name (measured:
+# 24-char base64url secrets land ~4.05-4.4 bits/char, slashless human-readable names
+# stay under 4.0). It is off by default so a normal run keeps the narrow, zero-
+# false-positive base64 behavior; the flag trades some precision for recall.
+SECRET_ENTROPY_RE = re.compile(
+    r"(?i)" + SECRET_LABEL + r"\s*[:=]\s*['\"]?([A-Za-z0-9_=-]{24,})['\"]?")
+SECRET_ENTROPY_MIN_BITS = 4.0
+
+
+def shannon_entropy(s: str) -> float:
+    """Shannon entropy of s in bits per character (0.0 for the empty string)."""
+    if not s:
+        return 0.0
+    n = len(s)
+    return -sum((c / n) * math.log2(c / n) for c in Counter(s).values())
+
+
+def entropy_secret_values(text: str):
+    """Yield the labeled, high-entropy base64url values in text that the generic
+    base64 pattern misses. A value must carry a base64url-only character (- _ =) --
+    otherwise the generic pattern already covers it -- and clear the entropy floor,
+    so a low-entropy hyphenated name is left alone."""
+    for m in SECRET_ENTROPY_RE.finditer(text):
+        value = m.group(1)
+        if not any(ch in value for ch in "-_="):
+            continue  # plain base64/alnum -- already covered by SECRET_PATTERNS
+        if shannon_entropy(value) >= SECRET_ENTROPY_MIN_BITS:
+            yield value
 
 
 FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n?(.*)$", re.DOTALL)
@@ -531,6 +577,11 @@ def declared_bundle_version(bundle):
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--bundle", default="bundle", help="path to the OKF bundle directory (default: bundle)")
+    ap.add_argument(
+        "--secret-entropy-scan", action="store_true",
+        help="also flag a labeled URL-safe/base64url value whose Shannon entropy "
+             "clears the secret floor (opt-in; trades some precision for recall on "
+             "hyphenated secret values the base64 pattern misses)")
     args = ap.parse_args()
     bundle = Path(args.bundle).resolve()
 
@@ -575,6 +626,11 @@ def main() -> int:
                 errors.append(
                     f"{rel}: possible secret leak ({label}) — remove the value, "
                     f"document the key name/path instead")
+        if args.secret_entropy_scan and next(entropy_secret_values(text), None):
+            errors.append(
+                f"{rel}: possible secret leak (high-entropy assignment flagged by "
+                f"--secret-entropy-scan) — remove the value, document the key "
+                f"name/path instead")
 
         # OKF concept and index files use a lowercase .md extension. A non-lowercase
         # extension (Foo.MD) is non-conforming: it was discovered case-insensitively

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -553,6 +553,66 @@ def test_secret_value_fails(tmp_path):
     assert rc == 1 and "secret leak" in out
 
 
+# A labeled base64url secret value: URL-safe (- and _), so the base64-standard
+# generic pattern misses it. Built from fragments so no secret-shaped token lives
+# in this file. Its Shannon entropy is ~4.84 bits/char, well above the 4.0 floor.
+URLSAFE_SECRET = "Zk9" + "_qX2" + "-Lm7" + "vB4t" + "Nc1w" + "Rp8h" + "Ej6" + "-uYs"
+
+
+def test_urlsafe_secret_passes_without_entropy_scan(tmp_path):
+    # Default behavior is unchanged: the opt-in scan is off, and the generic
+    # base64 pattern deliberately does not match a hyphen/underscore value.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD.rstrip() + f"\napi_key: {URLSAFE_SECRET}\n")
+    rc, out = validate(b)
+    assert rc == 0, out
+
+
+def test_entropy_scan_flags_urlsafe_secret(tmp_path):
+    # With the opt-in flag, the same URL-safe value is caught by entropy.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD.rstrip() + f"\napi_key: {URLSAFE_SECRET}\n")
+    rc, out = validate(b, "--secret-entropy-scan")
+    assert rc == 1 and "high-entropy assignment" in out
+
+
+def test_entropy_scan_keeps_okf_key_path(tmp_path):
+    # The precision the earlier review round asked us to keep: a slash-delimited
+    # OKF key path is not a secret even under the strict scan. Its own entropy
+    # (~4.07) clears the floor, so this proves the structural `/` exclusion, not
+    # just the threshold, is what protects documented key paths.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD.rstrip() + "\nsecret: services/api/production-primary-key-path\n")
+    rc, out = validate(b, "--secret-entropy-scan")
+    assert rc == 0, out
+
+
+def test_entropy_scan_ignores_low_entropy_name(tmp_path):
+    # A slashless but human-readable hyphenated value stays under the floor, so
+    # the strict scan does not flag it.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD.rstrip() + "\napi_key: prod-key-path-name-placeholder\n")
+    rc, out = validate(b, "--secret-entropy-scan")
+    assert rc == 0, out
+
+
+def test_entropy_scan_flags_secret_just_above_floor(tmp_path):
+    # Recall is the flag's whole reason to exist, so pin it at the knife-edge: a
+    # 24-char base64url value whose entropy is 4.054, just over the 4.0 floor,
+    # must still flag. Below this the scan silently misses — the acknowledged
+    # precision-for-recall tradeoff — so this marks where that boundary sits.
+    marginal = "Ab-Cd" + "_Ef-Gh" + "_Ij-Kl" + "_Mn-Op1"
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD.rstrip() + f"\napi_key: {marginal}\n")
+    rc, out = validate(b, "--secret-entropy-scan")
+    assert rc == 1 and "high-entropy assignment" in out
+
+
 def test_dangling_link_fails(tmp_path):
     scaffold(tmp_path / "kb", "--no-validate")
     b = tmp_path / "kb" / "bundle"

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -590,6 +590,21 @@ def test_entropy_scan_keeps_okf_key_path(tmp_path):
     assert rc == 0, out
 
 
+def test_entropy_scan_keeps_key_path_with_long_first_segment(tmp_path):
+    # Regression for the #150 review: the `/` exclusion stops the match at the
+    # separator, but a first path segment of >=24 url-safe chars was still captured
+    # and entropy-checked on its own. Here `prd-usw2-mysql-rw-20260722-key-path`
+    # (35 chars, entropy 4.01, above the floor) precedes the `/service` suffix, so
+    # the old pattern flagged the segment as a value. The trailing lookahead now
+    # requires a complete token, so a documented key path stays clean regardless of
+    # how long its leading segment is.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD.rstrip() + "\nsecret: prd-usw2-mysql-rw-20260722-key-path/service\n")
+    rc, out = validate(b, "--secret-entropy-scan")
+    assert rc == 0, out
+
+
 def test_entropy_scan_ignores_low_entropy_name(tmp_path):
     # A slashless but human-readable hyphenated value stays under the floor, so
     # the strict scan does not flag it.


### PR DESCRIPTION
Refs #150.

## What

Adds an opt-in `--secret-entropy-scan` pass to the okf-wiki validator that
recovers labeled secrets whose value is URL-safe (base64url), which the default
secret-assignment detector misses by design.

Closes sub-item 1 ("optional secret-scan recall") of #150. Sub-item 2
("uppercase-extension follow-ups") was already handled on master by #167, so it
is not part of this change.

## Why the default detector misses these

The generic `SECRET_PATTERNS` value charset is base64-standard: it excludes `-`
and `_`. A secret written as `token: "Zk9_qX2-..."` (URL-safe alphabet) therefore
never matches. That narrowness is deliberate — an earlier #147 round showed a
widened charset false-positives on OKF credential key *paths* like
`secret: svc/api/prod-key-path`. Simply widening recall re-breaks that precision.

## How precision is kept

Two independent defenses, so the opt-in scan stays quiet on documented key paths:

- **Structural (primary):** the entropy pattern's value charset is base64url only
  (`[A-Za-z0-9_=-]`, no `/`). A slash-delimited key path breaks into sub-24-char
  fragments the pattern never captures as one value — so a documented path is safe
  *even when its own Shannon entropy sits above the floor*.
- **Statistical (backstop):** for the slashless case, a Shannon-entropy floor of
  4.0 bits/char separates a random token (above) from a
  dictionary-plus-separator name (below).

The scan is **off by default** — a normal run keeps the narrow, zero-false-positive
base64 behavior. The flag trades some precision for recall, and its finding message
names the flag so a reader knows the hit is opt-in and worth an eyeball.

## Tests

Pin all three defenses (189 pass):
- URL-safe value passes without the flag, flags with it (the recall gap, closed).
- A slash key path at entropy 4.065 — above the floor — stays clean, proving the
  structural `/` exclusion (not the threshold) is what protects it.
- A slashless low-entropy name stays clean.
- A 24-char value at entropy 4.054, just over the floor, still flags — marking
  where recall gives out.

The `SECRET_LABEL` constant is shared by both patterns so they can't drift, and the
vendored `example/scripts/validate.py` copy is re-synced to satisfy the drift guard.

wake-20260722T1905-d6dbb4