### PR TITLE
Migrate the historical Document design lock key

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "canary:journalism-core:codex": "node scripts/journalism-core-install-canary.mjs codex",
     "canary:journalism-core:codex-skills": "node scripts/journalism-core-install-canary.mjs codex-skills",
     "canary:journalism-core:codex-skills-global": "node scripts/journalism-core-install-canary.mjs codex-skills-global",
+    "canary:document-design-lock": "node scripts/document-design-lock-update-canary.mjs",
+    "migrate:document-design-lock": "node scripts/document-design-lock-migration.mjs",
     "pilot:journalism-core": "node scripts/journalism-core-runtime-pilot.mjs",
     "pilot:okf-wiki": "node scripts/okf-wiki-runtime-pilot.mjs",
     "pilot:visual-explainer": "node scripts/visual-explainer-runtime-pilot.mjs",

--- a/plans/2026-07-23-document-design-lock-migration.md
+++ b/plans/2026-07-23-document-design-lock-migration.md
@@ -94,8 +94,12 @@ lock SHA-256: a586c9e6d61b960a0f9f3438efaedfab2a16d6187b5f3b514c530d27e6bcd5d8
 source master: d49ed1022a012269a237f7749b0e47c099e7add6
 ```
 
-The canary checked the public source commit before, between, and after the
-updates, then removed its disposable project, client home, and npm cache:
+The canary resolved the public source first, fetched both source commits into a
+disposable bare repository, and derived the expected tree hash from that
+resolved source rather than the local checkout. This also makes the historical
+replay work from a shallow checkout. It checked the public source commit
+between and after the updates, then removed its disposable project, source
+repository, client home, and npm cache:
 
 ```bash
 npm run canary:document-design-lock

