### PR TITLE
okf-wiki: add prefix-anchored provider secret detectors (#150 move A)

### DIFF
--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -105,22 +105,17 @@ SECRET_PATTERNS = [
     ("Slack token", re.compile(r"\bxox[baprs]-[0-9A-Za-z-]{10,}")),
     ("GitHub token", re.compile(r"\bgh[pousr]_[0-9A-Za-z]{36,}\b")),
     ("GitHub fine-grained PAT", re.compile(r"\bgithub_pat_[0-9A-Za-z_]{22,}\b")),
-    # More provider tokens, each anchored on a fixed literal prefix like the
-    # detectors above. Because they key on a prefix (not a widened value charset),
-    # none can fire on a documented key path such as `secret: svc/api/prod-key-path`
-    # -- so they raise default recall on real leaked tokens at zero precision cost,
-    # and unlike the opt-in entropy scan they run on every validation and match a
-    # token whether or not it sits after a credential label.
+    # More provider tokens with fixed literal prefixes and exact or narrow shapes.
+    # Providers whose token bodies allow path-like hyphens and underscores use the
+    # entropy-gated patterns below instead.
     ("Stripe secret key", re.compile(r"\b[sr]k_(?:live|test)_[0-9A-Za-z]{24,}\b")),
     ("Stripe webhook secret", re.compile(r"\bwhsec_[0-9A-Za-z]{32,}\b")),
-    ("GitLab token", re.compile(r"\bglpat-[0-9A-Za-z_-]{20,}")),
     ("npm token", re.compile(r"\bnpm_[0-9A-Za-z]{36}\b")),
     ("SendGrid API key", re.compile(r"\bSG\.[0-9A-Za-z_-]{22}\.[0-9A-Za-z_-]{43}")),
-    ("Anthropic API key", re.compile(r"\bsk-ant-[0-9A-Za-z_-]{20,}")),
-    ("OpenAI project key", re.compile(r"\bsk-(?:proj|svcacct)-[0-9A-Za-z_-]{20,}")),
     # Legacy personal OpenAI keys carry no project/service segment. `sk-` alone is a
     # weak prefix, so the 40-char solid-base62 run does the signal work; it stays
-    # disjoint from the project-key line above, whose `-` breaks the run.
+    # disjoint from the entropy-gated project-key detector below, whose `-` breaks
+    # the run.
     ("OpenAI legacy key", re.compile(r"\bsk-[0-9A-Za-z]{40,}\b")),
     ("secret assignment", re.compile(
         r"(?i)" + SECRET_LABEL +
@@ -130,6 +125,26 @@ SECRET_PATTERNS = [
         # Structured tokens that use -/_ (fine-grained PATs, Slack, etc.) have their
         # own specific patterns above; the opt-in entropy scan below covers the rest.
         r"\s*[:=]\s*['\"]?[A-Za-z0-9+/]{24,}['\"]?")),
+]
+
+# Some provider token bodies allow the same hyphens and underscores used in
+# human-readable vault paths. A prefix alone would therefore flag documentation
+# such as `openai/sk-proj-production-primary-key-path`. These patterns capture a
+# complete base64url-like body; prefixed_secret_labels applies the same 4.0
+# bits/character floor as the opt-in generic entropy scan. They still run by
+# default because the provider prefix is strong, but the entropy gate keeps path
+# documentation clean.
+#
+# GitLab prefixes are from its token overview (checked 2026-07-23):
+# https://docs.gitlab.com/security/tokens/#token-prefixes
+PREFIXED_SECRET_PATTERNS = [
+    ("GitLab token", re.compile(
+        r"\b(?:glpat|gloas|gldt|glrtr?|glcbt|glptt|glft|glimt|glagent|glwt"
+        r"|glsoat|glffct)-([0-9A-Za-z_-]{20,})(?![0-9A-Za-z_/-])")),
+    ("Anthropic API key", re.compile(
+        r"\bsk-ant-([0-9A-Za-z_-]{20,})(?![0-9A-Za-z_/-])")),
+    ("OpenAI project key", re.compile(
+        r"\bsk-(?:proj|svcacct)-([0-9A-Za-z_-]{20,})(?![0-9A-Za-z_/-])")),
 ]
 
 # Opt-in entropy scan (--secret-entropy-scan). The generic assignment pattern
@@ -165,6 +180,16 @@ def shannon_entropy(s: str) -> float:
         return 0.0
     n = len(s)
     return -sum((c / n) * math.log2(c / n) for c in Counter(s).values())
+
+
+def prefixed_secret_labels(text: str):
+    """Yield each provider label with a complete, random-looking token body."""
+    for label, pattern in PREFIXED_SECRET_PATTERNS:
+        if any(
+            shannon_entropy(match.group(1)) >= SECRET_ENTROPY_MIN_BITS
+            for match in pattern.finditer(text)
+        ):
+            yield label
 
 
 def entropy_secret_values(text: str):
@@ -653,6 +678,10 @@ def main() -> int:
                 errors.append(
                     f"{rel}: possible secret leak ({label}) — remove the value, "
                     f"document the key name/path instead")
+        for label in prefixed_secret_labels(text):
+            errors.append(
+                f"{rel}: possible secret leak ({label}) — remove the value, "
+                f"document the key name/path instead")
         if args.secret_entropy_scan and next(entropy_secret_values(text), None):
             errors.append(
                 f"{rel}: possible secret leak (high-entropy assignment flagged by "

--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -105,6 +105,23 @@ SECRET_PATTERNS = [
     ("Slack token", re.compile(r"\bxox[baprs]-[0-9A-Za-z-]{10,}")),
     ("GitHub token", re.compile(r"\bgh[pousr]_[0-9A-Za-z]{36,}\b")),
     ("GitHub fine-grained PAT", re.compile(r"\bgithub_pat_[0-9A-Za-z_]{22,}\b")),
+    # More provider tokens, each anchored on a fixed literal prefix like the
+    # detectors above. Because they key on a prefix (not a widened value charset),
+    # none can fire on a documented key path such as `secret: svc/api/prod-key-path`
+    # -- so they raise default recall on real leaked tokens at zero precision cost,
+    # and unlike the opt-in entropy scan they run on every validation and match a
+    # token whether or not it sits after a credential label.
+    ("Stripe secret key", re.compile(r"\b[sr]k_(?:live|test)_[0-9A-Za-z]{24,}\b")),
+    ("Stripe webhook secret", re.compile(r"\bwhsec_[0-9A-Za-z]{32,}\b")),
+    ("GitLab token", re.compile(r"\bglpat-[0-9A-Za-z_-]{20,}")),
+    ("npm token", re.compile(r"\bnpm_[0-9A-Za-z]{36}\b")),
+    ("SendGrid API key", re.compile(r"\bSG\.[0-9A-Za-z_-]{22}\.[0-9A-Za-z_-]{43}")),
+    ("Anthropic API key", re.compile(r"\bsk-ant-[0-9A-Za-z_-]{20,}")),
+    ("OpenAI project key", re.compile(r"\bsk-(?:proj|svcacct)-[0-9A-Za-z_-]{20,}")),
+    # Legacy personal OpenAI keys carry no project/service segment. `sk-` alone is a
+    # weak prefix, so the 40-char solid-base62 run does the signal work; it stays
+    # disjoint from the project-key line above, whose `-` breaks the run.
+    ("OpenAI legacy key", re.compile(r"\bsk-[0-9A-Za-z]{40,}\b")),
     ("secret assignment", re.compile(
         r"(?i)" + SECRET_LABEL +
         # Base64-standard value charset only -- deliberately excludes - and _. A

--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -109,7 +109,14 @@ SECRET_PATTERNS = [
     # Providers whose token bodies allow path-like hyphens and underscores use the
     # entropy-gated patterns below instead.
     ("Stripe secret key", re.compile(r"\b[sr]k_(?:live|test)_[0-9A-Za-z]{24,}\b")),
+    ("Stripe organization key", re.compile(r"\bsk_org_[0-9A-Za-z]{24,}\b")),
     ("Stripe webhook secret", re.compile(r"\bwhsec_[0-9A-Za-z]{32,}\b")),
+    # GitLab documents this exact cookie label as a token prefix. Keep the value
+    # shape narrow enough that its `_gitlab_session=...` documentation placeholder
+    # stays clean while an actual serialized cookie is caught.
+    ("GitLab session cookie", re.compile(
+        r"(?i)\b_gitlab_session\s*=\s*['\"]?"
+        r"[0-9A-Za-z%+/_=-]{20,}(?![0-9A-Za-z%+/_=.\-])")),
     ("npm token", re.compile(r"\bnpm_[0-9A-Za-z]{36}\b")),
     ("SendGrid API key", re.compile(r"\bSG\.[0-9A-Za-z_-]{22}\.[0-9A-Za-z_-]{43}")),
     # Legacy personal OpenAI keys carry no project/service segment. `sk-` alone is a
@@ -130,21 +137,25 @@ SECRET_PATTERNS = [
 # Some provider token bodies allow the same hyphens and underscores used in
 # human-readable vault paths. A prefix alone would therefore flag documentation
 # such as `openai/sk-proj-production-primary-key-path`. These patterns capture a
-# complete base64url-like body; prefixed_secret_labels applies the same 4.0
-# bits/character floor as the opt-in generic entropy scan. They still run by
-# default because the provider prefix is strong, but the entropy gate keeps path
-# documentation clean.
+# complete base64url-like body. They still run by default because the provider
+# prefix is strong, but the entropy gate keeps path documentation clean. OpenAI
+# and Anthropic use the generic 4.0 bits/character floor. GitLab accepts 20-char
+# bodies, whose repeated characters lower their observable entropy; its narrower
+# floor is 88% of the maximum entropy observable at the captured body length,
+# capped at 4.0. That is 3.80 bits/character at 20 chars and rises to 4.0 at 24,
+# so short tokens are not judged against a longer sample's ceiling while the
+# longer path regressions stay clean.
 #
 # GitLab prefixes are from its token overview (checked 2026-07-23):
 # https://docs.gitlab.com/security/tokens/#token-prefixes
 PREFIXED_SECRET_PATTERNS = [
     ("GitLab token", re.compile(
         r"\b(?:glpat|gloas|gldt|glrtr?|glcbt|glptt|glft|glimt|glagent|glwt"
-        r"|glsoat|glffct)-([0-9A-Za-z_-]{20,})(?![0-9A-Za-z_/-])")),
+        r"|glsoat|glffct)-([0-9A-Za-z_-]{20,})(?![0-9A-Za-z_/-])"), 0.88),
     ("Anthropic API key", re.compile(
-        r"\bsk-ant-([0-9A-Za-z_-]{20,})(?![0-9A-Za-z_/-])")),
+        r"\bsk-ant-([0-9A-Za-z_-]{20,})(?![0-9A-Za-z_/-])"), 1.0),
     ("OpenAI project key", re.compile(
-        r"\bsk-(?:proj|svcacct)-([0-9A-Za-z_-]{20,})(?![0-9A-Za-z_/-])")),
+        r"\bsk-(?:proj|svcacct)-([0-9A-Za-z_-]{20,})(?![0-9A-Za-z_/-])"), 1.0),
 ]
 
 # Opt-in entropy scan (--secret-entropy-scan). The generic assignment pattern
@@ -184,12 +195,18 @@ def shannon_entropy(s: str) -> float:
 
 def prefixed_secret_labels(text: str):
     """Yield each provider label with a complete, random-looking token body."""
-    for label, pattern in PREFIXED_SECRET_PATTERNS:
-        if any(
-            shannon_entropy(match.group(1)) >= SECRET_ENTROPY_MIN_BITS
-            for match in pattern.finditer(text)
-        ):
-            yield label
+    for label, pattern, max_entropy_fraction in PREFIXED_SECRET_PATTERNS:
+        for match in pattern.finditer(text):
+            body = match.group(1)
+            # A sample of n characters cannot exhibit more than log2(n) bits of
+            # entropy per character, even when every character is unique.
+            min_entropy = min(
+                SECRET_ENTROPY_MIN_BITS,
+                max_entropy_fraction * math.log2(len(body)),
+            )
+            if shannon_entropy(body) >= min_entropy:
+                yield label
+                break
 
 
 def entropy_secret_values(text: str):

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -105,22 +105,17 @@ SECRET_PATTERNS = [
     ("Slack token", re.compile(r"\bxox[baprs]-[0-9A-Za-z-]{10,}")),
     ("GitHub token", re.compile(r"\bgh[pousr]_[0-9A-Za-z]{36,}\b")),
     ("GitHub fine-grained PAT", re.compile(r"\bgithub_pat_[0-9A-Za-z_]{22,}\b")),
-    # More provider tokens, each anchored on a fixed literal prefix like the
-    # detectors above. Because they key on a prefix (not a widened value charset),
-    # none can fire on a documented key path such as `secret: svc/api/prod-key-path`
-    # -- so they raise default recall on real leaked tokens at zero precision cost,
-    # and unlike the opt-in entropy scan they run on every validation and match a
-    # token whether or not it sits after a credential label.
+    # More provider tokens with fixed literal prefixes and exact or narrow shapes.
+    # Providers whose token bodies allow path-like hyphens and underscores use the
+    # entropy-gated patterns below instead.
     ("Stripe secret key", re.compile(r"\b[sr]k_(?:live|test)_[0-9A-Za-z]{24,}\b")),
     ("Stripe webhook secret", re.compile(r"\bwhsec_[0-9A-Za-z]{32,}\b")),
-    ("GitLab token", re.compile(r"\bglpat-[0-9A-Za-z_-]{20,}")),
     ("npm token", re.compile(r"\bnpm_[0-9A-Za-z]{36}\b")),
     ("SendGrid API key", re.compile(r"\bSG\.[0-9A-Za-z_-]{22}\.[0-9A-Za-z_-]{43}")),
-    ("Anthropic API key", re.compile(r"\bsk-ant-[0-9A-Za-z_-]{20,}")),
-    ("OpenAI project key", re.compile(r"\bsk-(?:proj|svcacct)-[0-9A-Za-z_-]{20,}")),
     # Legacy personal OpenAI keys carry no project/service segment. `sk-` alone is a
     # weak prefix, so the 40-char solid-base62 run does the signal work; it stays
-    # disjoint from the project-key line above, whose `-` breaks the run.
+    # disjoint from the entropy-gated project-key detector below, whose `-` breaks
+    # the run.
     ("OpenAI legacy key", re.compile(r"\bsk-[0-9A-Za-z]{40,}\b")),
     ("secret assignment", re.compile(
         r"(?i)" + SECRET_LABEL +
@@ -130,6 +125,26 @@ SECRET_PATTERNS = [
         # Structured tokens that use -/_ (fine-grained PATs, Slack, etc.) have their
         # own specific patterns above; the opt-in entropy scan below covers the rest.
         r"\s*[:=]\s*['\"]?[A-Za-z0-9+/]{24,}['\"]?")),
+]
+
+# Some provider token bodies allow the same hyphens and underscores used in
+# human-readable vault paths. A prefix alone would therefore flag documentation
+# such as `openai/sk-proj-production-primary-key-path`. These patterns capture a
+# complete base64url-like body; prefixed_secret_labels applies the same 4.0
+# bits/character floor as the opt-in generic entropy scan. They still run by
+# default because the provider prefix is strong, but the entropy gate keeps path
+# documentation clean.
+#
+# GitLab prefixes are from its token overview (checked 2026-07-23):
+# https://docs.gitlab.com/security/tokens/#token-prefixes
+PREFIXED_SECRET_PATTERNS = [
+    ("GitLab token", re.compile(
+        r"\b(?:glpat|gloas|gldt|glrtr?|glcbt|glptt|glft|glimt|glagent|glwt"
+        r"|glsoat|glffct)-([0-9A-Za-z_-]{20,})(?![0-9A-Za-z_/-])")),
+    ("Anthropic API key", re.compile(
+        r"\bsk-ant-([0-9A-Za-z_-]{20,})(?![0-9A-Za-z_/-])")),
+    ("OpenAI project key", re.compile(
+        r"\bsk-(?:proj|svcacct)-([0-9A-Za-z_-]{20,})(?![0-9A-Za-z_/-])")),
 ]
 
 # Opt-in entropy scan (--secret-entropy-scan). The generic assignment pattern
@@ -165,6 +180,16 @@ def shannon_entropy(s: str) -> float:
         return 0.0
     n = len(s)
     return -sum((c / n) * math.log2(c / n) for c in Counter(s).values())
+
+
+def prefixed_secret_labels(text: str):
+    """Yield each provider label with a complete, random-looking token body."""
+    for label, pattern in PREFIXED_SECRET_PATTERNS:
+        if any(
+            shannon_entropy(match.group(1)) >= SECRET_ENTROPY_MIN_BITS
+            for match in pattern.finditer(text)
+        ):
+            yield label
 
 
 def entropy_secret_values(text: str):
@@ -653,6 +678,10 @@ def main() -> int:
                 errors.append(
                     f"{rel}: possible secret leak ({label}) — remove the value, "
                     f"document the key name/path instead")
+        for label in prefixed_secret_labels(text):
+            errors.append(
+                f"{rel}: possible secret leak ({label}) — remove the value, "
+                f"document the key name/path instead")
         if args.secret_entropy_scan and next(entropy_secret_values(text), None):
             errors.append(
                 f"{rel}: possible secret leak (high-entropy assignment flagged by "

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -105,6 +105,23 @@ SECRET_PATTERNS = [
     ("Slack token", re.compile(r"\bxox[baprs]-[0-9A-Za-z-]{10,}")),
     ("GitHub token", re.compile(r"\bgh[pousr]_[0-9A-Za-z]{36,}\b")),
     ("GitHub fine-grained PAT", re.compile(r"\bgithub_pat_[0-9A-Za-z_]{22,}\b")),
+    # More provider tokens, each anchored on a fixed literal prefix like the
+    # detectors above. Because they key on a prefix (not a widened value charset),
+    # none can fire on a documented key path such as `secret: svc/api/prod-key-path`
+    # -- so they raise default recall on real leaked tokens at zero precision cost,
+    # and unlike the opt-in entropy scan they run on every validation and match a
+    # token whether or not it sits after a credential label.
+    ("Stripe secret key", re.compile(r"\b[sr]k_(?:live|test)_[0-9A-Za-z]{24,}\b")),
+    ("Stripe webhook secret", re.compile(r"\bwhsec_[0-9A-Za-z]{32,}\b")),
+    ("GitLab token", re.compile(r"\bglpat-[0-9A-Za-z_-]{20,}")),
+    ("npm token", re.compile(r"\bnpm_[0-9A-Za-z]{36}\b")),
+    ("SendGrid API key", re.compile(r"\bSG\.[0-9A-Za-z_-]{22}\.[0-9A-Za-z_-]{43}")),
+    ("Anthropic API key", re.compile(r"\bsk-ant-[0-9A-Za-z_-]{20,}")),
+    ("OpenAI project key", re.compile(r"\bsk-(?:proj|svcacct)-[0-9A-Za-z_-]{20,}")),
+    # Legacy personal OpenAI keys carry no project/service segment. `sk-` alone is a
+    # weak prefix, so the 40-char solid-base62 run does the signal work; it stays
+    # disjoint from the project-key line above, whose `-` breaks the run.
+    ("OpenAI legacy key", re.compile(r"\bsk-[0-9A-Za-z]{40,}\b")),
     ("secret assignment", re.compile(
         r"(?i)" + SECRET_LABEL +
         # Base64-standard value charset only -- deliberately excludes - and _. A

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -109,7 +109,14 @@ SECRET_PATTERNS = [
     # Providers whose token bodies allow path-like hyphens and underscores use the
     # entropy-gated patterns below instead.
     ("Stripe secret key", re.compile(r"\b[sr]k_(?:live|test)_[0-9A-Za-z]{24,}\b")),
+    ("Stripe organization key", re.compile(r"\bsk_org_[0-9A-Za-z]{24,}\b")),
     ("Stripe webhook secret", re.compile(r"\bwhsec_[0-9A-Za-z]{32,}\b")),
+    # GitLab documents this exact cookie label as a token prefix. Keep the value
+    # shape narrow enough that its `_gitlab_session=...` documentation placeholder
+    # stays clean while an actual serialized cookie is caught.
+    ("GitLab session cookie", re.compile(
+        r"(?i)\b_gitlab_session\s*=\s*['\"]?"
+        r"[0-9A-Za-z%+/_=-]{20,}(?![0-9A-Za-z%+/_=.\-])")),
     ("npm token", re.compile(r"\bnpm_[0-9A-Za-z]{36}\b")),
     ("SendGrid API key", re.compile(r"\bSG\.[0-9A-Za-z_-]{22}\.[0-9A-Za-z_-]{43}")),
     # Legacy personal OpenAI keys carry no project/service segment. `sk-` alone is a
@@ -130,21 +137,25 @@ SECRET_PATTERNS = [
 # Some provider token bodies allow the same hyphens and underscores used in
 # human-readable vault paths. A prefix alone would therefore flag documentation
 # such as `openai/sk-proj-production-primary-key-path`. These patterns capture a
-# complete base64url-like body; prefixed_secret_labels applies the same 4.0
-# bits/character floor as the opt-in generic entropy scan. They still run by
-# default because the provider prefix is strong, but the entropy gate keeps path
-# documentation clean.
+# complete base64url-like body. They still run by default because the provider
+# prefix is strong, but the entropy gate keeps path documentation clean. OpenAI
+# and Anthropic use the generic 4.0 bits/character floor. GitLab accepts 20-char
+# bodies, whose repeated characters lower their observable entropy; its narrower
+# floor is 88% of the maximum entropy observable at the captured body length,
+# capped at 4.0. That is 3.80 bits/character at 20 chars and rises to 4.0 at 24,
+# so short tokens are not judged against a longer sample's ceiling while the
+# longer path regressions stay clean.
 #
 # GitLab prefixes are from its token overview (checked 2026-07-23):
 # https://docs.gitlab.com/security/tokens/#token-prefixes
 PREFIXED_SECRET_PATTERNS = [
     ("GitLab token", re.compile(
         r"\b(?:glpat|gloas|gldt|glrtr?|glcbt|glptt|glft|glimt|glagent|glwt"
-        r"|glsoat|glffct)-([0-9A-Za-z_-]{20,})(?![0-9A-Za-z_/-])")),
+        r"|glsoat|glffct)-([0-9A-Za-z_-]{20,})(?![0-9A-Za-z_/-])"), 0.88),
     ("Anthropic API key", re.compile(
-        r"\bsk-ant-([0-9A-Za-z_-]{20,})(?![0-9A-Za-z_/-])")),
+        r"\bsk-ant-([0-9A-Za-z_-]{20,})(?![0-9A-Za-z_/-])"), 1.0),
     ("OpenAI project key", re.compile(
-        r"\bsk-(?:proj|svcacct)-([0-9A-Za-z_-]{20,})(?![0-9A-Za-z_/-])")),
+        r"\bsk-(?:proj|svcacct)-([0-9A-Za-z_-]{20,})(?![0-9A-Za-z_/-])"), 1.0),
 ]
 
 # Opt-in entropy scan (--secret-entropy-scan). The generic assignment pattern
@@ -184,12 +195,18 @@ def shannon_entropy(s: str) -> float:
 
 def prefixed_secret_labels(text: str):
     """Yield each provider label with a complete, random-looking token body."""
-    for label, pattern in PREFIXED_SECRET_PATTERNS:
-        if any(
-            shannon_entropy(match.group(1)) >= SECRET_ENTROPY_MIN_BITS
-            for match in pattern.finditer(text)
-        ):
-            yield label
+    for label, pattern, max_entropy_fraction in PREFIXED_SECRET_PATTERNS:
+        for match in pattern.finditer(text):
+            body = match.group(1)
+            # A sample of n characters cannot exhibit more than log2(n) bits of
+            # entropy per character, even when every character is unique.
+            min_entropy = min(
+                SECRET_ENTROPY_MIN_BITS,
+                max_entropy_fraction * math.log2(len(body)),
+            )
+            if shannon_entropy(body) >= min_entropy:
+                yield label
+                break
 
 
 def entropy_secret_values(text: str):

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -864,6 +864,48 @@ def test_github_pat_secret_detected(tmp_path):
     assert rc == 1 and "secret leak" in out
 
 
+@pytest.mark.parametrize("label, token", [
+    ("Stripe secret key", "sk_" + "live_" + "A1b2C3d4E5f6G7h8I9j0K1L2"),
+    ("Stripe webhook secret", "whsec_" + "A1b2C3d4E5f6G7h8I9j0K1L2M3n4O5p6"),
+    ("GitLab token", "glpat-" + "A1b2C3d4E5f6G7h8I9j0"),
+    ("npm token", "npm_" + "A1b2C3d4E5f6G7h8" + "I9j0K1L2M3n4O5p6Q7r8"),
+    ("SendGrid API key", "SG." + "A" * 22 + "." + "B" * 43),
+    ("Anthropic API key", "sk-" + "ant-" + "api03-" + "A1b2C3d4E5f6G7h8I9j0"),
+    ("OpenAI project key", "sk-" + "proj-" + "A1b2C3d4E5f6G7h8I9j0"),
+    ("OpenAI legacy key", "sk-" + "A1b2C3d4E5f6G7h8I9j0" + "K1L2M3n4O5p6Q7r8S9t0"),
+])
+def test_provider_token_secret_detected(tmp_path, label, token):
+    # Prefix-anchored provider detectors (issue #150 move A). Each token is built
+    # from fragments so no real-looking secret lives in this file. They run on the
+    # default validate (no flag) and raise recall at no precision cost -- the
+    # negative test below proves they leave documentation alone.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD.rstrip() + f"\nkey = {token}\n")
+    rc, out = validate(b)
+    # Assert the specific detector, not just that some leak fired, so a token that
+    # matched the wrong pattern would still be caught.
+    assert rc == 1 and f"secret leak ({label})" in out
+
+
+def test_provider_prefixes_do_not_flag_prose(tmp_path):
+    # The provider prefixes must not fire on documentation: a placeholder ellipsis,
+    # an env-var name, words that merely contain an rk_/sk_ substring (the \b anchor
+    # guards these), and an OKF key path (the invariant the provider block promises)
+    # all stay clean on the default validate.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    prose = (
+        "Set your sk_test_... key from the dashboard.\n"
+        "The npm_config_registry env var points at the mirror.\n"
+        "Use the work_live and mark_live feature flags.\n"
+        "The pointer secret: svc/api/prod-key-path names a vault key, not a value.\n"
+    )
+    write_concept(b, GOOD.rstrip() + "\n" + prose)
+    rc, out = validate(b)
+    assert rc == 0, out
+
+
 def test_link_to_existing_uppercase_md_fails(tmp_path):
     # the case the prior case-sensitive design worried about: a link to an existing
     # Foo.MD used to "resolve" as valid while discovery never scanned that file. Now

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -866,8 +866,12 @@ def test_github_pat_secret_detected(tmp_path):
 
 @pytest.mark.parametrize("label, token", [
     ("Stripe secret key", "sk_" + "live_" + "A1b2C3d4E5f6G7h8I9j0K1L2"),
+    ("Stripe organization key", "sk_" + "org_" + "A1b2C3d4E5f6G7h8I9j0K1L2"),
     ("Stripe webhook secret", "whsec_" + "A1b2C3d4E5f6G7h8I9j0K1L2M3n4O5p6"),
     ("GitLab token", "glpat-" + "A1b2C3d4E5f6G7h8I9j0"),
+    # A valid 20-character GitLab token body can repeat characters and land just
+    # below the generic 4.0-bit entropy floor (3.984 bits/character here).
+    ("GitLab token", "glpat-" + "5lRDXNfPxOMFQmlFCcFZ"),
     ("GitLab token", "gloas-" + "A1b2C3d4E5f6G7h8I9j0"),
     ("GitLab token", "gldt-" + "A1b2C3d4E5f6G7h8I9j0"),
     ("GitLab token", "glrt-" + "A1b2C3d4E5f6G7h8I9j0"),
@@ -900,6 +904,18 @@ def test_provider_token_secret_detected(tmp_path, label, token):
     assert rc == 1 and f"secret leak ({label})" in out
 
 
+def test_gitlab_session_cookie_secret_detected(tmp_path):
+    # GitLab lists the session-cookie assignment itself alongside its fixed token
+    # prefixes. Build the fake cookie from fragments so no real-looking value
+    # lives in this test file.
+    fake = "_gitlab_" + "session=" + "A1b2C3d4E5f6G7h8I9j0K1L2M3n4O5p6"
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD.rstrip() + f"\nCookie: {fake}\n")
+    rc, out = validate(b)
+    assert rc == 1 and "secret leak (GitLab session cookie)" in out
+
+
 def test_provider_prefixes_do_not_flag_prose(tmp_path):
     # The provider prefixes must not fire on documentation: a placeholder ellipsis,
     # an env-var name, words that merely contain an rk_/sk_ substring (the \b anchor
@@ -916,6 +932,7 @@ def test_provider_prefixes_do_not_flag_prose(tmp_path):
         "The pointer secret: anthropic/sk-ant-production-primary-key-path is a vault path.\n"
         "The pointer secret: gitlab/gldt-production-deploy-token-path is a vault path.\n"
         "The pointer secret: openai/sk-proj-A1b2C3d4E5f6G7h8I9j0/key-path is a vault path.\n"
+        "GitLab documents the placeholder _gitlab_session=... for browser sessions.\n"
     )
     write_concept(b, GOOD.rstrip() + "\n" + prose)
     rc, out = validate(b)

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -868,6 +868,18 @@ def test_github_pat_secret_detected(tmp_path):
     ("Stripe secret key", "sk_" + "live_" + "A1b2C3d4E5f6G7h8I9j0K1L2"),
     ("Stripe webhook secret", "whsec_" + "A1b2C3d4E5f6G7h8I9j0K1L2M3n4O5p6"),
     ("GitLab token", "glpat-" + "A1b2C3d4E5f6G7h8I9j0"),
+    ("GitLab token", "gloas-" + "A1b2C3d4E5f6G7h8I9j0"),
+    ("GitLab token", "gldt-" + "A1b2C3d4E5f6G7h8I9j0"),
+    ("GitLab token", "glrt-" + "A1b2C3d4E5f6G7h8I9j0"),
+    ("GitLab token", "glrtr-" + "A1b2C3d4E5f6G7h8I9j0"),
+    ("GitLab token", "glcbt-" + "abc_" + "A1b2C3d4E5f6G7h8I9j0"),
+    ("GitLab token", "glptt-" + "A1b2C3d4E5f6G7h8I9j0"),
+    ("GitLab token", "glft-" + "A1b2C3d4E5f6G7h8I9j0"),
+    ("GitLab token", "glimt-" + "A1b2C3d4E5f6G7h8I9j0"),
+    ("GitLab token", "glagent-" + "A1b2C3d4E5f6G7h8I9j0"),
+    ("GitLab token", "glwt-" + "A1b2C3d4E5f6G7h8I9j0"),
+    ("GitLab token", "glsoat-" + "A1b2C3d4E5f6G7h8I9j0"),
+    ("GitLab token", "glffct-" + "A1b2C3d4E5f6G7h8I9j0"),
     ("npm token", "npm_" + "A1b2C3d4E5f6G7h8" + "I9j0K1L2M3n4O5p6Q7r8"),
     ("SendGrid API key", "SG." + "A" * 22 + "." + "B" * 43),
     ("Anthropic API key", "sk-" + "ant-" + "api03-" + "A1b2C3d4E5f6G7h8I9j0"),
@@ -877,8 +889,8 @@ def test_github_pat_secret_detected(tmp_path):
 def test_provider_token_secret_detected(tmp_path, label, token):
     # Prefix-anchored provider detectors (issue #150 move A). Each token is built
     # from fragments so no real-looking secret lives in this file. They run on the
-    # default validate (no flag) and raise recall at no precision cost -- the
-    # negative test below proves they leave documentation alone.
+    # default validate (no flag); the negative test below pins the path-documentation
+    # precision boundary.
     scaffold(tmp_path / "kb", "--no-validate")
     b = tmp_path / "kb" / "bundle"
     write_concept(b, GOOD.rstrip() + f"\nkey = {token}\n")
@@ -891,8 +903,8 @@ def test_provider_token_secret_detected(tmp_path, label, token):
 def test_provider_prefixes_do_not_flag_prose(tmp_path):
     # The provider prefixes must not fire on documentation: a placeholder ellipsis,
     # an env-var name, words that merely contain an rk_/sk_ substring (the \b anchor
-    # guards these), and an OKF key path (the invariant the provider block promises)
-    # all stay clean on the default validate.
+    # guards these), and provider-specific OKF key paths all stay clean on the
+    # default validate.
     scaffold(tmp_path / "kb", "--no-validate")
     b = tmp_path / "kb" / "bundle"
     prose = (
@@ -900,6 +912,10 @@ def test_provider_prefixes_do_not_flag_prose(tmp_path):
         "The npm_config_registry env var points at the mirror.\n"
         "Use the work_live and mark_live feature flags.\n"
         "The pointer secret: svc/api/prod-key-path names a vault key, not a value.\n"
+        "The pointer secret: openai/sk-proj-production-primary-key-path is a vault path.\n"
+        "The pointer secret: anthropic/sk-ant-production-primary-key-path is a vault path.\n"
+        "The pointer secret: gitlab/gldt-production-deploy-token-path is a vault path.\n"
+        "The pointer secret: openai/sk-proj-A1b2C3d4E5f6G7h8I9j0/key-path is a vault path.\n"
     )
     write_concept(b, GOOD.rstrip() + "\n" + prose)
     rc, out = validate(b)


### PR DESCRIPTION
## What

Adds default provider-token detectors to the okf-wiki bundle validator, completing move A from #150's July analysis.

Exact-shape detectors cover Stripe secret, restricted, and organization keys; Stripe webhook secrets; GitLab session cookies; npm tokens; SendGrid keys; OpenAI legacy keys; and the existing high-signal provider formats. Entropy-gated prefix detectors cover:

- Anthropic API keys
- OpenAI project and service-account keys
- GitLab personal, OAuth, deploy, runner, job, trigger, feed, incoming-mail, agent, workspace, SCIM, and feature-flag token prefixes

The GitLab prefix list follows the current [GitLab token overview](https://docs.gitlab.com/security/tokens/#token-prefixes).

## Why

The generic base64 assignment detector deliberately excludes `-` and `_` so it does not flag documented OKF key paths. The opt-in entropy scan on `master` recovers the generic URL-safe case, but high-signal provider tokens should still be caught on a default validation run.

## Precision

Providers with exact token shapes remain simple prefix-anchored regular expressions. GitLab, Anthropic, and OpenAI project token bodies allow the same hyphens and underscores used in human-readable vault paths, so those detectors now require:

1. a complete base64url-like token body with a trailing boundary, and
2. an entropy floor appropriate to the provider and captured body length.

OpenAI and Anthropic use the generic 4.0-bit floor. GitLab's documented prefixes are stronger and its accepted body starts at 20 characters, so its floor is 88% of the maximum entropy observable at that length, capped at 4.0 bits. The floor is 3.80 bits at 20 characters and reaches 4.0 at 24. That catches short tokens with repeated characters while keeping paths such as `gitlab/gldt-production-deploy-token-path` clean. A random-looking path segment followed by `/` also stays clean.

## Review fixes

- guard OpenAI and Anthropic project-key detectors against provider-specific vault paths
- cover all documented GitLab hyphen prefixes, including deploy, runner, and CI job tokens
- apply a length-aware GitLab entropy floor so valid 20-character bodies are not judged against a longer sample's ceiling
- cover Stripe organization keys and GitLab session cookies
- replace the original zero-false-positive claim with an explicit heuristic boundary

## Tests

- focused provider regression set: 24 passed
- full okf-wiki suite: 214 passed
- repository Node test suite: 129 passed
- generated docs CSS: 49 pages verified
- canonical and scaffolded `validate.py` copies are byte-identical
- `git diff --check`

Closes #150.
