### PR TITLE
Record journalism-core Claude and Codex runtime pilots

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "canary:journalism-core:codex": "node scripts/journalism-core-install-canary.mjs codex",
     "canary:journalism-core:codex-skills": "node scripts/journalism-core-install-canary.mjs codex-skills",
     "canary:journalism-core:codex-skills-global": "node scripts/journalism-core-install-canary.mjs codex-skills-global",
+    "pilot:journalism-core": "node scripts/journalism-core-runtime-pilot.mjs",
     "a11y": "node scripts/verify_a11y.mjs",
     "build:docs-css": "node scripts/docs-tailwind.mjs --write",
     "check:docs-css": "node scripts/docs-tailwind.mjs --check"

--- a/plans/2026-07-23-journalism-core-runtime-pilot.md
+++ b/plans/2026-07-23-journalism-core-runtime-pilot.md
@@ -91,7 +91,7 @@ claims.
 
 ## Verification and cleanup
 
-The repeatable harness passed its five focused tests. The repository suite
-passed 119 of 119 tests, all 49 page-specific Tailwind stylesheets were current,
+The repeatable harness passed its six focused tests. The repository suite
+passed 120 of 120 tests, all 49 page-specific Tailwind stylesheets were current,
 and `git diff --check` passed. The disposable test root was removed after the
 final verification run.