--- a/plans/2026-07-23-document-design-lock-migration.md
+++ b/plans/2026-07-23-document-design-lock-migration.md
@@ -1,0 +1,113 @@
+# Document design lock-key migration
+
+- Date: July 23, 2026
+- Tracking issue: [#230](https://github.com/jamditis/claude-skills-journalism/issues/230)
+- Client: Codex CLI 0.145.0
+- Standards client: skills CLI 1.5.20
+- Runtime: Node.js 22.23.1 and npm 10.9.8
+- Historical source commit:
+  [`64dc95d8584d66e35ceb79e3c43e7fa3d201d3e4`](https://github.com/jamditis/claude-skills-journalism/commit/64dc95d8584d66e35ceb79e3c43e7fa3d201d3e4)
+- Update target:
+  [`d49ed1022a012269a237f7749b0e47c099e7add6`](https://github.com/jamditis/claude-skills-journalism/commit/d49ed1022a012269a237f7749b0e47c099e7add6)
+
+## Scope
+
+The phase-one standards repair changed the skill frontmatter name from
+`Document design` to `document-design`. Older project installs already used
+the canonical `.agents/skills/document-design` directory, but their
+`skills-lock.json` key retained the display-style name.
+
+This evidence covers that local lock identity only. It does not merge catalog
+metrics, alias skills across install roots, change the installed directory, or
+claim Codex activation and output behavior for `pdf-playground`.
+
+## Reproduction
+
+The checked-in fixture records the historical key, repository source, source
+skill path, and content hash:
+
+```text
+scripts/fixtures/document-design-lock-v1.json
+fixture SHA-256: 06c6f36f29dfae539e856456786642047c0bc742c4d231c5460fe58aeecc3ebc
+historical skill hash: 1a388f259e5894a04617d8b599719ec5e1adcf778eec81dbdf8324816b1ed8dc
+installed directory: .agents/skills/document-design
+```
+
+The canary reconstructed the installed skill from the historical commit and
+confirmed that its folder hash matched the lock. It then ran:
+
+```bash
+npx --yes skills@1.5.20 update --project -y
+```
+
+The command exited 1. The updater read `Document design` from the lock and
+reported `Failed to update Document design`. The fixture lock digest and
+installed folder hash remained unchanged. Source-wide deletion preflight also
+printed a non-blocking warning; that warning appeared on the successful
+canonical updates too and is separate from the name failure.
+
+## Migration boundary
+
+Run the explicit repository command from this checkout:
+
+```bash
+npm run migrate:document-design-lock -- --project '<project>'
+```
+
+The command rewrites only an entry with all of these properties:
+
+- key `Document design`;
+- source `jamditis/claude-skills-journalism`;
+- source type `github`;
+- skill path `pdf-playground/skills/document-design/SKILL.md`;
+- a 64-character SHA-256 content hash that matches the installed tree.
+
+It preserves the complete lock record, writes an atomic replacement with the
+existing file mode, and does not edit the installed skill. An identical
+canonical duplicate is collapsed. A conflicting duplicate, unexpected
+source/path/type, malformed lock, linked lock, linked installed directory, or
+path escape stops without rewriting the lock.
+
+This is deliberately not an install lifecycle hook. The migration is visible,
+project-scoped, reversible from version control or a lock backup, and
+independent of public catalog slug history.
+
+## Update and idempotence result
+
+After migration, skills CLI 1.5.20 ran the same project update twice. Both
+updates exited 0 and reported `Updated document-design`. After each run:
+
+- only the `document-design` identity remained;
+- the installed directory was `.agents/skills/document-design`;
+- the source stayed `jamditis/claude-skills-journalism`;
+- the source path stayed
+  `pdf-playground/skills/document-design/SKILL.md`;
+- installed frontmatter used `name: document-design`;
+- the installed tree matched the update target;
+- the lock hash matched the installed tree.
+
+The first and second update produced the same values:
+
+```text
+content hash: 129514adfe5f81dd3095ff4e92cec3a5b86a05103bf6386c0d761ddba74bc335
+lock SHA-256: a586c9e6d61b960a0f9f3438efaedfab2a16d6187b5f3b514c530d27e6bcd5d8
+source master: d49ed1022a012269a237f7749b0e47c099e7add6
+```
+
+The canary checked the public source commit before, between, and after the
+updates, then removed its disposable project and npm cache:
+
+```bash
+npm run canary:document-design-lock
+```
+
+To verify a migrated project without changing it:
+
+```bash
+node scripts/document-design-lock-migration.mjs \
+  --verify --project '<project>'
+```
+
+The pure migration and filesystem boundary tests run in the normal
+`npm test` suite. The live canary stays explicit because it clones the public
+repository and resolves a pinned skills CLI release.

--- a/plans/2026-07-23-document-design-lock-migration.md
+++ b/plans/2026-07-23-document-design-lock-migration.md
@@ -95,7 +95,7 @@ source master: d49ed1022a012269a237f7749b0e47c099e7add6
 ```
 
 The canary checked the public source commit before, between, and after the
-updates, then removed its disposable project and npm cache:
+updates, then removed its disposable project, client home, and npm cache:
 
 ```bash
 npm run canary:document-design-lock

--- a/plans/codex-compatibility-matrix.md
+++ b/plans/codex-compatibility-matrix.md
@@ -34,6 +34,7 @@ Status labels:
 | Repository release verification | [`9eef57629edbaa19bf47ec35296acebdd7b4ab1f`](https://github.com/jamditis/claude-skills-journalism/commit/9eef57629edbaa19bf47ec35296acebdd7b4ab1f) | July 23 post-merge `master` head used for the phase-one release evidence |
 | Repository visual-explainer pilot | [`f6a4b84dd2e9feafc6c2bf067f873e9301a083c2`](https://github.com/jamditis/claude-skills-journalism/commit/f6a4b84dd2e9feafc6c2bf067f873e9301a083c2) | July 23 `master` head installed for the V-ex-1 runtime evidence |
 | Repository okf-wiki pilot | [`cabb43bc2515c6c30a3d0839909f786e7afbcba8`](https://github.com/jamditis/claude-skills-journalism/commit/cabb43bc2515c6c30a3d0839909f786e7afbcba8) | July 23 `master` head installed for the Okf-1 no-Claude runtime evidence |
+| Repository Document design lock pilot | [`d49ed1022a012269a237f7749b0e47c099e7add6`](https://github.com/jamditis/claude-skills-journalism/commit/d49ed1022a012269a237f7749b0e47c099e7add6) | July 23 `master` head used for the D-lock-1 update target |
 | Claude Code | 2.1.215; 2.1.218 | Phase-one marketplace validation, then the post-merge clean `journalism-core` install |
 | Codex CLI | 0.145.0 | Legacy-compatible marketplace and clean `journalism-core` install |
 | skills CLI | 1.5.19; 1.5.20 | Phase-one standards discovery, then post-merge project and user install canaries |
@@ -351,6 +352,28 @@ Codex project behavior. Removing the installed skill left the generated
 project intact and valid, while the empty lock entry, Claude adapter directory,
 and OKF user data remained independently removable.
 
+### D-lock-release-1: Document design standards lock migration
+
+Environment: Codex CLI 0.145.0 with a disposable skills CLI 1.5.20 project on
+July 23, 2026. The
+[migration record](2026-07-23-document-design-lock-migration.md) contains the
+historical fixture, exact source commits, hashes, failure, migration boundary,
+two update passes, verification, and cleanup.
+
+Result: skills CLI 1.5.20 exited 1 when its project updater passed the
+historical `Document design` lock key back to the current repository. The
+explicit repository migration renamed only the exact
+`jamditis/claude-skills-journalism` and
+`pdf-playground/skills/document-design/SKILL.md` identity. It left the
+installed directory and complete record intact, rejected ambiguous inputs, and
+did not run automatically.
+
+After migration, two consecutive skills CLI updates exited 0. Exactly one
+`document-design` lock identity remained; its repository source, skill path,
+installed directory, frontmatter, and content hash matched. The second update
+left the lock and installed-tree digests unchanged. This is local lock
+migration evidence, not public catalog history or a mixed-install claim.
+
 ## Package matrix
 
 | Package | Version and components | Current classification | Included and excluded scope | Evidence | Next proof |
@@ -360,7 +383,7 @@ and OKF user data remained independently removable.
 | `journalism-core` | 1.2.0; 14 nested skills | Runtime pilot passed on the Claude package and Codex project-standards paths | Include the 14 shared skills. No commands, agents, or hooks are part of this package. The legacy-compatible Codex package and user-level standards paths remain install-only. | [J-release-1](#j-release-1-paired-journalism-core-runtime-pilot), [C-phase-1](#c-phase-1-repeatable-claude-install-canary), [K-phase-1](#k-phase-1-repeatable-codex-legacy-package-canary), [S-phase-1](#s-phase-1-full-journalism-core-standards-canary), [S-global-phase-1](#s-global-phase-1-user-level-journalism-core-standards-canary), [V-phase-1](#v-phase-1-repaired-standards-baseline) | Add a no-Claude-environment gate and scheduled runtime regression before a broader package support claim. |
 | `okf-wiki` | 0.6.1; one root skill; scripts and generated Claude settings | Pre-set portable runtime pilot passed; instruction and Claude-output adapters remain | Include the tested Okf-1 path: standards discovery, installed spec and scaffolder reads, explicit project-relative scaffolding, validation, examples, and the generated OKF bundle. Exclude the unadapted general instructions that name `AskUserQuestion` and `${CLAUDE_SKILL_DIR}`. The generated `.claude/settings.json` and hook scripts are an inert Claude Code adapter, not Codex configuration or lifecycle behavior. | [Okf-release-1](#okf-release-1-okf-wiki-no-claude-runtime-pilot), [V-phase-1](#v-phase-1-repaired-standards-baseline), and [R-phase-1](#r-phase-1-phase-one-repository-checks) | Port and test general onboarding and skill-root resolution; add scheduled Okf-1 coverage against current Codex; test mixed-client hook trust separately before any cross-client lifecycle claim. |
 | `pdf-design` | 1.1.0; one root skill | Adapter required | Shared design guidance and assets are candidates. Hard-coded `~/.claude` and host-specific browser paths are excluded from a Codex claim. | [V-phase-1](#v-phase-1-repaired-standards-baseline) covers structure | Add a no-Claude path-resolution fixture before editing paths. |
-| `pdf-playground` | 1.3.2; one nested skill; eight commands; one hook file | Candidate plus Claude-only surfaces | `document-design` is shared. Commands and hook behavior remain Claude-only until mapped. | [V-phase-1](#v-phase-1-repaired-standards-baseline) and [F-phase-1](#f-phase-1-affected-claude-package-regression); standards, Claude install, and argument delivery pass | Test Codex activation, non-activation, resource loading, and output before a runtime claim. |
+| `pdf-playground` | 1.3.2; one nested skill; eight commands; one hook file | Candidate plus Claude-only surfaces | `document-design` is shared. Its historical project lock identity has an explicit migration. Commands and hook behavior remain Claude-only until mapped. | [D-lock-release-1](#d-lock-release-1-document-design-standards-lock-migration), [V-phase-1](#v-phase-1-repaired-standards-baseline), and [F-phase-1](#f-phase-1-affected-claude-package-regression); lock migration, standards, Claude install, and argument delivery pass | Test Codex activation, non-activation, resource loading, and output before a runtime claim. |
 | `project-templates-toolkit` | 1.0.0; three nested skills | Adapter required | Retrospective and template selection may be shared. `project-memory` must distinguish `CLAUDE.md` from `AGENTS.md` scope. | [V-phase-1](#v-phase-1-repaired-standards-baseline) covers structure | Add paired Claude/Codex project-memory fixtures before changing generated instructions. |
 | `research-toolkit` | 1.1.0; six nested skills | Candidate | Include shared instruction-led skills. Network and external-content trust boundaries stay unchanged. | [V-phase-1](#v-phase-1-repaired-standards-baseline) covers structure | Add representative activation, non-activation, network-boundary, and resource checks. |
 | `security-toolkit` | 1.2.0; four nested skills; one command | Candidate plus Claude-only surface | The four shared skills are candidates. `/security-toolkit:hotpatch` and its sandbox lifecycle remain Claude-only. | [V-phase-1](#v-phase-1-repaired-standards-baseline) covers structure; [R-phase-1](#r-phase-1-phase-one-repository-checks) covers security tests | Test skill activation separately; do not map `hotpatch` without authority and failure-semantics tests. |
@@ -487,9 +510,10 @@ alias or restoration for the same repository, path, and slug; another source
 rename would create more identity churn and is not a recovery. Track that
 catalog-side request with #219 and the upstream stale-snapshot report above.
 
-Issue #230 separately tests an update fixture whose old lock key is
-`Document design` so local normalization cannot leave two lock entries for one
-directory.
+[D-lock-release-1](#d-lock-release-1-document-design-standards-lock-migration)
+separately proves the local `Document design` lock migration and prevents two
+lock identities from remaining for one installed directory. That project
+migration neither restores nor changes public catalog metrics.
 
 ## Mixed-install cases still pending
 

--- a/scripts/codex-compatibility-docs.test.mjs
+++ b/scripts/codex-compatibility-docs.test.mjs
@@ -53,6 +53,7 @@ test('the compatibility matrix classifies every marketplace package', () => {
   assert.match(matrix, /J-release-1: paired journalism-core runtime pilot/u);
   assert.match(matrix, /V-ex-release-1: visual-explainer root-skill runtime pilot/u);
   assert.match(matrix, /Okf-release-1: okf-wiki no-Claude runtime pilot/u);
+  assert.match(matrix, /D-lock-release-1: Document design standards lock migration/u);
   assert.match(
     matrix,
     /`journalism-core` \| 1\.2\.0; 14 nested skills \| Runtime pilot passed on the Claude package and Codex project-standards paths/u,
@@ -71,6 +72,7 @@ test('the compatibility matrix classifies every marketplace package', () => {
   );
   assert.match(matrix, /scripts\/okf-wiki-runtime-pilot\.mjs/u);
   assert.match(matrix, /scripts\/visual-explainer-runtime-pilot\.mjs/u);
+  assert.match(matrix, /2026-07-23-document-design-lock-migration\.md/u);
 
   const evidenceCells = matrix
     .split('\n')
@@ -80,6 +82,34 @@ test('the compatibility matrix classifies every marketplace package', () => {
   for (const evidence of evidenceCells) {
     assert.match(evidence, /\[[^\]]+\]\(#[^)]+\)/u);
   }
+});
+
+test('Document design lock evidence stays separate from catalog history', () => {
+  const record = readFileSync(
+    join(ROOT, 'plans', '2026-07-23-document-design-lock-migration.md'),
+    'utf8',
+  );
+  const matrix = readFileSync(
+    join(ROOT, 'plans', 'codex-compatibility-matrix.md'),
+    'utf8',
+  );
+
+  assert.match(record, /Tracking issue: \[#230\]/u);
+  assert.match(record, /Codex CLI 0\.145\.0/u);
+  assert.match(record, /skills CLI 1\.5\.20/u);
+  assert.match(record, /64dc95d8584d66e35ceb79e3c43e7fa3d201d3e4/u);
+  assert.match(record, /d49ed1022a012269a237f7749b0e47c099e7add6/u);
+  assert.match(record, /06c6f36f29dfae539e856456786642047c0bc742c4d231c5460fe58aeecc3ebc/u);
+  assert.match(record, /1a388f259e5894a04617d8b599719ec5e1adcf778eec81dbdf8324816b1ed8dc/u);
+  assert.match(record, /129514adfe5f81dd3095ff4e92cec3a5b86a05103bf6386c0d761ddba74bc335/u);
+  assert.match(record, /a586c9e6d61b960a0f9f3438efaedfab2a16d6187b5f3b514c530d27e6bcd5d8/u);
+  assert.match(record, /Both\s+updates exited 0/u);
+  assert.match(record, /independent of public catalog slug history/u);
+  assert.match(matrix, /This is local lock\s+migration evidence, not public catalog history/u);
+  assert.match(
+    matrix,
+    /That project\s+migration neither restores nor changes public catalog metrics/u,
+  );
 });
 
 test('okf-wiki no-Claude evidence keeps Claude adapters outside Codex behavior', () => {

--- a/scripts/document-design-lock-migration.mjs
+++ b/scripts/document-design-lock-migration.mjs
@@ -1,0 +1,302 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import {
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { isAbsolute, join, relative, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { isDeepStrictEqual } from 'node:util';
+
+export const LEGACY_SKILL_NAME = 'Document design';
+export const CANONICAL_SKILL_NAME = 'document-design';
+
+const EXPECTED_SOURCE = 'jamditis/claude-skills-journalism';
+const EXPECTED_SOURCE_TYPE = 'github';
+const EXPECTED_SKILL_PATH = 'pdf-playground/skills/document-design/SKILL.md';
+const LOCK_FILE_NAME = 'skills-lock.json';
+const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
+
+function isRecord(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function assertLockShape(lock) {
+  if (!isRecord(lock) || lock.version !== 1 || !isRecord(lock.skills)) {
+    throw new Error('skills-lock.json must contain a version 1 skills object');
+  }
+}
+
+function assertExpectedIdentity(record) {
+  if (
+    !isRecord(record)
+    || record.source !== EXPECTED_SOURCE
+    || record.sourceType !== EXPECTED_SOURCE_TYPE
+    || record.skillPath !== EXPECTED_SKILL_PATH
+    || typeof record.computedHash !== 'string'
+    || !SHA256_PATTERN.test(record.computedHash)
+  ) {
+    throw new Error(`refusing to migrate ambiguous ${LEGACY_SKILL_NAME} lock entry`);
+  }
+}
+
+function sortSkills(skills) {
+  return Object.fromEntries(
+    Object.entries(skills).sort(([left], [right]) => {
+      if (left < right) return -1;
+      if (left > right) return 1;
+      return 0;
+    }),
+  );
+}
+
+export function migrateDocumentDesignLock(lock) {
+  assertLockShape(lock);
+  const migratedLock = structuredClone(lock);
+  const legacy = migratedLock.skills[LEGACY_SKILL_NAME];
+  const canonical = migratedLock.skills[CANONICAL_SKILL_NAME];
+
+  if (legacy === undefined) {
+    if (canonical !== undefined) assertExpectedIdentity(canonical);
+    return {
+      lock: migratedLock,
+      status: canonical === undefined ? 'absent' : 'current',
+    };
+  }
+
+  assertExpectedIdentity(legacy);
+  if (canonical !== undefined) {
+    assertExpectedIdentity(canonical);
+    if (!isDeepStrictEqual(legacy, canonical)) {
+      throw new Error('conflicting legacy and canonical lock entries require manual recovery');
+    }
+    delete migratedLock.skills[LEGACY_SKILL_NAME];
+    migratedLock.skills = sortSkills(migratedLock.skills);
+    return { lock: migratedLock, status: 'collapsed' };
+  }
+
+  delete migratedLock.skills[LEGACY_SKILL_NAME];
+  migratedLock.skills[CANONICAL_SKILL_NAME] = legacy;
+  migratedLock.skills = sortSkills(migratedLock.skills);
+  return { lock: migratedLock, status: 'migrated' };
+}
+
+function assertContainedPath(projectRoot, path, label) {
+  const realPath = realpathSync(path);
+  const pathFromRoot = relative(projectRoot, realPath);
+  if (
+    pathFromRoot === ''
+    || pathFromRoot.startsWith('..')
+    || isAbsolute(pathFromRoot)
+  ) {
+    throw new Error(`${label} escaped the project root`);
+  }
+  return realPath;
+}
+
+function verifyProjectPaths(project) {
+  const projectRoot = realpathSync(resolve(project));
+  const lockPath = join(projectRoot, LOCK_FILE_NAME);
+  const lockStat = lstatSync(lockPath);
+  if (lockStat.isSymbolicLink()) throw new Error(`${LOCK_FILE_NAME} must not be a symbolic link`);
+  if (!lockStat.isFile()) throw new Error(`${LOCK_FILE_NAME} must be a regular file`);
+  assertContainedPath(projectRoot, lockPath, LOCK_FILE_NAME);
+
+  const installedPath = join(
+    projectRoot,
+    '.agents',
+    'skills',
+    CANONICAL_SKILL_NAME,
+  );
+  const installedStat = lstatSync(installedPath);
+  if (installedStat.isSymbolicLink()) {
+    throw new Error(`installed ${CANONICAL_SKILL_NAME} path is a symbolic link`);
+  }
+  if (!installedStat.isDirectory()) {
+    throw new Error(`installed ${CANONICAL_SKILL_NAME} path must be a directory`);
+  }
+  assertContainedPath(projectRoot, installedPath, `installed ${CANONICAL_SKILL_NAME} path`);
+
+  return { installedPath, lockPath, lockStat, projectRoot };
+}
+
+function readProjectLock(lockPath) {
+  try {
+    return JSON.parse(readFileSync(lockPath, 'utf8'));
+  } catch (error) {
+    throw new Error(`could not parse ${LOCK_FILE_NAME}: ${error.message}`);
+  }
+}
+
+function collectSkillFiles(basePath, directory, files) {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isSymbolicLink()) {
+      throw new Error(`installed ${CANONICAL_SKILL_NAME} contains a symbolic link`);
+    }
+    if (entry.isDirectory()) {
+      if (entry.name !== '.git' && entry.name !== 'node_modules') {
+        collectSkillFiles(basePath, path, files);
+      }
+      continue;
+    }
+    if (!entry.isFile()) {
+      throw new Error(`installed ${CANONICAL_SKILL_NAME} contains a non-file resource`);
+    }
+    files.push({
+      content: readFileSync(path),
+      relativePath: relative(basePath, path).replaceAll('\\', '/'),
+    });
+  }
+}
+
+export function computeSkillFolderHash(skillPath) {
+  const files = [];
+  collectSkillFiles(skillPath, skillPath, files);
+  files.sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+  const hash = createHash('sha256');
+  for (const file of files) {
+    hash.update(file.relativePath);
+    hash.update(file.content);
+  }
+  return hash.digest('hex');
+}
+
+export function verifyCanonicalDocumentDesignProject(project) {
+  const { installedPath, lockPath } = verifyProjectPaths(project);
+  const lock = readProjectLock(lockPath);
+  assertLockShape(lock);
+  if (lock.skills[LEGACY_SKILL_NAME] !== undefined) {
+    throw new Error(`${LEGACY_SKILL_NAME} lock identity still exists`);
+  }
+  const record = lock.skills[CANONICAL_SKILL_NAME];
+  if (record === undefined) {
+    throw new Error(`${CANONICAL_SKILL_NAME} lock identity is missing`);
+  }
+  assertExpectedIdentity(record);
+
+  const skill = readFileSync(join(installedPath, 'SKILL.md'), 'utf8');
+  if (!/^name: document-design$/mu.test(skill)) {
+    throw new Error(`installed ${CANONICAL_SKILL_NAME} frontmatter is not canonical`);
+  }
+  const computedHash = computeSkillFolderHash(installedPath);
+  if (computedHash !== record.computedHash) {
+    throw new Error(`installed ${CANONICAL_SKILL_NAME} content hash does not match the lock`);
+  }
+  return { computedHash, installedPath, lockPath, record };
+}
+
+function writeLockAtomically(lockPath, lock, mode) {
+  const temporaryPath = `${lockPath}.migration-${process.pid}-${Date.now()}`;
+  const serialized = `${JSON.stringify(lock, null, 2)}\n`;
+  try {
+    writeFileSync(temporaryPath, serialized, { encoding: 'utf8', flag: 'wx', mode });
+    renameSync(temporaryPath, lockPath);
+  } catch (error) {
+    try {
+      unlinkSync(temporaryPath);
+    } catch {}
+    throw error;
+  }
+}
+
+export function migrateDocumentDesignProject(project, { write = true } = {}) {
+  const { installedPath, lockPath, lockStat } = verifyProjectPaths(project);
+  const parsed = readProjectLock(lockPath);
+  const result = migrateDocumentDesignLock(parsed);
+  if (result.status === 'migrated' || result.status === 'collapsed') {
+    const installedHash = computeSkillFolderHash(installedPath);
+    const lockedHash = parsed.skills[LEGACY_SKILL_NAME].computedHash;
+    if (installedHash !== lockedHash) {
+      throw new Error(
+        `installed ${CANONICAL_SKILL_NAME} content hash does not match the legacy lock`,
+      );
+    }
+  }
+  if (write && (result.status === 'migrated' || result.status === 'collapsed')) {
+    writeLockAtomically(lockPath, result.lock, lockStat.mode & 0o777);
+  }
+  return result;
+}
+
+function usage() {
+  return [
+    'Usage: node scripts/document-design-lock-migration.mjs [options]',
+    '',
+    'Options:',
+    '  --project <path>  Project containing skills-lock.json (default: current directory)',
+    '  --check           Report whether migration is required without writing',
+    '  --verify          Verify the post-update canonical identity and content hash',
+    '  --help            Show this help',
+  ].join('\n');
+}
+
+function parseArguments(args) {
+  const options = { check: false, project: process.cwd(), verify: false };
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === '--check') {
+      options.check = true;
+    } else if (argument === '--verify') {
+      options.verify = true;
+    } else if (argument === '--project') {
+      index += 1;
+      if (!args[index]) throw new Error('--project requires a path');
+      options.project = args[index];
+    } else if (argument === '--help') {
+      options.help = true;
+    } else {
+      throw new Error(`unknown argument: ${argument}`);
+    }
+  }
+  if (options.check && options.verify) {
+    throw new Error('--check and --verify cannot be combined');
+  }
+  return options;
+}
+
+function runCli(args) {
+  const options = parseArguments(args);
+  if (options.help) {
+    console.log(usage());
+    return;
+  }
+  if (options.verify) {
+    const result = verifyCanonicalDocumentDesignProject(options.project);
+    console.log(
+      `Verified ${CANONICAL_SKILL_NAME} lock identity, installed path, and content hash ${result.computedHash}.`,
+    );
+    return;
+  }
+
+  const result = migrateDocumentDesignProject(options.project, { write: !options.check });
+  if (options.check && (result.status === 'migrated' || result.status === 'collapsed')) {
+    console.error(`${LOCK_FILE_NAME} requires ${LEGACY_SKILL_NAME} key migration`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const messages = {
+    absent: `No ${LEGACY_SKILL_NAME} or ${CANONICAL_SKILL_NAME} lock entry found.`,
+    collapsed: `Collapsed identical ${LEGACY_SKILL_NAME} and ${CANONICAL_SKILL_NAME} lock entries.`,
+    current: `${CANONICAL_SKILL_NAME} lock identity is already current.`,
+    migrated: `Migrated ${LEGACY_SKILL_NAME} lock identity to ${CANONICAL_SKILL_NAME}.`,
+  };
+  console.log(messages[result.status]);
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : '';
+if (invokedPath === import.meta.url) {
+  try {
+    runCli(process.argv.slice(2));
+  } catch (error) {
+    assert(error instanceof Error);
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/document-design-lock-migration.mjs
+++ b/scripts/document-design-lock-migration.mjs
@@ -99,7 +99,7 @@ function assertContainedPath(projectRoot, path, label) {
   return realPath;
 }
 
-function verifyProjectPaths(project) {
+function verifyLockPath(project) {
   const projectRoot = realpathSync(resolve(project));
   const lockPath = join(projectRoot, LOCK_FILE_NAME);
   const lockStat = lstatSync(lockPath);
@@ -107,6 +107,10 @@ function verifyProjectPaths(project) {
   if (!lockStat.isFile()) throw new Error(`${LOCK_FILE_NAME} must be a regular file`);
   assertContainedPath(projectRoot, lockPath, LOCK_FILE_NAME);
 
+  return { lockPath, lockStat, projectRoot };
+}
+
+function verifyInstalledPath(projectRoot) {
   const installedPath = join(
     projectRoot,
     '.agents',
@@ -122,7 +126,7 @@ function verifyProjectPaths(project) {
   }
   assertContainedPath(projectRoot, installedPath, `installed ${CANONICAL_SKILL_NAME} path`);
 
-  return { installedPath, lockPath, lockStat, projectRoot };
+  return installedPath;
 }
 
 function readProjectLock(lockPath) {
@@ -168,7 +172,7 @@ export function computeSkillFolderHash(skillPath) {
 }
 
 export function verifyCanonicalDocumentDesignProject(project) {
-  const { installedPath, lockPath } = verifyProjectPaths(project);
+  const { lockPath, projectRoot } = verifyLockPath(project);
   const lock = readProjectLock(lockPath);
   assertLockShape(lock);
   if (lock.skills[LEGACY_SKILL_NAME] !== undefined) {
@@ -180,8 +184,13 @@ export function verifyCanonicalDocumentDesignProject(project) {
   }
   assertExpectedIdentity(record);
 
+  const installedPath = verifyInstalledPath(projectRoot);
   const skill = readFileSync(join(installedPath, 'SKILL.md'), 'utf8');
-  if (!/^name: document-design$/mu.test(skill)) {
+  const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/u.exec(skill)?.[1];
+  const nameLines = frontmatter
+    ?.split(/\r?\n/u)
+    .filter((line) => /^name:/u.test(line)) ?? [];
+  if (nameLines.length !== 1 || !/^name:[ \t]*document-design[ \t]*$/u.test(nameLines[0])) {
     throw new Error(`installed ${CANONICAL_SKILL_NAME} frontmatter is not canonical`);
   }
   const computedHash = computeSkillFolderHash(installedPath);
@@ -206,9 +215,12 @@ function writeLockAtomically(lockPath, lock, mode) {
 }
 
 export function migrateDocumentDesignProject(project, { write = true } = {}) {
-  const { installedPath, lockPath, lockStat } = verifyProjectPaths(project);
+  const { lockPath, lockStat, projectRoot } = verifyLockPath(project);
   const parsed = readProjectLock(lockPath);
   const result = migrateDocumentDesignLock(parsed);
+  if (result.status === 'absent') return result;
+
+  const installedPath = verifyInstalledPath(projectRoot);
   if (result.status === 'migrated' || result.status === 'collapsed') {
     const installedHash = computeSkillFolderHash(installedPath);
     const lockedHash = parsed.skills[LEGACY_SKILL_NAME].computedHash;

--- a/scripts/document-design-lock-migration.test.mjs
+++ b/scripts/document-design-lock-migration.test.mjs
@@ -239,6 +239,8 @@ test('package scripts keep migration explicit and the live updater canary separa
   assert.match(canary, /assertStatus\(prechange, 1/u);
   assert.match(canary, /assertStatus\(firstUpdate, 0/u);
   assert.match(canary, /assertStatus\(secondUpdate, 0/u);
+  assert.match(canary, /HOME: clientHome/u);
+  assert.match(canary, /USERPROFILE: clientHome/u);
   assert.match(canary, /removeCanaryRoot\(canaryRoot\)/u);
   assert.doesNotMatch(canary, /shell:\s*true/u);
 });

--- a/scripts/document-design-lock-migration.test.mjs
+++ b/scripts/document-design-lock-migration.test.mjs
@@ -1,0 +1,244 @@
+import assert from 'node:assert/strict';
+import {
+  chmodSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  CANONICAL_SKILL_NAME,
+  LEGACY_SKILL_NAME,
+  computeSkillFolderHash,
+  migrateDocumentDesignLock,
+  migrateDocumentDesignProject,
+  verifyCanonicalDocumentDesignProject,
+} from './document-design-lock-migration.mjs';
+
+const FIXTURE_PATH = new URL('./fixtures/document-design-lock-v1.json', import.meta.url);
+
+function readFixture() {
+  return JSON.parse(readFileSync(FIXTURE_PATH, 'utf8'));
+}
+
+function makeProject(t, lock = readFixture()) {
+  const project = mkdtempSync(join(tmpdir(), 'document-design-lock-test-'));
+  t.after(() => rmSync(project, { recursive: true, force: true }));
+  mkdirSync(join(project, '.agents', 'skills', CANONICAL_SKILL_NAME), { recursive: true });
+  writeFileSync(
+    join(project, '.agents', 'skills', CANONICAL_SKILL_NAME, 'SKILL.md'),
+    '---\nname: Document design\ndescription: Historical fixture\n---\n',
+  );
+  const projectLock = structuredClone(lock);
+  const installedHash = computeSkillFolderHash(
+    join(project, '.agents', 'skills', CANONICAL_SKILL_NAME),
+  );
+  for (const name of [LEGACY_SKILL_NAME, CANONICAL_SKILL_NAME]) {
+    if (projectLock.skills[name]) projectLock.skills[name].computedHash = installedHash;
+  }
+  writeFileSync(
+    join(project, 'skills-lock.json'),
+    `${JSON.stringify(projectLock, null, 2)}\n`,
+  );
+  return project;
+}
+
+test('the fixture captures the historical lock key, source path, and installed path', (t) => {
+  const fixture = readFixture();
+  const project = makeProject(t, fixture);
+
+  assert.deepEqual(Object.keys(fixture.skills), [LEGACY_SKILL_NAME]);
+  assert.equal(
+    fixture.skills[LEGACY_SKILL_NAME].skillPath,
+    'pdf-playground/skills/document-design/SKILL.md',
+  );
+  assert.equal(
+    lstatSync(join(project, '.agents', 'skills', CANONICAL_SKILL_NAME)).isDirectory(),
+    true,
+  );
+});
+
+test('the migration renames only the exact legacy identity and preserves its record', () => {
+  const fixture = readFixture();
+  const originalRecord = structuredClone(fixture.skills[LEGACY_SKILL_NAME]);
+  const result = migrateDocumentDesignLock(fixture);
+
+  assert.equal(result.status, 'migrated');
+  assert.deepEqual(Object.keys(result.lock.skills), [CANONICAL_SKILL_NAME]);
+  assert.deepEqual(result.lock.skills[CANONICAL_SKILL_NAME], originalRecord);
+  assert.deepEqual(Object.keys(fixture.skills), [LEGACY_SKILL_NAME]);
+});
+
+test('a second migration is byte-for-byte idempotent', (t) => {
+  const project = makeProject(t);
+  const first = migrateDocumentDesignProject(project);
+  const firstBytes = readFileSync(join(project, 'skills-lock.json'));
+  const second = migrateDocumentDesignProject(project);
+  const secondBytes = readFileSync(join(project, 'skills-lock.json'));
+
+  assert.equal(first.status, 'migrated');
+  assert.equal(second.status, 'current');
+  assert.deepEqual(secondBytes, firstBytes);
+  assert.equal(
+    readFileSync(
+      join(project, '.agents', 'skills', CANONICAL_SKILL_NAME, 'SKILL.md'),
+      'utf8',
+    ),
+    '---\nname: Document design\ndescription: Historical fixture\n---\n',
+  );
+});
+
+test('an identical duplicate is collapsed without changing the canonical record', () => {
+  const fixture = readFixture();
+  const record = structuredClone(fixture.skills[LEGACY_SKILL_NAME]);
+  fixture.skills[CANONICAL_SKILL_NAME] = structuredClone(record);
+  const result = migrateDocumentDesignLock(fixture);
+
+  assert.equal(result.status, 'collapsed');
+  assert.deepEqual(Object.keys(result.lock.skills), [CANONICAL_SKILL_NAME]);
+  assert.deepEqual(result.lock.skills[CANONICAL_SKILL_NAME], record);
+});
+
+test('conflicting duplicate identities fail closed', () => {
+  const fixture = readFixture();
+  fixture.skills[CANONICAL_SKILL_NAME] = {
+    ...fixture.skills[LEGACY_SKILL_NAME],
+    computedHash: 'f'.repeat(64),
+  };
+
+  assert.throws(
+    () => migrateDocumentDesignLock(fixture),
+    /conflicting legacy and canonical lock entries/u,
+  );
+});
+
+test('unrelated source, path, type, or malformed hashes fail closed', () => {
+  for (const patch of [
+    { source: 'someone/another-repository' },
+    { sourceType: 'local' },
+    { skillPath: 'another/path/SKILL.md' },
+    { computedHash: 'not-a-sha256' },
+  ]) {
+    const fixture = readFixture();
+    Object.assign(fixture.skills[LEGACY_SKILL_NAME], patch);
+    assert.throws(
+      () => migrateDocumentDesignLock(fixture),
+      /refusing to migrate ambiguous Document design lock entry/u,
+    );
+  }
+});
+
+test('missing locks, linked locks, and linked installed paths are rejected', (t) => {
+  const missing = mkdtempSync(join(tmpdir(), 'document-design-lock-missing-'));
+  t.after(() => rmSync(missing, { recursive: true, force: true }));
+  assert.throws(() => migrateDocumentDesignProject(missing), /skills-lock\.json/u);
+
+  const linkedLockProject = makeProject(t);
+  const realLock = join(linkedLockProject, 'real-lock.json');
+  writeFileSync(realLock, readFileSync(join(linkedLockProject, 'skills-lock.json')));
+  rmSync(join(linkedLockProject, 'skills-lock.json'));
+  symlinkSync(realLock, join(linkedLockProject, 'skills-lock.json'));
+  assert.throws(() => migrateDocumentDesignProject(linkedLockProject), /symbolic link/u);
+
+  const linkedInstallProject = makeProject(t);
+  const linkedInstall = join(linkedInstallProject, '.agents', 'skills', CANONICAL_SKILL_NAME);
+  rmSync(linkedInstall, { recursive: true });
+  symlinkSync(tmpdir(), linkedInstall, 'dir');
+  assert.throws(
+    () => migrateDocumentDesignProject(linkedInstallProject),
+    /installed document-design path is a symbolic link/u,
+  );
+});
+
+test('atomic replacement preserves the lock file mode', (t) => {
+  const project = makeProject(t);
+  const lockPath = join(project, 'skills-lock.json');
+  chmodSync(lockPath, 0o640);
+
+  migrateDocumentDesignProject(project);
+
+  assert.equal(lstatSync(lockPath).mode & 0o777, 0o640);
+});
+
+test('migration rejects an installed tree whose content has drifted from the legacy lock', (t) => {
+  const project = makeProject(t);
+  writeFileSync(
+    join(project, '.agents', 'skills', CANONICAL_SKILL_NAME, 'drift.md'),
+    'changed after install',
+  );
+
+  assert.throws(
+    () => migrateDocumentDesignProject(project),
+    /content hash does not match the legacy lock/u,
+  );
+  const lock = JSON.parse(readFileSync(join(project, 'skills-lock.json'), 'utf8'));
+  assert.deepEqual(Object.keys(lock.skills), [LEGACY_SKILL_NAME]);
+});
+
+test('post-update verification checks the canonical path, source, frontmatter, and hash', (t) => {
+  const project = makeProject(t);
+  const installedPath = join(project, '.agents', 'skills', CANONICAL_SKILL_NAME);
+  writeFileSync(
+    join(installedPath, 'SKILL.md'),
+    '---\nname: document-design\ndescription: Current fixture\n---\n',
+  );
+  const fixture = readFixture();
+  const record = {
+    ...fixture.skills[LEGACY_SKILL_NAME],
+    computedHash: computeSkillFolderHash(installedPath),
+  };
+  writeFileSync(
+    join(project, 'skills-lock.json'),
+    `${JSON.stringify({
+      version: 1,
+      skills: { [CANONICAL_SKILL_NAME]: record },
+    }, null, 2)}\n`,
+  );
+
+  const result = verifyCanonicalDocumentDesignProject(project);
+  assert.equal(result.computedHash, record.computedHash);
+  assert.equal(result.record.source, 'jamditis/claude-skills-journalism');
+  assert.equal(
+    result.record.skillPath,
+    'pdf-playground/skills/document-design/SKILL.md',
+  );
+
+  writeFileSync(join(installedPath, 'changed.md'), 'drift');
+  assert.throws(
+    () => verifyCanonicalDocumentDesignProject(project),
+    /content hash does not match/u,
+  );
+});
+
+test('package scripts keep migration explicit and the live updater canary separate', () => {
+  const packageJson = JSON.parse(
+    readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+  );
+  assert.equal(
+    packageJson.scripts['migrate:document-design-lock'],
+    'node scripts/document-design-lock-migration.mjs',
+  );
+  assert.equal(
+    packageJson.scripts['canary:document-design-lock'],
+    'node scripts/document-design-lock-update-canary.mjs',
+  );
+
+  const canary = readFileSync(
+    new URL('./document-design-lock-update-canary.mjs', import.meta.url),
+    'utf8',
+  );
+  assert.match(canary, /SKILLS_CLI_VERSION = '1\.5\.20'/u);
+  assert.match(canary, /CODEX_CLI_VERSION = '0\.145\.0'/u);
+  assert.match(canary, /assertStatus\(prechange, 1/u);
+  assert.match(canary, /assertStatus\(firstUpdate, 0/u);
+  assert.match(canary, /assertStatus\(secondUpdate, 0/u);
+  assert.match(canary, /removeCanaryRoot\(canaryRoot\)/u);
+  assert.doesNotMatch(canary, /shell:\s*true/u);
+});

--- a/scripts/document-design-lock-migration.test.mjs
+++ b/scripts/document-design-lock-migration.test.mjs
@@ -217,6 +217,54 @@ test('post-update verification checks the canonical path, source, frontmatter, a
   );
 });
 
+test('verification reads only the leading frontmatter name', (t) => {
+  const project = makeProject(t);
+  const installedPath = join(project, '.agents', 'skills', CANONICAL_SKILL_NAME);
+  writeFileSync(
+    join(installedPath, 'SKILL.md'),
+    [
+      '---',
+      'name: Document design',
+      'description: Stale frontmatter fixture',
+      '---',
+      '',
+      'Example:',
+      'name: document-design',
+      '',
+    ].join('\n'),
+  );
+  const fixture = readFixture();
+  const record = {
+    ...fixture.skills[LEGACY_SKILL_NAME],
+    computedHash: computeSkillFolderHash(installedPath),
+  };
+  writeFileSync(
+    join(project, 'skills-lock.json'),
+    `${JSON.stringify({
+      version: 1,
+      skills: { [CANONICAL_SKILL_NAME]: record },
+    }, null, 2)}\n`,
+  );
+
+  assert.throws(
+    () => verifyCanonicalDocumentDesignProject(project),
+    /frontmatter is not canonical/u,
+  );
+});
+
+test('a project without either lock identity is a no-op without an installed directory', (t) => {
+  const project = mkdtempSync(join(tmpdir(), 'document-design-lock-absent-'));
+  t.after(() => rmSync(project, { recursive: true, force: true }));
+  writeFileSync(
+    join(project, 'skills-lock.json'),
+    '{\n  "version": 1,\n  "skills": {}\n}\n',
+  );
+
+  const result = migrateDocumentDesignProject(project);
+  assert.equal(result.status, 'absent');
+  assert.deepEqual(result.lock.skills, {});
+});
+
 test('package scripts keep migration explicit and the live updater canary separate', () => {
   const packageJson = JSON.parse(
     readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
@@ -241,6 +289,12 @@ test('package scripts keep migration explicit and the live updater canary separa
   assert.match(canary, /assertStatus\(secondUpdate, 0/u);
   assert.match(canary, /HOME: clientHome/u);
   assert.match(canary, /USERPROFILE: clientHome/u);
+  assert.match(canary, /git[\s\S]*fetch[\s\S]*HISTORICAL_SOURCE_COMMIT/u);
+  assert.match(canary, /materializeSkillTree\([\s\S]*sourceCommit/u);
+  assert.doesNotMatch(
+    canary,
+    /computeSkillFolderHash\(join\(ROOT, SOURCE_SKILL_PATH\)\)/u,
+  );
   assert.match(canary, /removeCanaryRoot\(canaryRoot\)/u);
   assert.doesNotMatch(canary, /shell:\s*true/u);
 });

--- a/scripts/document-design-lock-update-canary.mjs
+++ b/scripts/document-design-lock-update-canary.mjs
@@ -1,0 +1,238 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { isAbsolute, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  computeSkillFolderHash,
+  migrateDocumentDesignProject,
+  verifyCanonicalDocumentDesignProject,
+} from './document-design-lock-migration.mjs';
+import { buildCommandInvocation } from './journalism-core-install-canary.mjs';
+
+export const SKILLS_CLI_VERSION = '1.5.20';
+export const CODEX_CLI_VERSION = '0.145.0';
+export const HISTORICAL_SOURCE_COMMIT = '64dc95d8584d66e35ceb79e3c43e7fa3d201d3e4';
+export const HISTORICAL_CONTENT_HASH =
+  '1a388f259e5894a04617d8b599719ec5e1adcf778eec81dbdf8324816b1ed8dc';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const FIXTURE_PATH = join(ROOT, 'scripts', 'fixtures', 'document-design-lock-v1.json');
+const SOURCE_SKILL_PATH = 'pdf-playground/skills/document-design';
+const REMOTE_URL = 'https://github.com/jamditis/claude-skills-journalism.git';
+const REMOTE_REF = 'refs/heads/master';
+const SUBPROCESS_TIMEOUT_MS = 180_000;
+
+function digest(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function stripAnsi(value) {
+  return value.replace(/\u001b\[[0-?]*[ -/]*[@-~]/gu, '');
+}
+
+function runCommand(command, args, { cwd = ROOT, env = process.env } = {}) {
+  const invocation = buildCommandInvocation(command, args, { env });
+  return spawnSync(invocation.command, invocation.args, {
+    cwd,
+    encoding: 'utf8',
+    env,
+    maxBuffer: 10 * 1024 * 1024,
+    shell: false,
+    timeout: SUBPROCESS_TIMEOUT_MS,
+    windowsHide: true,
+  });
+}
+
+function commandOutput(result) {
+  return stripAnsi(`${result.stdout ?? ''}${result.stderr ?? ''}`);
+}
+
+function assertStatus(result, expected, label) {
+  if (result.error) throw result.error;
+  if (result.signal) throw new Error(`${label} ended with signal ${result.signal}`);
+  if (result.status !== expected) {
+    throw new Error(`${label} exited ${result.status}; expected ${expected}:\n${commandOutput(result)}`);
+  }
+}
+
+function runGit(args, { encoding = 'utf8' } = {}) {
+  const result = spawnSync('git', args, {
+    cwd: ROOT,
+    encoding,
+    maxBuffer: 10 * 1024 * 1024,
+    shell: false,
+    timeout: SUBPROCESS_TIMEOUT_MS,
+  });
+  assertStatus(result, 0, `git ${args[0]}`);
+  return result.stdout;
+}
+
+function remoteMasterCommit() {
+  const output = runGit(['ls-remote', REMOTE_URL, REMOTE_REF]).trim();
+  const [commit, ref, extra] = output.split(/\s+/u);
+  if (!/^[a-f0-9]{40}$/u.test(commit ?? '') || ref !== REMOTE_REF || extra !== undefined) {
+    throw new Error(`could not resolve exactly one ${REMOTE_REF} commit`);
+  }
+  return commit;
+}
+
+function materializeHistoricalSkill(project) {
+  const list = runGit([
+    'ls-tree',
+    '-r',
+    '--name-only',
+    HISTORICAL_SOURCE_COMMIT,
+    '--',
+    SOURCE_SKILL_PATH,
+  ]);
+  const repoPaths = list.trim().split('\n').filter(Boolean);
+  if (repoPaths.length === 0) throw new Error('historical document-design tree is empty');
+
+  const installedRoot = join(project, '.agents', 'skills', 'document-design');
+  for (const repoPath of repoPaths) {
+    const relativePath = relative(SOURCE_SKILL_PATH, repoPath);
+    if (
+      !relativePath
+      || relativePath.startsWith('..')
+      || isAbsolute(relativePath)
+    ) {
+      throw new Error(`historical skill path escaped its source root: ${repoPath}`);
+    }
+    const destination = join(installedRoot, relativePath);
+    mkdirSync(resolve(destination, '..'), { recursive: true });
+    const content = runGit(
+      ['show', `${HISTORICAL_SOURCE_COMMIT}:${repoPath}`],
+      { encoding: null },
+    );
+    writeFileSync(destination, content);
+  }
+  const contentHash = computeSkillFolderHash(installedRoot);
+  if (contentHash !== HISTORICAL_CONTENT_HASH) {
+    throw new Error(`historical content hash drifted: ${contentHash}`);
+  }
+  return installedRoot;
+}
+
+function removeCanaryRoot(directory) {
+  const temporaryRoot = resolve(tmpdir());
+  const resolved = resolve(directory);
+  const pathFromTemporaryRoot = relative(temporaryRoot, resolved);
+  if (
+    !pathFromTemporaryRoot
+    || pathFromTemporaryRoot.startsWith('..')
+    || isAbsolute(pathFromTemporaryRoot)
+    || !pathFromTemporaryRoot.startsWith('document-design-lock-canary-')
+  ) {
+    throw new Error(`refusing to remove non-canary path: ${resolved}`);
+  }
+  rmSync(resolved, { recursive: true, force: true });
+}
+
+export function runDocumentDesignLockCanary() {
+  const canaryRoot = mkdtempSync(join(tmpdir(), 'document-design-lock-canary-'));
+  try {
+    const project = join(canaryRoot, 'project');
+    const cache = join(canaryRoot, 'npm-cache');
+    mkdirSync(project);
+    mkdirSync(cache);
+    const installedRoot = materializeHistoricalSkill(project);
+    const fixtureBytes = readFileSync(FIXTURE_PATH);
+    const lockPath = join(project, 'skills-lock.json');
+    writeFileSync(lockPath, fixtureBytes);
+
+    const env = {
+      ...process.env,
+      DISABLE_TELEMETRY: '1',
+      DO_NOT_TRACK: '1',
+      npm_config_cache: cache,
+    };
+    const npxArgs = ['--yes', `skills@${SKILLS_CLI_VERSION}`];
+    const sourceCommit = remoteMasterCommit();
+    const sourceHash = computeSkillFolderHash(join(ROOT, SOURCE_SKILL_PATH));
+    const initialLockDigest = digest(fixtureBytes);
+
+    const codexVersion = runCommand('codex', ['--version'], { env });
+    assertStatus(codexVersion, 0, 'codex --version');
+    assert.match(commandOutput(codexVersion), new RegExp(`codex-cli ${CODEX_CLI_VERSION}\\b`, 'u'));
+
+    const skillsVersion = runCommand('npx', [...npxArgs, '--version'], { env });
+    assertStatus(skillsVersion, 0, 'skills --version');
+    assert.match(commandOutput(skillsVersion), new RegExp(`^${SKILLS_CLI_VERSION}\\b`, 'mu'));
+
+    const prechange = runCommand(
+      'npx',
+      [...npxArgs, 'update', '--project', '-y'],
+      { cwd: project, env },
+    );
+    assertStatus(prechange, 1, 'historical-key update');
+    assert.match(commandOutput(prechange), /Failed to update Document design/u);
+    assert.equal(digest(readFileSync(lockPath)), initialLockDigest);
+    assert.equal(computeSkillFolderHash(installedRoot), HISTORICAL_CONTENT_HASH);
+
+    const migration = migrateDocumentDesignProject(project);
+    assert.equal(migration.status, 'migrated');
+
+    const firstUpdate = runCommand(
+      'npx',
+      [...npxArgs, 'update', '--project', '-y'],
+      { cwd: project, env },
+    );
+    assertStatus(firstUpdate, 0, 'first canonical update');
+    assert.match(commandOutput(firstUpdate), /Updated document-design/u);
+    const first = verifyCanonicalDocumentDesignProject(project);
+    assert.equal(first.computedHash, sourceHash);
+    assert.equal(remoteMasterCommit(), sourceCommit);
+    const firstLockBytes = readFileSync(lockPath);
+    assert.deepEqual(
+      Object.keys(JSON.parse(firstLockBytes.toString('utf8')).skills),
+      ['document-design'],
+    );
+
+    const secondUpdate = runCommand(
+      'npx',
+      [...npxArgs, 'update', '--project', '-y'],
+      { cwd: project, env },
+    );
+    assertStatus(secondUpdate, 0, 'second canonical update');
+    assert.match(commandOutput(secondUpdate), /Updated document-design/u);
+    const second = verifyCanonicalDocumentDesignProject(project);
+    assert.equal(second.computedHash, first.computedHash);
+    assert.deepEqual(readFileSync(lockPath), firstLockBytes);
+    assert.equal(remoteMasterCommit(), sourceCommit);
+
+    return {
+      client: `Codex CLI ${CODEX_CLI_VERSION}`,
+      finalContentHash: second.computedHash,
+      finalLockDigest: digest(firstLockBytes),
+      fixtureDigest: initialLockDigest,
+      historicalContentHash: HISTORICAL_CONTENT_HASH,
+      prechangeExit: prechange.status,
+      skillsCli: `skills CLI ${SKILLS_CLI_VERSION}`,
+      sourceCommit,
+      updateExits: [firstUpdate.status, secondUpdate.status],
+    };
+  } finally {
+    removeCanaryRoot(canaryRoot);
+  }
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : '';
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  try {
+    console.log(JSON.stringify(runDocumentDesignLockCanary(), null, 2));
+  } catch (error) {
+    assert(error instanceof Error);
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/document-design-lock-update-canary.mjs
+++ b/scripts/document-design-lock-update-canary.mjs
@@ -143,8 +143,10 @@ export function runDocumentDesignLockCanary() {
   try {
     const project = join(canaryRoot, 'project');
     const cache = join(canaryRoot, 'npm-cache');
+    const clientHome = join(canaryRoot, 'home');
     mkdirSync(project);
     mkdirSync(cache);
+    mkdirSync(clientHome);
     const installedRoot = materializeHistoricalSkill(project);
     const fixtureBytes = readFileSync(FIXTURE_PATH);
     const lockPath = join(project, 'skills-lock.json');
@@ -154,6 +156,8 @@ export function runDocumentDesignLockCanary() {
       ...process.env,
       DISABLE_TELEMETRY: '1',
       DO_NOT_TRACK: '1',
+      HOME: clientHome,
+      USERPROFILE: clientHome,
       npm_config_cache: cache,
     };
     const npxArgs = ['--yes', `skills@${SKILLS_CLI_VERSION}`];

--- a/scripts/document-design-lock-update-canary.mjs
+++ b/scripts/document-design-lock-update-canary.mjs
@@ -65,9 +65,9 @@ function assertStatus(result, expected, label) {
   }
 }
 
-function runGit(args, { encoding = 'utf8' } = {}) {
+function runGit(args, { cwd = ROOT, encoding = 'utf8' } = {}) {
   const result = spawnSync('git', args, {
-    cwd: ROOT,
+    cwd,
     encoding,
     maxBuffer: 10 * 1024 * 1024,
     shell: false,
@@ -86,19 +86,64 @@ function remoteMasterCommit() {
   return commit;
 }
 
-function materializeHistoricalSkill(project) {
+function prepareSourceRepository(canaryRoot, sourceCommit) {
+  const repository = join(canaryRoot, 'source.git');
+  runGit(['init', '--bare', repository]);
+
+  runGit([
+    '--git-dir',
+    repository,
+    'fetch',
+    '--no-tags',
+    '--depth=1',
+    REMOTE_URL,
+    REMOTE_REF,
+  ]);
+  const fetchedSource = runGit([
+    '--git-dir',
+    repository,
+    'rev-parse',
+    'FETCH_HEAD^{commit}',
+  ]).trim();
+  if (fetchedSource !== sourceCommit) {
+    throw new Error(`fetched source moved from ${sourceCommit} to ${fetchedSource}`);
+  }
+
+  runGit([
+    '--git-dir',
+    repository,
+    'fetch',
+    '--no-tags',
+    '--depth=1',
+    REMOTE_URL,
+    HISTORICAL_SOURCE_COMMIT,
+  ]);
+  const fetchedHistorical = runGit([
+    '--git-dir',
+    repository,
+    'rev-parse',
+    'FETCH_HEAD^{commit}',
+  ]).trim();
+  if (fetchedHistorical !== HISTORICAL_SOURCE_COMMIT) {
+    throw new Error('fetched historical source commit did not match the pinned fixture');
+  }
+  return repository;
+}
+
+function materializeSkillTree(repository, commit, destinationRoot) {
   const list = runGit([
+    '--git-dir',
+    repository,
     'ls-tree',
     '-r',
     '--name-only',
-    HISTORICAL_SOURCE_COMMIT,
+    commit,
     '--',
     SOURCE_SKILL_PATH,
   ]);
   const repoPaths = list.trim().split('\n').filter(Boolean);
-  if (repoPaths.length === 0) throw new Error('historical document-design tree is empty');
+  if (repoPaths.length === 0) throw new Error(`document-design tree is empty at ${commit}`);
 
-  const installedRoot = join(project, '.agents', 'skills', 'document-design');
   for (const repoPath of repoPaths) {
     const relativePath = relative(SOURCE_SKILL_PATH, repoPath);
     if (
@@ -108,19 +153,15 @@ function materializeHistoricalSkill(project) {
     ) {
       throw new Error(`historical skill path escaped its source root: ${repoPath}`);
     }
-    const destination = join(installedRoot, relativePath);
+    const destination = join(destinationRoot, relativePath);
     mkdirSync(resolve(destination, '..'), { recursive: true });
     const content = runGit(
-      ['show', `${HISTORICAL_SOURCE_COMMIT}:${repoPath}`],
+      ['--git-dir', repository, 'show', `${commit}:${repoPath}`],
       { encoding: null },
     );
     writeFileSync(destination, content);
   }
-  const contentHash = computeSkillFolderHash(installedRoot);
-  if (contentHash !== HISTORICAL_CONTENT_HASH) {
-    throw new Error(`historical content hash drifted: ${contentHash}`);
-  }
-  return installedRoot;
+  return destinationRoot;
 }
 
 function removeCanaryRoot(directory) {
@@ -147,7 +188,22 @@ export function runDocumentDesignLockCanary() {
     mkdirSync(project);
     mkdirSync(cache);
     mkdirSync(clientHome);
-    const installedRoot = materializeHistoricalSkill(project);
+    const sourceCommit = remoteMasterCommit();
+    const sourceRepository = prepareSourceRepository(canaryRoot, sourceCommit);
+    const installedRoot = materializeSkillTree(
+      sourceRepository,
+      HISTORICAL_SOURCE_COMMIT,
+      join(project, '.agents', 'skills', 'document-design'),
+    );
+    const historicalHash = computeSkillFolderHash(installedRoot);
+    if (historicalHash !== HISTORICAL_CONTENT_HASH) {
+      throw new Error(`historical content hash drifted: ${historicalHash}`);
+    }
+    const sourceSnapshot = materializeSkillTree(
+      sourceRepository,
+      sourceCommit,
+      join(canaryRoot, 'source-snapshot'),
+    );
     const fixtureBytes = readFileSync(FIXTURE_PATH);
     const lockPath = join(project, 'skills-lock.json');
     writeFileSync(lockPath, fixtureBytes);
@@ -161,8 +217,7 @@ export function runDocumentDesignLockCanary() {
       npm_config_cache: cache,
     };
     const npxArgs = ['--yes', `skills@${SKILLS_CLI_VERSION}`];
-    const sourceCommit = remoteMasterCommit();
-    const sourceHash = computeSkillFolderHash(join(ROOT, SOURCE_SKILL_PATH));
+    const sourceHash = computeSkillFolderHash(sourceSnapshot);
     const initialLockDigest = digest(fixtureBytes);
 
     const codexVersion = runCommand('codex', ['--version'], { env });

--- a/scripts/fixtures/document-design-lock-v1.json
+++ b/scripts/fixtures/document-design-lock-v1.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "Document design": {
+      "source": "jamditis/claude-skills-journalism",
+      "sourceType": "github",
+      "skillPath": "pdf-playground/skills/document-design/SKILL.md",
+      "computedHash": "1a388f259e5894a04617d8b599719ec5e1adcf778eec81dbdf8324816b1ed8dc"
+    }
+  }
+}


### PR DESCRIPTION
Closes #230

## Summary

- add the historical Document design project-lock fixture and reproduce the skills CLI 1.5.20 update failure
- add an explicit fail-closed migration and post-update verifier for the canonical document-design identity
- add a live canary proving two successful, idempotent updates with stable source, path, directory, and content hashes
- record dated client evidence separately from public catalog history

## Verification

- npm test (160/160)
- npm run validate:agent-skills (60/60)
- npm run check:docs-css (49/49)
- npm run canary:document-design-lock (pre-change exit 1; post-migration exits 0 and 0)
- node syntax checks and git diff --check