### PR TITLE
Record visual-explainer Codex runtime pilot

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "canary:journalism-core:codex-skills": "node scripts/journalism-core-install-canary.mjs codex-skills",
     "canary:journalism-core:codex-skills-global": "node scripts/journalism-core-install-canary.mjs codex-skills-global",
     "pilot:journalism-core": "node scripts/journalism-core-runtime-pilot.mjs",
+    "pilot:visual-explainer": "node scripts/visual-explainer-runtime-pilot.mjs",
     "a11y": "node scripts/verify_a11y.mjs",
     "build:docs-css": "node scripts/docs-tailwind.mjs --write",
     "check:docs-css": "node scripts/docs-tailwind.mjs --check"

--- a/plans/2026-07-23-visual-explainer-runtime-pilot.md
+++ b/plans/2026-07-23-visual-explainer-runtime-pilot.md
@@ -1,0 +1,146 @@
+# Visual-explainer Codex runtime pilot
+
+- Status: passed on the Codex project-standards path
+- Evidence date: July 23, 2026
+- Tracking issue: [#228](https://github.com/jamditis/claude-skills-journalism/issues/228)
+- Source revision: [`f6a4b84dd2e9feafc6c2bf067f873e9301a083c2`](https://github.com/jamditis/claude-skills-journalism/commit/f6a4b84dd2e9feafc6c2bf067f873e9301a083c2)
+
+## Scope
+
+This pilot tested the repository's `visual-explainer` 0.7.1 root skill in
+Codex CLI 0.145.0 after skills CLI 1.5.20 copied it into a disposable
+project's `.agents/skills/visual-explainer` directory.
+
+The fixture exercised discovery, installed relative resources, HTML creation,
+responsive rendering, and basic accessibility. It did not test the eight
+source commands as Codex commands, sharing through Vercel, optional image
+generation, or a user-level install. It adds no native manifest or adapter.
+
+## Standards installation
+
+The disposable root was
+`/tmp/visual-explainer-runtime-20260723-ECLDTK`. The accepted install command
+ran from its empty `project` directory:
+
+```bash
+npx -y skills@1.5.20 add \
+  '<checkout>/visual-explainer' \
+  --skill visual-explainer \
+  --agent codex \
+  --copy \
+  -y
+```
+
+The installer found one skill, wrote it to
+`.agents/skills/visual-explainer`, and created a `skills-lock.json` entry for
+that exact name. The source and installed copies each contained 24 files.
+Their sorted relative-path and content manifest had the same SHA-256 digest:
+
+```text
+83e44cc015b0ebb5b3c19cb5e5f2127b873dec8f5b07d3dc0e3e865d082b6215
+```
+
+The pinned official Agent Skills validator accepted the installed copy. Codex
+0.145.0's bundled creator helper rejected only the standards-valid
+`compatibility` field:
+
+```text
+Unexpected key(s) in SKILL.md frontmatter: compatibility.
+```
+
+This is the already-allowlisted validator difference, not a runtime failure.
+
+## V-ex-1 runtime result
+
+The exact accepted prompt is stored in
+`scripts/visual-explainer-runtime-pilot.mjs`. It invokes
+`$visual-explainer`, supplies a four-stage newsroom flow, requires the
+installed copy to read:
+
+- `.agents/skills/visual-explainer/references/css-patterns.md`; and
+- `.agents/skills/visual-explainer/templates/architecture.html`.
+
+The Codex command trace showed reads from the installed `SKILL.md` and both
+required relative resources. It then created `v-ex-1.html` in the disposable
+project. The 9,605-byte file had SHA-256 digest:
+
+```text
+2a9c3266c0dc33d6487845bd44dc6bc392e8073612bb4733558218fc8514221e
+```
+
+The output contained one primary heading, semantic stage headings, all four
+requested stages in order, visible connectors, and the requested audit-trail
+note. It loaded no runtime CDN script.
+
+## Render and accessibility review
+
+Playwright loaded the generated file at 1,440 by 1,000 pixels and 390 by 844
+pixels. Both layouts had no horizontal overflow, browser console error, or
+page error. The mobile layout stacked the four stages while preserving their
+order and connectors. The page also rendered correctly with the dark color
+scheme after its entrance animation settled.
+
+An axe scan using the repository's lockfile-verified dependencies reported
+zero WCAG 2.2 A or AA violations in the tested light desktop, light mobile,
+and dark desktop renders. This automated result supports the fixture; it is
+not a substitute for a full manual accessibility certification.
+
+## Legacy-package omission
+
+A separate empty `CODEX_HOME` added the local Claude marketplace and installed
+`visual-explainer@claude-skills-journalism` 0.7.1 through Codex's
+legacy-compatible plugin route.
+
+The plugin cache retained the source root `SKILL.md` as package data, but Codex
+did not register it under a standards skill root. No
+`skills/*/SKILL.md` entry existed for `visual-explainer`, so
+`$visual-explainer` was unavailable through that route as expected.
+
+Codex generated three untested migrated-command wrapper skills for
+`generate-slides`, `generate-web-diagram`, and `share-page`. Those wrappers
+are client-generated adapter surfaces and are outside this root-skill pilot;
+their existence is not a runtime support claim for the eight source commands.
+
+## Harness behavior
+
+Run the accepted fixture only with an explicit disposable client home and a
+fresh standards install:
+
+```bash
+CODEX_HOME='<disposable-codex-home>' \
+  npm run pilot:visual-explainer -- codex v-ex-1 \
+  --project '<disposable-project>'
+```
+
+The runner uses `--ignore-user-config`, `--ignore-rules`, and `--ephemeral`;
+starts subprocesses without a shell; applies a five-minute timeout; and
+defaults to the `workspace-write` sandbox because the fixture must create an
+HTML file. It refuses to reuse an existing output and verifies the installed
+resources plus the generated file's semantic contract.
+
+The nested writable sandbox could not initialize a second Bubblewrap
+namespace inside the already isolated top-level session. It failed before
+reading or writing a fixture file. The accepted probe was rerun with
+`--unboxed`, as the repository's `AGENTS.md` permits only when the top-level
+Codex session is already externally isolated and was launched with sandbox
+bypass. Do not use `--unboxed` from an ordinary unsandboxed shell.
+
+Recheck an existing artifact without invoking Codex:
+
+```bash
+npm run pilot:visual-explainer -- codex v-ex-1 \
+  --project '<disposable-project>' \
+  --verify-only
+```
+
+## Verification and cleanup
+
+The focused harness tests cover the exact prompt, sandbox plan, authorized
+fallback, resource checks, linked-parent containment, ordered output contract,
+runtime-CDN rejection, timeout, shell avoidance, and adversarial CLI input. The
+full repository suite, docs CSS freshness, and diff checks are recorded in the
+pull request.
+
+The disposable standards project, legacy Codex home, generated HTML, render
+screenshots, and authentication symlink were removed after verification.
+Credential content was not copied into the test root or repository.

--- a/plans/codex-compatibility-matrix.md
+++ b/plans/codex-compatibility-matrix.md
@@ -1,6 +1,6 @@
 # Codex compatibility matrix
 
-- Status: phase-two runtime pilots; journalism-core passed on two scoped paths
+- Status: phase-two runtime pilots; journalism-core and visual-explainer have scoped passes
 - Last evidence update: July 23, 2026
 - Architecture: [Codex compatibility architecture decision](2026-07-21-codex-compatibility-architecture.md)
 
@@ -32,6 +32,7 @@ Status labels:
 |---|---|---|
 | Repository | `b0617649515d24ebfcd51f15bceb1d76b03db668` | Architecture commit used as the phase-one worktree base |
 | Repository release verification | [`9eef57629edbaa19bf47ec35296acebdd7b4ab1f`](https://github.com/jamditis/claude-skills-journalism/commit/9eef57629edbaa19bf47ec35296acebdd7b4ab1f) | July 23 post-merge `master` head used for the phase-one release evidence |
+| Repository visual-explainer pilot | [`f6a4b84dd2e9feafc6c2bf067f873e9301a083c2`](https://github.com/jamditis/claude-skills-journalism/commit/f6a4b84dd2e9feafc6c2bf067f873e9301a083c2) | July 23 `master` head installed for the V-ex-1 runtime evidence |
 | Claude Code | 2.1.215; 2.1.218 | Phase-one marketplace validation, then the post-merge clean `journalism-core` install |
 | Codex CLI | 0.145.0 | Legacy-compatible marketplace and clean `journalism-core` install |
 | skills CLI | 1.5.19; 1.5.20 | Phase-one standards discovery, then post-merge project and user install canaries |
@@ -301,6 +302,29 @@ Codex CLI 0.145.0 passed the same behavior through a skills CLI 1.5.20 project
 standards install. The legacy-compatible Codex package path and user-level
 standards path remain install-only evidence.
 
+### V-ex-release-1: visual-explainer root-skill runtime pilot
+
+Environment: public `master` at
+[`f6a4b84dd2e9feafc6c2bf067f873e9301a083c2`](https://github.com/jamditis/claude-skills-journalism/commit/f6a4b84dd2e9feafc6c2bf067f873e9301a083c2)
+installed into a disposable Codex project on July 23, 2026. The
+[runtime record](2026-07-23-visual-explainer-runtime-pilot.md) contains the
+exact scope, install command, file-manifest digest, prompt, installed resource
+reads, output digest, render review, validator difference, legacy omission,
+harness behavior, and cleanup.
+
+Result: Codex CLI 0.145.0 discovered `$visual-explainer` after skills CLI
+1.5.20 copied the 24-file root skill into `.agents/skills`. V-ex-1 read the
+installed `references/css-patterns.md` and `templates/architecture.html`, then
+produced the requested four-stage newsroom architecture HTML. Desktop, mobile,
+light, and dark checks found no overflow or runtime errors; the automated axe
+checks found no WCAG 2.2 A or AA violations.
+
+The legacy-compatible Codex plugin route cached the source root `SKILL.md` but
+did not register it as a root skill. Codex generated three untested command
+wrappers; they remain outside this root-skill runtime claim. The official
+validator accepted the standards copy, while the creator helper produced only
+the already-allowlisted `compatibility`-field difference.
+
 ## Package matrix
 
 | Package | Version and components | Current classification | Included and excluded scope | Evidence | Next proof |
@@ -316,7 +340,7 @@ standards path remain install-only evidence.
 | `security-toolkit` | 1.2.0; four nested skills; one command | Candidate plus Claude-only surface | The four shared skills are candidates. `/security-toolkit:hotpatch` and its sandbox lifecycle remain Claude-only. | [V-phase-1](#v-phase-1-repaired-standards-baseline) covers structure; [R-phase-1](#r-phase-1-phase-one-repository-checks) covers security tests | Test skill activation separately; do not map `hotpatch` without authority and failure-semantics tests. |
 | `superjawn` | 1.0.0; 14 nested skills | Not assessed | No package-wide claim. Each skill needs review for Claude tool names, namespacing, agent dispatch, and parallel-agent assumptions. | [V-phase-1](#v-phase-1-repaired-standards-baseline) covers structure only | Evaluate one skill at a time with client-specific tool traces. Do not bulk-port. |
 | `video-toolkit` | 1.0.3; four nested skills; external media runtimes | Candidate; runtime dependencies pending | Shared frontmatter and Claude argument delivery pass. GPU, CPU, browser, media sandbox, and hosted-API behavior remain unclaimed. | [V-phase-1](#v-phase-1-repaired-standards-baseline), [F-phase-1](#f-phase-1-affected-claude-package-regression), and [R-phase-1](#r-phase-1-phase-one-repository-checks) | Run dependency, no-GPU, activation, non-activation, and output fixtures. |
-| `visual-explainer` | 0.7.1; one root skill; eight commands | Adapter required | The root skill and assets are candidates through standards installation. Eight Claude commands remain Claude-only. | [V-phase-1](#v-phase-1-repaired-standards-baseline) passes; [Cv-base-1](#cv-base-1-codex-creator-helper-comparison) records the `compatibility` difference | Run V-ex-1 through standards install and record the expected legacy-package omission. |
+| `visual-explainer` | 0.7.1; one root skill; eight source commands | Runtime pilot passed on the Codex project-standards path; command surfaces unclaimed | Include the root skill and its relative resources only through `.agents/skills`. The legacy route omits root-skill registration. Its three client-generated command wrappers and all eight source commands remain outside this claim. | [V-ex-release-1](#v-ex-release-1-visual-explainer-root-skill-runtime-pilot), [V-phase-1](#v-phase-1-repaired-standards-baseline), and [Cv-base-1](#cv-base-1-codex-creator-helper-comparison) | Add a no-Claude-environment gate and scheduled runtime regression before a broader package claim; test command wrappers only in a separately scoped issue. |
 
 ## Pilot fixtures
 
@@ -362,6 +386,15 @@ Expected result: the root skill is discovered, reads its relative references and
 assets from the installed copy, and produces the requested file. The legacy
 package path is expected not to expose this root skill until evidence says
 otherwise.
+
+The exact accepted prompt and semantic output verifier live in
+`scripts/visual-explainer-runtime-pilot.mjs`. Run them with:
+
+```bash
+CODEX_HOME='<disposable-codex-home>' \
+  npm run pilot:visual-explainer -- codex v-ex-1 \
+  --project '<disposable-project>'
+```
 
 ### Okf-1: no-Claude scaffold
 

--- a/scripts/codex-compatibility-docs.test.mjs
+++ b/scripts/codex-compatibility-docs.test.mjs
@@ -51,10 +51,16 @@ test('the compatibility matrix classifies every marketplace package', () => {
   assert.match(matrix, /`video-toolkit` \| 1\.0\.3/u);
   assert.match(matrix, /V-phase-1: repaired standards baseline/u);
   assert.match(matrix, /J-release-1: paired journalism-core runtime pilot/u);
+  assert.match(matrix, /V-ex-release-1: visual-explainer root-skill runtime pilot/u);
   assert.match(
     matrix,
     /`journalism-core` \| 1\.2\.0; 14 nested skills \| Runtime pilot passed on the Claude package and Codex project-standards paths/u,
   );
+  assert.match(
+    matrix,
+    /`visual-explainer` \| 0\.7\.1; one root skill; eight source commands \| Runtime pilot passed on the Codex project-standards path; command surfaces unclaimed/u,
+  );
+  assert.match(matrix, /scripts\/visual-explainer-runtime-pilot\.mjs/u);
 
   const evidenceCells = matrix
     .split('\n')
@@ -64,6 +70,26 @@ test('the compatibility matrix classifies every marketplace package', () => {
   for (const evidence of evidenceCells) {
     assert.match(evidence, /\[[^\]]+\]\(#[^)]+\)/u);
   }
+});
+
+test('visual-explainer runtime evidence stays scoped to the tested Codex path', () => {
+  const record = readFileSync(
+    join(ROOT, 'plans', '2026-07-23-visual-explainer-runtime-pilot.md'),
+    'utf8',
+  );
+
+  assert.match(record, /Tracking issue: \[#228\]/u);
+  assert.match(record, /Codex CLI 0\.145\.0/u);
+  assert.match(record, /skills CLI 1\.5\.20/u);
+  assert.match(record, /project's `\.agents\/skills\/visual-explainer` directory/u);
+  assert.match(
+    record,
+    /83e44cc015b0ebb5b3c19cb5e5f2127b873dec8f5b07d3dc0e3e865d082b6215/u,
+  );
+  assert.match(record, /did not register it under a standards skill root/u);
+  assert.match(record, /three untested migrated-command wrapper skills/u);
+  assert.match(record, /outside this root-skill pilot/u);
+  assert.doesNotMatch(record, /repository-wide Codex support/u);
 });
 
 test('the README routes Codex users without implying mixed-install support', () => {

--- a/scripts/visual-explainer-runtime-pilot.mjs
+++ b/scripts/visual-explainer-runtime-pilot.mjs
@@ -1,0 +1,343 @@
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  realpathSync,
+} from 'node:fs';
+import {
+  isAbsolute,
+  relative,
+  resolve,
+} from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const VISUAL_EXPLAINER_TIMEOUT_MS = 300_000;
+
+export const VISUAL_EXPLAINER_FIXTURES = Object.freeze({
+  'v-ex-1': Object.freeze({
+    output: 'v-ex-1.html',
+    resources: Object.freeze([
+      'references/css-patterns.md',
+      'templates/architecture.html',
+    ]),
+    requiredText: Object.freeze([
+      'Receive tips',
+      'Verify evidence',
+      'Assign an editor',
+      'Publish corrected story',
+      'Audit trail',
+    ]),
+    prompt:
+      'Create a self-contained HTML architecture diagram at ./v-ex-1.html '
+      + 'from this supplied text: A newsroom receives tips, verifies evidence, '
+      + 'assigns an editor, and publishes a corrected story with an audit trail. '
+      + 'Before generating, read the installed skill copy at '
+      + '.agents/skills/visual-explainer/references/css-patterns.md and '
+      + '.agents/skills/visual-explainer/templates/architecture.html and use '
+      + 'their patterns. Do not open a browser in this noninteractive test. '
+      + 'Do not use external images or runtime CDN scripts. Include a title, '
+      + 'the four stages in order, visible connecting flow, semantic headings, '
+      + 'and a short audit-trail note. After writing the file, report the exact '
+      + 'installed files you read and the output path.',
+  }),
+});
+
+function fixtureFor(id) {
+  if (!Object.hasOwn(VISUAL_EXPLAINER_FIXTURES, id)) {
+    throw new Error(`Unsupported visual-explainer fixture: ${id}`);
+  }
+  return VISUAL_EXPLAINER_FIXTURES[id];
+}
+
+function childPath(root, child, label) {
+  const absoluteRoot = resolve(root);
+  const absoluteChild = resolve(absoluteRoot, child);
+  const fromRoot = relative(absoluteRoot, absoluteChild);
+  if (
+    !fromRoot
+    || fromRoot.startsWith('..')
+    || isAbsolute(fromRoot)
+  ) {
+    throw new Error(`${label} must resolve below the disposable project`);
+  }
+  return absoluteChild;
+}
+
+function requireRegularFile(path, label) {
+  if (!existsSync(path)) throw new Error(`Missing ${label}: ${path}`);
+  const stat = lstatSync(path);
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error(`${label} must be a regular file: ${path}`);
+  }
+}
+
+function requireDirectory(path, label) {
+  if (!existsSync(path)) throw new Error(`Missing ${label}: ${path}`);
+  const stat = lstatSync(path);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`${label} must be a real directory: ${path}`);
+  }
+}
+
+function requireContainedRealPath(path, root, label) {
+  const realRoot = realpathSync(root);
+  const realPath = realpathSync(path);
+  const fromRoot = relative(realRoot, realPath);
+  if (
+    !fromRoot
+    || fromRoot.startsWith('..')
+    || isAbsolute(fromRoot)
+  ) {
+    throw new Error(`${label} escapes the installed skill root: ${path}`);
+  }
+}
+
+export function verifyVisualExplainerInstall(projectDir, fixtureId) {
+  const fixture = fixtureFor(fixtureId);
+  const project = resolve(projectDir);
+  requireDirectory(project, 'disposable project');
+  const skillRoot = childPath(
+    project,
+    '.agents/skills/visual-explainer',
+    'Installed skill root',
+  );
+  requireDirectory(skillRoot, 'installed skill root');
+  requireContainedRealPath(skillRoot, project, 'Installed skill root');
+  const skillFile = resolve(skillRoot, 'SKILL.md');
+  requireRegularFile(skillFile, 'installed SKILL.md');
+  requireContainedRealPath(skillFile, skillRoot, 'installed SKILL.md');
+  for (const resource of fixture.resources) {
+    const resourcePath = resolve(skillRoot, resource);
+    requireRegularFile(
+      resourcePath,
+      `installed resource ${resource}`,
+    );
+    requireContainedRealPath(
+      resourcePath,
+      skillRoot,
+      `installed resource ${resource}`,
+    );
+  }
+  return { project, skillRoot };
+}
+
+export function verifyVisualExplainerOutput(projectDir, fixtureId) {
+  const fixture = fixtureFor(fixtureId);
+  const { project, skillRoot } = verifyVisualExplainerInstall(
+    projectDir,
+    fixtureId,
+  );
+  const outputPath = childPath(project, fixture.output, 'Fixture output');
+  requireRegularFile(outputPath, 'fixture output');
+  const html = readFileSync(outputPath, 'utf8');
+
+  const requiredPatterns = [
+    [/<!doctype html>/iu, 'HTML doctype'],
+    [/<html\b[^>]*\blang=["']en["']/iu, 'English document language'],
+    [/<meta\b[^>]*\bname=["']viewport["']/iu, 'viewport metadata'],
+    [/<title>[^<]+<\/title>/iu, 'document title'],
+    [/<main\b/iu, 'main landmark'],
+    [/<h1\b/iu, 'primary heading'],
+    [/<h2\b/iu, 'section heading'],
+    [/<svg\b|class=["'][^"']*(?:connector|flow-arrow|pipeline__arrow)[^"']*["']/iu,
+      'visible connecting flow'],
+  ];
+  for (const [pattern, label] of requiredPatterns) {
+    if (!pattern.test(html)) throw new Error(`Fixture output is missing ${label}`);
+  }
+
+  if ((html.match(/<h1\b/giu) ?? []).length !== 1) {
+    throw new Error('Fixture output must contain exactly one primary heading');
+  }
+
+  let previousIndex = -1;
+  for (const text of fixture.requiredText) {
+    const index = html.indexOf(text);
+    if (index === -1) {
+      throw new Error(`Fixture output is missing required text: ${text}`);
+    }
+    if (index <= previousIndex) {
+      throw new Error(`Fixture output text is out of order: ${text}`);
+    }
+    previousIndex = index;
+  }
+
+  if (/<script\b[^>]*\bsrc\s*=\s*["']https?:\/\//iu.test(html)) {
+    throw new Error('Fixture output must not load a runtime script from a CDN');
+  }
+
+  return {
+    project,
+    skillRoot,
+    outputPath,
+    bytes: Buffer.byteLength(html),
+  };
+}
+
+export function buildVisualExplainerInvocation(
+  client,
+  fixtureId,
+  {
+    projectDir,
+    codexHome,
+    unboxed = false,
+  } = {},
+) {
+  if (client !== 'codex') {
+    throw new Error(`Unsupported visual-explainer pilot client: ${client}`);
+  }
+  if (!projectDir) throw new Error('A disposable --project directory is required');
+  if (!codexHome) {
+    throw new Error('CODEX_HOME is required for the visual-explainer runtime pilot');
+  }
+  const fixture = fixtureFor(fixtureId);
+  const cwd = resolve(projectDir);
+  const isolationArgs = unboxed
+    ? ['--dangerously-bypass-approvals-and-sandbox']
+    : ['--sandbox', 'workspace-write'];
+
+  return {
+    command: 'codex',
+    args: [
+      'exec',
+      '--ignore-user-config',
+      '--ignore-rules',
+      '--ephemeral',
+      ...isolationArgs,
+      '--skip-git-repo-check',
+      '-C',
+      cwd,
+      '--json',
+      `$visual-explainer ${fixture.prompt}`,
+    ],
+    cwd,
+    env: { CODEX_HOME: resolve(codexHome) },
+  };
+}
+
+export function runVisualExplainerPilot(
+  invocation,
+  {
+    run = spawnSync,
+    env = process.env,
+  } = {},
+) {
+  const result = run(invocation.command, invocation.args, {
+    cwd: invocation.cwd,
+    env: { ...env, ...invocation.env },
+    shell: false,
+    stdio: 'inherit',
+    timeout: VISUAL_EXPLAINER_TIMEOUT_MS,
+    windowsHide: true,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `${invocation.command} visual-explainer pilot failed with status `
+      + `${result.status ?? 'unknown'}`,
+    );
+  }
+}
+
+export function parseCliArgs(args) {
+  const [client, fixtureId, ...options] = args;
+  let projectDir;
+  let unboxed = false;
+  let dryRun = false;
+  let verifyOnly = false;
+
+  for (let index = 0; index < options.length; index += 1) {
+    const option = options[index];
+    if (option === '--project') {
+      const value = options[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error('--project requires a directory value');
+      }
+      projectDir = value;
+      index += 1;
+    } else if (option === '--unboxed') {
+      unboxed = true;
+    } else if (option === '--dry-run') {
+      dryRun = true;
+    } else if (option === '--verify-only') {
+      verifyOnly = true;
+    } else {
+      throw new Error(`Unsupported option: ${option}`);
+    }
+  }
+
+  if (!client || !fixtureId) {
+    throw new Error(
+      'Usage: node scripts/visual-explainer-runtime-pilot.mjs '
+      + 'codex <fixture-id> --project <disposable-project> '
+      + '[--unboxed] [--dry-run|--verify-only]',
+    );
+  }
+  if (client !== 'codex') {
+    throw new Error(`Unsupported visual-explainer pilot client: ${client}`);
+  }
+  fixtureFor(fixtureId);
+  if (!projectDir) throw new Error('A disposable --project directory is required');
+  if (dryRun && verifyOnly) {
+    throw new Error('--dry-run and --verify-only cannot be combined');
+  }
+  return {
+    client,
+    fixtureId,
+    projectDir,
+    unboxed,
+    dryRun,
+    verifyOnly,
+  };
+}
+
+function runCli() {
+  const {
+    client,
+    fixtureId,
+    projectDir,
+    unboxed,
+    dryRun,
+    verifyOnly,
+  } = parseCliArgs(process.argv.slice(2));
+
+  if (verifyOnly) {
+    const result = verifyVisualExplainerOutput(projectDir, fixtureId);
+    console.log(`PASS ${fixtureId}: ${result.bytes} bytes at ${result.outputPath}`);
+    return;
+  }
+
+  const invocation = buildVisualExplainerInvocation(client, fixtureId, {
+    projectDir,
+    codexHome: process.env.CODEX_HOME,
+    unboxed,
+  });
+
+  if (dryRun) {
+    console.log(JSON.stringify(invocation, null, 2));
+    return;
+  }
+
+  verifyVisualExplainerInstall(projectDir, fixtureId);
+  const outputPath = childPath(
+    resolve(projectDir),
+    fixtureFor(fixtureId).output,
+    'Fixture output',
+  );
+  if (existsSync(outputPath)) {
+    throw new Error(`Refusing to reuse an existing fixture output: ${outputPath}`);
+  }
+  runVisualExplainerPilot(invocation);
+  const result = verifyVisualExplainerOutput(projectDir, fixtureId);
+  console.log(`PASS ${fixtureId}: ${result.bytes} bytes at ${result.outputPath}`);
+}
+
+const entryPoint = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : '';
+if (entryPoint === import.meta.url) {
+  try {
+    runCli();
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/visual-explainer-runtime-pilot.test.mjs
+++ b/scripts/visual-explainer-runtime-pilot.test.mjs
@@ -1,0 +1,271 @@
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  afterEach,
+  test,
+} from 'node:test';
+
+import {
+  VISUAL_EXPLAINER_FIXTURES,
+  VISUAL_EXPLAINER_TIMEOUT_MS,
+  buildVisualExplainerInvocation,
+  parseCliArgs,
+  runVisualExplainerPilot,
+  verifyVisualExplainerInstall,
+  verifyVisualExplainerOutput,
+} from './visual-explainer-runtime-pilot.mjs';
+
+const projectDir = '/tmp/visual-explainer-runtime/project';
+const codexHome = '/tmp/visual-explainer-runtime/codex';
+const disposableRoots = [];
+
+const validHtml = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Newsroom flow</title>
+</head>
+<body>
+  <main>
+    <h1>Newsroom flow</h1>
+    <h2>Four stages</h2>
+    <section class="pipeline">
+      <article><h3>Receive tips</h3></article>
+      <svg aria-hidden="true"></svg>
+      <article><h3>Verify evidence</h3></article>
+      <article><h3>Assign an editor</h3></article>
+      <article><h3>Publish corrected story</h3></article>
+    </section>
+    <aside><h2>Audit trail</h2></aside>
+  </main>
+</body>
+</html>`;
+
+function createFixtureProject(html = validHtml) {
+  const root = mkdtempSync(join(tmpdir(), 'visual-explainer-pilot-test-'));
+  disposableRoots.push(root);
+  const skillRoot = join(root, '.agents', 'skills', 'visual-explainer');
+  mkdirSync(join(skillRoot, 'references'), { recursive: true });
+  mkdirSync(join(skillRoot, 'templates'), { recursive: true });
+  writeFileSync(join(skillRoot, 'SKILL.md'), '---\nname: visual-explainer\n---\n');
+  writeFileSync(join(skillRoot, 'references', 'css-patterns.md'), '# CSS\n');
+  writeFileSync(join(skillRoot, 'templates', 'architecture.html'), '<main></main>\n');
+  writeFileSync(join(root, 'v-ex-1.html'), html);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of disposableRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('V-ex-1 preserves the accepted prompt, resources, and output contract', () => {
+  assert.deepEqual(Object.keys(VISUAL_EXPLAINER_FIXTURES), ['v-ex-1']);
+  const fixture = VISUAL_EXPLAINER_FIXTURES['v-ex-1'];
+  assert.equal(fixture.output, 'v-ex-1.html');
+  assert.deepEqual(fixture.resources, [
+    'references/css-patterns.md',
+    'templates/architecture.html',
+  ]);
+  assert.match(fixture.prompt, /newsroom receives tips, verifies evidence/u);
+  assert.match(fixture.prompt, /Do not use external images or runtime CDN scripts/u);
+});
+
+test('Codex invocation uses the project standards skill and writable sandbox', () => {
+  const invocation = buildVisualExplainerInvocation('codex', 'v-ex-1', {
+    projectDir,
+    codexHome,
+  });
+  assert.equal(invocation.command, 'codex');
+  assert.equal(invocation.cwd, projectDir);
+  assert.deepEqual(invocation.env, { CODEX_HOME: codexHome });
+  assert.ok(invocation.args.includes('--ignore-user-config'));
+  assert.ok(invocation.args.includes('--ignore-rules'));
+  assert.ok(invocation.args.includes('--ephemeral'));
+  assert.deepEqual(
+    invocation.args.slice(
+      invocation.args.indexOf('--sandbox'),
+      invocation.args.indexOf('--sandbox') + 2,
+    ),
+    ['--sandbox', 'workspace-write'],
+  );
+  assert.match(invocation.args.at(-1), /^\$visual-explainer Create/u);
+  assert.match(
+    invocation.args.at(-1),
+    /\.agents\/skills\/visual-explainer\/templates\/architecture\.html/u,
+  );
+});
+
+test('authorized unboxed fallback replaces the nested writable sandbox', () => {
+  const invocation = buildVisualExplainerInvocation('codex', 'v-ex-1', {
+    projectDir,
+    codexHome,
+    unboxed: true,
+  });
+  assert.ok(invocation.args.includes('--dangerously-bypass-approvals-and-sandbox'));
+  assert.ok(!invocation.args.includes('--sandbox'));
+});
+
+test('fixture verifier accepts installed resources and semantic ordered output', () => {
+  const root = createFixtureProject();
+  const install = verifyVisualExplainerInstall(root, 'v-ex-1');
+  assert.equal(
+    install.skillRoot,
+    join(root, '.agents', 'skills', 'visual-explainer'),
+  );
+  const output = verifyVisualExplainerOutput(root, 'v-ex-1');
+  assert.equal(output.outputPath, join(root, 'v-ex-1.html'));
+  assert.equal(output.bytes, Buffer.byteLength(validHtml));
+});
+
+test('fixture verifier rejects missing resources and malformed output', () => {
+  const missingResource = createFixtureProject();
+  unlinkSync(join(
+    missingResource,
+    '.agents',
+    'skills',
+    'visual-explainer',
+    'references',
+    'css-patterns.md',
+  ));
+  assert.throws(
+    () => verifyVisualExplainerInstall(missingResource, 'v-ex-1'),
+    /Missing installed resource references\/css-patterns\.md/u,
+  );
+
+  const outOfOrder = createFixtureProject(
+    validHtml.replace('Receive tips', '__TEMP_STAGE__')
+      .replace('Publish corrected story', 'Receive tips')
+      .replace('__TEMP_STAGE__', 'Publish corrected story'),
+  );
+  assert.throws(
+    () => verifyVisualExplainerOutput(outOfOrder, 'v-ex-1'),
+    /Fixture output text is out of order/u,
+  );
+
+  const remoteRuntime = createFixtureProject(
+    validHtml.replace('</head>', '<script src="https://cdn.example/app.js"></script></head>'),
+  );
+  assert.throws(
+    () => verifyVisualExplainerOutput(remoteRuntime, 'v-ex-1'),
+    /must not load a runtime script from a CDN/u,
+  );
+});
+
+test('install verifier rejects a required resource behind a linked parent', () => {
+  const root = createFixtureProject();
+  const skillRoot = join(root, '.agents', 'skills', 'visual-explainer');
+  const externalReferences = join(root, 'external-references');
+  mkdirSync(externalReferences);
+  writeFileSync(join(externalReferences, 'css-patterns.md'), '# External CSS\n');
+  rmSync(join(skillRoot, 'references'), { recursive: true });
+  symlinkSync(externalReferences, join(skillRoot, 'references'), 'dir');
+
+  assert.throws(
+    () => verifyVisualExplainerInstall(root, 'v-ex-1'),
+    /installed resource references\/css-patterns\.md escapes the installed skill root/u,
+  );
+});
+
+test('runtime runner avoids a shell and preserves timeout and environment', () => {
+  const calls = [];
+  runVisualExplainerPilot(
+    {
+      command: 'fixture-client',
+      args: ['--json'],
+      cwd: projectDir,
+      env: { CODEX_HOME: codexHome },
+    },
+    {
+      env: { PATH: '/bin' },
+      run: (command, args, options) => {
+        calls.push({ command, args, options });
+        return { status: 0 };
+      },
+    },
+  );
+
+  assert.equal(VISUAL_EXPLAINER_TIMEOUT_MS, 300_000);
+  assert.equal(calls[0].options.shell, false);
+  assert.equal(calls[0].options.timeout, VISUAL_EXPLAINER_TIMEOUT_MS);
+  assert.deepEqual(calls[0].options.env, {
+    PATH: '/bin',
+    CODEX_HOME: codexHome,
+  });
+});
+
+test('CLI and invocation reject ambiguous or unsupported inputs', () => {
+  assert.throws(
+    () => parseCliArgs(['codex', 'v-ex-1', '--project', '--unboxed']),
+    /--project requires a directory value/u,
+  );
+  assert.throws(
+    () => parseCliArgs(['codex', 'v-ex-1']),
+    /A disposable --project directory is required/u,
+  );
+  assert.throws(
+    () => parseCliArgs(['claude', 'v-ex-1', '--project', projectDir]),
+    /Unsupported visual-explainer pilot client/u,
+  );
+  assert.throws(
+    () => parseCliArgs(['codex', 'toString', '--project', projectDir]),
+    /Unsupported visual-explainer fixture/u,
+  );
+  assert.throws(
+    () => parseCliArgs([
+      'codex',
+      'v-ex-1',
+      '--project',
+      projectDir,
+      '--dry-run',
+      '--verify-only',
+    ]),
+    /cannot be combined/u,
+  );
+  assert.throws(
+    () => buildVisualExplainerInvocation('claude', 'v-ex-1', {
+      projectDir,
+      codexHome,
+    }),
+    /Unsupported visual-explainer pilot client/u,
+  );
+  assert.throws(
+    () => buildVisualExplainerInvocation('codex', 'toString', {
+      projectDir,
+      codexHome,
+    }),
+    /Unsupported visual-explainer fixture/u,
+  );
+  assert.throws(
+    () => buildVisualExplainerInvocation('codex', 'v-ex-1', { projectDir }),
+    /CODEX_HOME is required/u,
+  );
+  assert.deepEqual(
+    parseCliArgs([
+      'codex',
+      'v-ex-1',
+      '--project',
+      projectDir,
+      '--unboxed',
+      '--verify-only',
+    ]),
+    {
+      client: 'codex',
+      fixtureId: 'v-ex-1',
+      projectDir,
+      unboxed: true,
+      dryRun: false,
+      verifyOnly: true,
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- add a repeatable V-ex-1 Codex runner that verifies the installed root skill, required relative resources, semantic output, and runtime-script boundary
- record the successful standards-path runtime, render, accessibility, validator, and legacy root-skill omission evidence
- harden the disposable harness against linked resource parents and ambiguous CLI inputs
- update the compatibility matrix only for the tested Codex project-standards path

## Evidence

- Codex CLI 0.145.0 with skills CLI 1.5.20 discovered `$visual-explainer` from `.agents/skills`
- the 24-file source and installed trees shared manifest digest `83e44cc015b0ebb5b3c19cb5e5f2127b873dec8f5b07d3dc0e3e865d082b6215`
- the installed skill read `references/css-patterns.md` and `templates/architecture.html`, then produced the requested 9,605-byte HTML artifact
- desktop, mobile, light, and dark renders had no overflow or runtime errors; axe reported zero tested WCAG 2.2 A/AA violations
- the legacy-compatible plugin route cached the root file but did not register `$visual-explainer`; three generated command wrappers remain untested and unclaimed

## Verification

- `npm test` — 129/129 passed
- `npm run check:docs-css` — 49 stylesheets current
- pinned official Agent Skills validator — 60/60 passed
- actual generated artifact passed `--verify-only`
- `node --check` passed for the new runner and tests
- `git diff --check` passed
- `npm ci --ignore-scripts` — 0 vulnerabilities

## Boundaries

This does not modify visual-explainer source, add a native Codex adapter, test source commands, or publish a repository-wide Codex support claim. It builds on the merged journalism-core pilot in #247.

Closes #228