--- a/plans/2026-07-23-journalism-core-runtime-pilot.md
+++ b/plans/2026-07-23-journalism-core-runtime-pilot.md
@@ -1,0 +1,97 @@
+# Journalism-core paired runtime pilot
+
+- Status: passed on the scoped Claude package and Codex project-standards paths
+- Evidence date: July 23, 2026
+- Tracking issue: [#227](https://github.com/jamditis/claude-skills-journalism/issues/227)
+- Source revision: [`9eef57629edbaa19bf47ec35296acebdd7b4ab1f`](https://github.com/jamditis/claude-skills-journalism/commit/9eef57629edbaa19bf47ec35296acebdd7b4ab1f)
+
+## Scope
+
+This pilot tested the same public `journalism-core` 1.2.0 source in:
+
+- Claude Code 2.1.218, installed as
+  `journalism-core@claude-skills-journalism` from a fresh public-repository
+  marketplace clone; and
+- Codex CLI 0.145.0, installed into a disposable project's
+  `.agents/skills` directory with skills CLI 1.5.20.
+
+The legacy-compatible Codex package path and the Codex user-level standards
+path retain install-canary evidence only. This pilot does not turn their
+installation results into runtime claims.
+
+## Isolation and installation
+
+The test root was `/tmp/jcore-runtime-pilots-20260723`. It contained separate
+Claude configuration and project directories plus separate Codex home and
+project directories. The clients reused authenticated command-line state
+through symlinks; no credential content was copied into the test root or
+repository. Claude sessions used `--no-session-persistence`. Codex sessions
+used `--ephemeral`, `--ignore-user-config`, and `--ignore-rules`.
+
+The Claude marketplace install exposed all 14 namespaced journalism-core slash
+commands. The Codex standards install copied the same 14 skills into
+`.agents/skills`. The source, Claude-installed, and Codex-installed copies of
+`photo-metadata/reference.md` had the same SHA-256 digest:
+
+```text
+0150c0db2b78ecc3c38a4d7fa585b3444c58cceb1b22dd55e21eb64f5d659d17
+```
+
+## Runtime results
+
+| Fixture | Claude Code 2.1.218 | Codex CLI 0.145.0 |
+|---|---|---|
+| J-core-1 explicit `fact-check-workflow` | `/journalism-core:fact-check-workflow` selected the installed command. The response separated the claim, provenance, primary evidence, corroboration, right of response, and uncertainty, and left the unsupported claim unverifiable. | `$fact-check-workflow` selected the installed skill. The response produced the same conservative verification stages and did not invent a source or verdict. |
+| J-core-2 implicit verification | The client invoked the `Skill` tool with `journalism-core:source-verification`, then returned a verification checklist with sourcing and uncertainty controls. | The client selected the fact-check and source-verification skills, read both installed `SKILL.md` files, and returned a conservative verification checklist. |
+| J-core-3 unrelated non-trigger | No `Skill` tool call occurred. Output: “42 × 0.18 = **$7.56**. Total with tip: **$49.56**.” | No skill-selection message or installed-skill read occurred. Output: “An 18% tip on $42 is **$7.56**. Total: **$49.56**.” |
+| Installed sibling resource | `/journalism-core:photo-metadata` read the installed cache's `skills/photo-metadata/reference.md`. It returned the 256-byte IPTC-IIM Headline limit and the reference's four-part AP caption recipe. | `$photo-metadata` read `.agents/skills/photo-metadata/reference.md` and returned the same limit and caption recipe. |
+
+The exact accepted prompts remain in
+`scripts/journalism-core-runtime-pilot.mjs` and are protected by
+`scripts/journalism-core-runtime-pilot.test.mjs`.
+
+## Harness behavior
+
+Run one fixture only with explicit disposable client homes:
+
+```bash
+CLAUDE_CONFIG_DIR='<disposable-claude-config>' \
+  npm run pilot:journalism-core -- claude j-core-1 \
+  --project '<disposable-project>'
+
+CODEX_HOME='<disposable-codex-home>' \
+  npm run pilot:journalism-core -- codex j-core-1 \
+  --project '<disposable-project>'
+```
+
+The runner starts subprocesses without a shell, applies a five-minute timeout,
+and streams client JSON for inspection. It gives Claude only the tool needed by
+the fixture. Codex defaults to its read-only sandbox.
+
+The nested Codex read-only sandbox could not initialize a second Bubblewrap
+workspace-reader namespace inside the already isolated top-level session. The
+affected Codex probes were rerun with `--unboxed`, as the repository's
+`AGENTS.md` permits only when the top-level Codex session is already externally
+isolated and was launched with sandbox bypass. Do not use `--unboxed` from an
+ordinary unsandboxed shell.
+
+## Harness adjustments and negative evidence
+
+- A descriptive Claude J-core-1 attempt with all tools disabled did not activate
+  the installed skill. The accepted explicit test therefore uses Claude's
+  stable namespaced slash-command surface.
+- The first Claude resource probe did not authorize `Read`. The accepted probe
+  exposes only `Read` and adds the disposable install root.
+- The first nested Codex read-only probes selected the expected skills but could
+  not read the workspace after sandbox initialization failed. Only the reruns
+  under the repository-authorized isolated fallback count as passing output.
+
+These adjustments are harness constraints, not additional package support
+claims.
+
+## Verification and cleanup
+
+The repeatable harness passed its five focused tests. The repository suite
+passed 119 of 119 tests, all 49 page-specific Tailwind stylesheets were current,
+and `git diff --check` passed. The disposable test root was removed after the
+final verification run.

--- a/plans/codex-compatibility-matrix.md
+++ b/plans/codex-compatibility-matrix.md
@@ -1,6 +1,6 @@
 # Codex compatibility matrix
 
-- Status: phase-one installation baseline; runtime pilots pending
+- Status: phase-two runtime pilots; journalism-core passed on two scoped paths
 - Last evidence update: July 23, 2026
 - Architecture: [Codex compatibility architecture decision](2026-07-21-codex-compatibility-architecture.md)
 
@@ -15,6 +15,9 @@ Status labels:
 
 - **Baseline installed:** a clean client installed the package or skill, but
   runtime behavior is not yet proved.
+- **Runtime pilot passed:** paired client behavior passed for the named install
+  paths. Other install paths and package-wide support gates remain unclaimed
+  unless their evidence says otherwise.
 - **Candidate:** the shared skills appear portable from static review, but the
   runtime gates are pending.
 - **Adapter required:** static review found a platform-bound path, instruction,
@@ -282,13 +285,29 @@ marketplace 2.3.3 exposes installable `pdf-playground` 1.3.2 and
 `skills@1.5.20` public-repository discovery found exactly 60 source skills.
 The disposable configurations were not reused as runtime evidence.
 
+### J-release-1: paired journalism-core runtime pilot
+
+Environment: public `master` at
+[`9eef57629edbaa19bf47ec35296acebdd7b4ab1f`](https://github.com/jamditis/claude-skills-journalism/commit/9eef57629edbaa19bf47ec35296acebdd7b4ab1f)
+installed into separate disposable Claude and Codex profiles on July 23, 2026.
+The [paired runtime record](2026-07-23-journalism-core-runtime-pilot.md)
+contains the exact scope, prompts, selection evidence, output summaries,
+resource hash, harness adjustments, verification, and cleanup.
+
+Result: Claude Code 2.1.218 passed explicit activation through the installed
+namespaced command, implicit `source-verification` selection, unrelated
+non-trigger behavior, and installed `photo-metadata/reference.md` resolution.
+Codex CLI 0.145.0 passed the same behavior through a skills CLI 1.5.20 project
+standards install. The legacy-compatible Codex package path and user-level
+standards path remain install-only evidence.
+
 ## Package matrix
 
 | Package | Version and components | Current classification | Included and excluded scope | Evidence | Next proof |
 |---|---|---|---|---|---|
 | `autocontext` | 1.1.0; no skills; five commands; one agent; six hook files | Claude-only surface | Include nothing in the Codex claim. Commands, curator agent, hook lifecycle, persisted data, and compatibility environment variables need a separate design. | [I-phase-1](#i-phase-1-package-inventory) | Define state, lifecycle, authority, and uninstall contracts in a separate accepted decision. |
 | `dev-toolkit` | 1.1.1; 11 nested skills | Candidate with adapter review | Instruction-led skills may be shared. Exclude Claude tool vocabulary, `CLAUDE.md` updates, hook wiring, and Claude subagent syntax until tested. | [V-phase-1](#v-phase-1-repaired-standards-baseline) covers structure | Classify each skill; add explicit trigger and non-trigger fixtures for the portable subset. |
-| `journalism-core` | 1.2.0; 14 nested skills | Baseline installed through four paths | Include the 14 shared skills. No commands, agents, or hooks are part of this package. Runtime support remains unclaimed. | [C-phase-1](#c-phase-1-repeatable-claude-install-canary), [K-phase-1](#k-phase-1-repeatable-codex-legacy-package-canary), [S-phase-1](#s-phase-1-full-journalism-core-standards-canary), [S-global-phase-1](#s-global-phase-1-user-level-journalism-core-standards-canary), [V-phase-1](#v-phase-1-repaired-standards-baseline) | Run J-core-1 through J-core-3 in fresh Claude and Codex sessions and verify installed resource resolution. |
+| `journalism-core` | 1.2.0; 14 nested skills | Runtime pilot passed on the Claude package and Codex project-standards paths | Include the 14 shared skills. No commands, agents, or hooks are part of this package. The legacy-compatible Codex package and user-level standards paths remain install-only. | [J-release-1](#j-release-1-paired-journalism-core-runtime-pilot), [C-phase-1](#c-phase-1-repeatable-claude-install-canary), [K-phase-1](#k-phase-1-repeatable-codex-legacy-package-canary), [S-phase-1](#s-phase-1-full-journalism-core-standards-canary), [S-global-phase-1](#s-global-phase-1-user-level-journalism-core-standards-canary), [V-phase-1](#v-phase-1-repaired-standards-baseline) | Add a no-Claude-environment gate and scheduled runtime regression before a broader package support claim. |
 | `okf-wiki` | 0.6.1; one root skill; scripts and generated Claude settings | Adapter required | Preserve OKF scaffolding, validation, examples, and tests. Exclude Codex project settings until the no-Claude behavior test defines the needed branch. | [V-phase-1](#v-phase-1-repaired-standards-baseline) covers structure; [R-phase-1](#r-phase-1-phase-one-repository-checks) covers package tests | Run Okf-1 without Claude installed; record generated files, trust behavior, and cleanup. |
 | `pdf-design` | 1.1.0; one root skill | Adapter required | Shared design guidance and assets are candidates. Hard-coded `~/.claude` and host-specific browser paths are excluded from a Codex claim. | [V-phase-1](#v-phase-1-repaired-standards-baseline) covers structure | Add a no-Claude path-resolution fixture before editing paths. |
 | `pdf-playground` | 1.3.2; one nested skill; eight commands; one hook file | Candidate plus Claude-only surfaces | `document-design` is shared. Commands and hook behavior remain Claude-only until mapped. | [V-phase-1](#v-phase-1-repaired-standards-baseline) and [F-phase-1](#f-phase-1-affected-claude-package-regression); standards, Claude install, and argument delivery pass | Test Codex activation, non-activation, resource loading, and output before a runtime claim. |

--- a/scripts/codex-compatibility-docs.test.mjs
+++ b/scripts/codex-compatibility-docs.test.mjs
@@ -50,6 +50,11 @@ test('the compatibility matrix classifies every marketplace package', () => {
   assert.match(matrix, /`pdf-playground` \| 1\.3\.2/u);
   assert.match(matrix, /`video-toolkit` \| 1\.0\.3/u);
   assert.match(matrix, /V-phase-1: repaired standards baseline/u);
+  assert.match(matrix, /J-release-1: paired journalism-core runtime pilot/u);
+  assert.match(
+    matrix,
+    /`journalism-core` \| 1\.2\.0; 14 nested skills \| Runtime pilot passed on the Claude package and Codex project-standards paths/u,
+  );
 
   const evidenceCells = matrix
     .split('\n')

--- a/scripts/journalism-core-runtime-pilot.mjs
+++ b/scripts/journalism-core-runtime-pilot.mjs
@@ -35,9 +35,10 @@ export const RUNTIME_PILOT_FIXTURES = Object.freeze({
 });
 
 function fixtureFor(id) {
-  const fixture = RUNTIME_PILOT_FIXTURES[id];
-  if (!fixture) throw new Error(`Unsupported runtime pilot fixture: ${id}`);
-  return fixture;
+  if (!Object.hasOwn(RUNTIME_PILOT_FIXTURES, id)) {
+    throw new Error(`Unsupported runtime pilot fixture: ${id}`);
+  }
+  return RUNTIME_PILOT_FIXTURES[id];
 }
 
 function promptFor(client, fixture) {
@@ -152,7 +153,7 @@ export function runRuntimePilot(
   }
 }
 
-function parseCliArgs(args) {
+export function parseCliArgs(args) {
   const [client, fixtureId, ...options] = args;
   let projectDir;
   let unboxed = false;
@@ -161,7 +162,11 @@ function parseCliArgs(args) {
   for (let index = 0; index < options.length; index += 1) {
     const option = options[index];
     if (option === '--project') {
-      projectDir = options[index + 1];
+      const value = options[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error('--project requires a directory value');
+      }
+      projectDir = value;
       index += 1;
     } else if (option === '--unboxed') {
       unboxed = true;
@@ -177,6 +182,9 @@ function parseCliArgs(args) {
       'Usage: node scripts/journalism-core-runtime-pilot.mjs '
       + '<claude|codex> <fixture-id> --project <disposable-project> [--unboxed] [--dry-run]',
     );
+  }
+  if (unboxed && client !== 'codex') {
+    throw new Error('--unboxed is supported only for the Codex runtime pilot');
   }
   return { client, fixtureId, projectDir, unboxed, dryRun };
 }

--- a/scripts/journalism-core-runtime-pilot.mjs
+++ b/scripts/journalism-core-runtime-pilot.mjs
@@ -1,0 +1,210 @@
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const RUNTIME_PILOT_TIMEOUT_MS = 300_000;
+
+export const RUNTIME_PILOT_FIXTURES = Object.freeze({
+  'j-core-1': Object.freeze({
+    mode: 'explicit',
+    skill: Object.freeze({
+      claude: 'journalism-core:fact-check-workflow',
+      codex: 'fact-check-workflow',
+    }),
+    prompt:
+      'Use the installed fact-check workflow to build a verification plan for an unsigned screenshot claiming that a city budget doubled in 2025. Treat the claim as unverified and do not invent sources.',
+  }),
+  'j-core-2': Object.freeze({
+    mode: 'implicit',
+    prompt:
+      'I received an unsigned screenshot with a public-spending claim. What should I verify before publication?',
+  }),
+  'j-core-3': Object.freeze({
+    mode: 'non-trigger',
+    prompt: 'Calculate an 18% tip on a $42 meal.',
+  }),
+  'j-core-resource': Object.freeze({
+    mode: 'explicit-resource',
+    skill: Object.freeze({
+      claude: 'journalism-core:photo-metadata',
+      codex: 'photo-metadata',
+    }),
+    prompt:
+      "Read the installed skill's sibling reference.md before answering. What is the IPTC-IIM maximum byte length for Headline, and what exact four-part shape does the AP-style caption recipe use? Do not guess.",
+  }),
+});
+
+function fixtureFor(id) {
+  const fixture = RUNTIME_PILOT_FIXTURES[id];
+  if (!fixture) throw new Error(`Unsupported runtime pilot fixture: ${id}`);
+  return fixture;
+}
+
+function promptFor(client, fixture) {
+  if (fixture.mode === 'explicit' || fixture.mode === 'explicit-resource') {
+    const skill = fixture.skill[client];
+    const prefix = client === 'claude' ? `/${skill}` : `$${skill}`;
+    return `${prefix} ${fixture.prompt}`;
+  }
+  return fixture.prompt;
+}
+
+function claudeToolArgs(fixture, claudeConfigDir) {
+  if (fixture.mode === 'explicit-resource') {
+    return [
+      '--tools',
+      'Read',
+      '--allowedTools',
+      'Read',
+      '--add-dir',
+      claudeConfigDir,
+    ];
+  }
+  if (fixture.mode === 'implicit' || fixture.mode === 'non-trigger') {
+    return ['--tools', 'Skill', '--allowedTools', 'Skill'];
+  }
+  return ['--tools', ''];
+}
+
+export function buildRuntimeInvocation(
+  client,
+  fixtureId,
+  {
+    projectDir,
+    claudeConfigDir,
+    codexHome,
+    unboxed = false,
+  } = {},
+) {
+  if (!projectDir) throw new Error('A disposable --project directory is required');
+  const cwd = resolve(projectDir);
+  const fixture = fixtureFor(fixtureId);
+
+  if (client === 'claude') {
+    if (!claudeConfigDir) {
+      throw new Error('CLAUDE_CONFIG_DIR is required for the Claude runtime pilot');
+    }
+    const config = resolve(claudeConfigDir);
+    return {
+      command: 'claude',
+      args: [
+        '-p',
+        promptFor(client, fixture),
+        '--output-format',
+        'stream-json',
+        '--verbose',
+        '--no-session-persistence',
+        '--permission-mode',
+        'dontAsk',
+        ...claudeToolArgs(fixture, config),
+      ],
+      cwd,
+      env: { CLAUDE_CONFIG_DIR: config },
+    };
+  }
+
+  if (client === 'codex') {
+    if (!codexHome) throw new Error('CODEX_HOME is required for the Codex runtime pilot');
+    const isolationArgs = unboxed
+      ? ['--dangerously-bypass-approvals-and-sandbox']
+      : ['--sandbox', 'read-only'];
+    return {
+      command: 'codex',
+      args: [
+        'exec',
+        '--ignore-user-config',
+        '--ignore-rules',
+        '--ephemeral',
+        ...isolationArgs,
+        '--skip-git-repo-check',
+        '-C',
+        cwd,
+        '--json',
+        promptFor(client, fixture),
+      ],
+      cwd,
+      env: { CODEX_HOME: resolve(codexHome) },
+    };
+  }
+
+  throw new Error(`Unsupported runtime pilot client: ${client}`);
+}
+
+export function runRuntimePilot(
+  invocation,
+  {
+    run = spawnSync,
+    env = process.env,
+  } = {},
+) {
+  const result = run(invocation.command, invocation.args, {
+    cwd: invocation.cwd,
+    env: { ...env, ...invocation.env },
+    shell: false,
+    stdio: 'inherit',
+    timeout: RUNTIME_PILOT_TIMEOUT_MS,
+    windowsHide: true,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `${invocation.command} runtime pilot failed with status ${result.status ?? 'unknown'}`,
+    );
+  }
+}
+
+function parseCliArgs(args) {
+  const [client, fixtureId, ...options] = args;
+  let projectDir;
+  let unboxed = false;
+  let dryRun = false;
+
+  for (let index = 0; index < options.length; index += 1) {
+    const option = options[index];
+    if (option === '--project') {
+      projectDir = options[index + 1];
+      index += 1;
+    } else if (option === '--unboxed') {
+      unboxed = true;
+    } else if (option === '--dry-run') {
+      dryRun = true;
+    } else {
+      throw new Error(`Unsupported option: ${option}`);
+    }
+  }
+
+  if (!client || !fixtureId) {
+    throw new Error(
+      'Usage: node scripts/journalism-core-runtime-pilot.mjs '
+      + '<claude|codex> <fixture-id> --project <disposable-project> [--unboxed] [--dry-run]',
+    );
+  }
+  return { client, fixtureId, projectDir, unboxed, dryRun };
+}
+
+function runCli() {
+  const { client, fixtureId, projectDir, unboxed, dryRun } = parseCliArgs(
+    process.argv.slice(2),
+  );
+  const invocation = buildRuntimeInvocation(client, fixtureId, {
+    projectDir,
+    claudeConfigDir: process.env.CLAUDE_CONFIG_DIR,
+    codexHome: process.env.CODEX_HOME,
+    unboxed,
+  });
+
+  if (dryRun) {
+    console.log(JSON.stringify(invocation, null, 2));
+    return;
+  }
+  runRuntimePilot(invocation);
+}
+
+const entryPoint = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : '';
+if (entryPoint === import.meta.url) {
+  try {
+    runCli();
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/journalism-core-runtime-pilot.test.mjs
+++ b/scripts/journalism-core-runtime-pilot.test.mjs
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  RUNTIME_PILOT_FIXTURES,
+  RUNTIME_PILOT_TIMEOUT_MS,
+  buildRuntimeInvocation,
+  runRuntimePilot,
+} from './journalism-core-runtime-pilot.mjs';
+
+const projectDir = '/tmp/journalism-core-runtime/project';
+const claudeConfigDir = '/tmp/journalism-core-runtime/claude';
+const codexHome = '/tmp/journalism-core-runtime/codex';
+
+test('runtime pilot fixtures preserve the accepted prompts and modes', () => {
+  assert.deepEqual(Object.keys(RUNTIME_PILOT_FIXTURES), [
+    'j-core-1',
+    'j-core-2',
+    'j-core-3',
+    'j-core-resource',
+  ]);
+  assert.equal(RUNTIME_PILOT_FIXTURES['j-core-1'].mode, 'explicit');
+  assert.match(
+    RUNTIME_PILOT_FIXTURES['j-core-1'].prompt,
+    /unsigned screenshot claiming that a city budget doubled in 2025/u,
+  );
+  assert.equal(RUNTIME_PILOT_FIXTURES['j-core-2'].mode, 'implicit');
+  assert.equal(RUNTIME_PILOT_FIXTURES['j-core-3'].mode, 'non-trigger');
+  assert.equal(
+    RUNTIME_PILOT_FIXTURES['j-core-3'].prompt,
+    'Calculate an 18% tip on a $42 meal.',
+  );
+  assert.match(RUNTIME_PILOT_FIXTURES['j-core-resource'].prompt, /sibling reference\.md/u);
+});
+
+test('Claude plans isolate sessions and expose only the fixture-required tool', () => {
+  const explicit = buildRuntimeInvocation('claude', 'j-core-1', {
+    projectDir,
+    claudeConfigDir,
+  });
+  assert.equal(explicit.command, 'claude');
+  assert.equal(explicit.cwd, projectDir);
+  assert.deepEqual(explicit.env, { CLAUDE_CONFIG_DIR: claudeConfigDir });
+  assert.equal(
+    explicit.args[1],
+    '/journalism-core:fact-check-workflow '
+      + RUNTIME_PILOT_FIXTURES['j-core-1'].prompt,
+  );
+  assert.ok(explicit.args.includes('--no-session-persistence'));
+  assert.deepEqual(explicit.args.slice(-2), ['--tools', '']);
+
+  const implicit = buildRuntimeInvocation('claude', 'j-core-2', {
+    projectDir,
+    claudeConfigDir,
+  });
+  assert.deepEqual(
+    implicit.args.slice(-4),
+    ['--tools', 'Skill', '--allowedTools', 'Skill'],
+  );
+
+  const resource = buildRuntimeInvocation('claude', 'j-core-resource', {
+    projectDir,
+    claudeConfigDir,
+  });
+  assert.equal(
+    resource.args[1],
+    '/journalism-core:photo-metadata '
+      + RUNTIME_PILOT_FIXTURES['j-core-resource'].prompt,
+  );
+  assert.deepEqual(
+    resource.args.slice(-6),
+    ['--tools', 'Read', '--allowedTools', 'Read', '--add-dir', claudeConfigDir],
+  );
+});
+
+test('Codex plans use project standards skills and default to a read-only sandbox', () => {
+  const explicit = buildRuntimeInvocation('codex', 'j-core-1', {
+    projectDir,
+    codexHome,
+  });
+  assert.equal(explicit.command, 'codex');
+  assert.equal(explicit.cwd, projectDir);
+  assert.deepEqual(explicit.env, { CODEX_HOME: codexHome });
+  assert.ok(explicit.args.includes('--ignore-user-config'));
+  assert.ok(explicit.args.includes('--ephemeral'));
+  assert.deepEqual(
+    explicit.args.slice(explicit.args.indexOf('--sandbox'), explicit.args.indexOf('--sandbox') + 2),
+    ['--sandbox', 'read-only'],
+  );
+  assert.equal(
+    explicit.args.at(-1),
+    '$fact-check-workflow ' + RUNTIME_PILOT_FIXTURES['j-core-1'].prompt,
+  );
+
+  const resource = buildRuntimeInvocation('codex', 'j-core-resource', {
+    projectDir,
+    codexHome,
+    unboxed: true,
+  });
+  assert.ok(resource.args.includes('--dangerously-bypass-approvals-and-sandbox'));
+  assert.ok(!resource.args.includes('--sandbox'));
+  assert.equal(
+    resource.args.at(-1),
+    '$photo-metadata ' + RUNTIME_PILOT_FIXTURES['j-core-resource'].prompt,
+  );
+});
+
+test('runtime runner avoids a shell and preserves the subprocess timeout', () => {
+  const calls = [];
+  runRuntimePilot(
+    {
+      command: 'fixture-client',
+      args: ['--json'],
+      cwd: projectDir,
+      env: { FIXTURE_HOME: '/tmp/fixture-home' },
+    },
+    {
+      env: { PATH: '/bin' },
+      run: (command, args, options) => {
+        calls.push({ command, args, options });
+        return { status: 0 };
+      },
+    },
+  );
+
+  assert.equal(RUNTIME_PILOT_TIMEOUT_MS, 300_000);
+  assert.equal(calls[0].options.shell, false);
+  assert.equal(calls[0].options.timeout, RUNTIME_PILOT_TIMEOUT_MS);
+  assert.deepEqual(calls[0].options.env, {
+    PATH: '/bin',
+    FIXTURE_HOME: '/tmp/fixture-home',
+  });
+});
+
+test('runtime pilot plans require explicit disposable client homes', () => {
+  assert.throws(
+    () => buildRuntimeInvocation('claude', 'j-core-1', { projectDir }),
+    /CLAUDE_CONFIG_DIR is required/u,
+  );
+  assert.throws(
+    () => buildRuntimeInvocation('codex', 'j-core-1', { projectDir }),
+    /CODEX_HOME is required/u,
+  );
+  assert.throws(
+    () => buildRuntimeInvocation('codex', 'unknown', { projectDir, codexHome }),
+    /Unsupported runtime pilot fixture/u,
+  );
+});

--- a/scripts/journalism-core-runtime-pilot.test.mjs
+++ b/scripts/journalism-core-runtime-pilot.test.mjs
@@ -5,6 +5,7 @@ import {
   RUNTIME_PILOT_FIXTURES,
   RUNTIME_PILOT_TIMEOUT_MS,
   buildRuntimeInvocation,
+  parseCliArgs,
   runRuntimePilot,
 } from './journalism-core-runtime-pilot.mjs';
 
@@ -144,5 +145,30 @@ test('runtime pilot plans require explicit disposable client homes', () => {
   assert.throws(
     () => buildRuntimeInvocation('codex', 'unknown', { projectDir, codexHome }),
     /Unsupported runtime pilot fixture/u,
+  );
+  assert.throws(
+    () => buildRuntimeInvocation('codex', 'toString', { projectDir, codexHome }),
+    /Unsupported runtime pilot fixture/u,
+  );
+});
+
+test('runtime pilot CLI rejects missing option values and client-mismatched bypasses', () => {
+  assert.throws(
+    () => parseCliArgs(['codex', 'j-core-1', '--project', '--unboxed']),
+    /--project requires a directory value/u,
+  );
+  assert.throws(
+    () => parseCliArgs(['claude', 'j-core-1', '--project', projectDir, '--unboxed']),
+    /--unboxed is supported only for the Codex runtime pilot/u,
+  );
+  assert.deepEqual(
+    parseCliArgs(['codex', 'j-core-1', '--project', projectDir, '--unboxed', '--dry-run']),
+    {
+      client: 'codex',
+      fixtureId: 'j-core-1',
+      projectDir,
+      unboxed: true,
+      dryRun: true,
+    },
   );
 });


### PR DESCRIPTION
## Summary

- add a repeatable, shell-free runtime pilot harness for the accepted journalism-core fixtures
- record paired Claude Code 2.1.218 and Codex CLI 0.145.0 activation, non-trigger, output, and installed-resource evidence
- update the compatibility matrix with a narrowly scoped runtime-passed classification
- harden fixture and CLI option validation with regression tests

## Runtime evidence

- J-core-1 explicit `fact-check-workflow`: passed in fresh Claude and Codex sessions
- J-core-2 implicit verification: passed in both clients with recorded selection evidence
- J-core-3 unrelated tip calculation: no journalism-core activation in either client
- installed `photo-metadata/reference.md`: resolved and read by both clients; source and installed copies shared SHA-256 `0150c0db2b78ecc3c38a4d7fa585b3444c58cceb1b22dd55e21eb64f5d659d17`
- disposable runtime roots and authentication symlinks were removed after verification

The compatibility claim applies only to the Claude package path and Codex project standards path. The legacy-compatible Codex package and user-level standards paths remain install-only.

## Verification

- `npm test` — 120/120 passed
- `npm run check:docs-css` — 49 stylesheets current
- `git diff --check`
- actual Claude and Codex wrapper executions for the non-trigger fixture
- commit-scoped Codex review after hardening — no actionable findings

Built on the phase-one evidence merged in #246.

Closes #227