### PR TITLE
Catch an AI git identity inherited from the environment (#194)

### DIFF
--- a/hooks/no-ai-attribution.py
+++ b/hooks/no-ai-attribution.py
@@ -1171,16 +1171,31 @@ def _git_effective_dir(core, stop, base):
     return d
 
 
-def find_attribution(command, cwd, depth=0):
+def find_attribution(command, cwd, depth=0, inherited=None):
     """Return a short reason string if the command would write AI attribution, else None.
 
     Walks the command's logical lines (so a newline-separated command is seen), then the
     segments of each, tracking the effective directory across `cd` so relative message
     files resolve where the command would read them. `depth` bounds recursion into a shell
     runner's `-c` script (bash -c '<script>'), so a pathological nest cannot run away.
+    `inherited` carries the ambient git-identity vars the OUTER command hands this one when
+    recursing into a `bash -c` script; at the top level it is seeded from the process
+    environment instead.
     """
     eff_cwd = cwd
-    exported_identity = {}  # exported identity var -> latest value (shell last-wins)
+    # The starting ambient identity. At the top level, an identity var already exported
+    # before the hook runs (GIT_AUTHOR_NAME=Claude set in the parent shell) is inherited by
+    # a bare `git commit`, so seed from the process environment. When recursing into a
+    # `bash -c` script, take the identity the outer segment actually passes in `inherited`
+    # instead -- re-reading os.environ there would resurrect a value the outer `env -i` or
+    # `unset` already cleared and falsely block. Either way a later unset/reassign in the
+    # command overrides it (last-wins below).
+    if depth == 0:
+        exported_identity = {
+            name: os.environ[name] for name in _GIT_IDENTITY_ENV if name in os.environ
+        }
+    else:
+        exported_identity = dict(inherited or {})  # exported var -> latest value
     for raw_line in _logical_lines(command):
         # Drop an unquoted trailing `#` comment first: the shell never runs it, so a clean
         # command with an attributed example in a comment must not be blocked.
@@ -1224,7 +1239,19 @@ def find_attribution(command, cwd, depth=0):
                     # the inner command reads (git commit -F MSG) resolves there. Recurse
                     # with the env -C-adjusted cwd, not the bare tracked cwd.
                     rec_cwd = eff_cwd if env_chdir is None else _resolve_dir(eff_cwd, env_chdir)
-                    inner = find_attribution(script, rec_cwd, depth + 1)
+                    # The script inherits this segment's effective environment: the tracked
+                    # exported identity, wiped by env -i, minus any env -u unset, plus the
+                    # inline `NAME=val bash -c ...` prefix (all last-wins) -- the same fields
+                    # the git-commit branch computes. Pass only identity vars so the nested
+                    # `git commit` is judged against the identity it would really inherit.
+                    rec_env = {} if ignore_env else dict(exported_identity)
+                    for u in unsets:
+                        rec_env.pop(u, None)
+                    for a in assigns:
+                        name, _, val = a.partition("=")
+                        rec_env[name] = val
+                    rec_env = {k: v for k, v in rec_env.items() if k in _GIT_IDENTITY_ENV}
+                    inner = find_attribution(script, rec_cwd, depth + 1, inherited=rec_env)
                     if inner is not None:
                         return inner
                 continue

--- a/hooks/tests/test_no_ai_attribution.py
+++ b/hooks/tests/test_no_ai_attribution.py
@@ -611,6 +611,76 @@ def test_allow_exported_clean_env_then_commit():
     assert_allowed(r)
 
 
+def test_block_ambient_exported_identity_before_bare_commit():
+    # An identity var exported in the PARENT shell, before the hook even runs, is inherited
+    # by a bare `git commit`, so the commit is authored by the tool with no assignment in
+    # the command itself. Seeding identity tracking from the inherited environment is what
+    # catches it; without that seed the bare commit reads as unwatched.
+    r = run('git commit -m "Fix the parser"', env={"GIT_AUTHOR_NAME": "Claude"})
+    assert_blocked(r)
+
+
+def test_block_ambient_exported_identity_email():
+    # The same inheritance holds for the email twin: an ambient GIT_COMMITTER_EMAIL naming
+    # a bot is inherited by a bare commit and must block.
+    r = run('git commit -m "Fix the parser"', env={"GIT_COMMITTER_EMAIL": "claude@anthropic.com"})
+    assert_blocked(r)
+
+
+def test_allow_ambient_human_identity_before_bare_commit():
+    # Seeding from the environment must not misfire on a real person's identity: an ambient
+    # GIT_AUTHOR_NAME that names no tool is a normal developer setup and must pass.
+    r = run('git commit -m "Fix the parser"', env={"GIT_AUTHOR_NAME": "Jane Doe"})
+    assert_allowed(r)
+
+
+def test_allow_inline_human_reassignment_overrides_ambient_identity():
+    # Reassignment is the third way the ambient identity is cleared, alongside env -i and
+    # unset: an inline `GIT_AUTHOR_NAME=Jane git commit` overrides an ambient tool value for
+    # that command (last-wins), so the effective author is the human and it must pass.
+    r = run('GIT_AUTHOR_NAME="Jane Doe" git commit -m Fix', env={"GIT_AUTHOR_NAME": "Claude"})
+    assert_allowed(r)
+
+
+def test_allow_env_i_wipes_ambient_identity():
+    # `env -i` starts the command with an empty environment, so an ambient tool identity is
+    # NOT inherited by the commit it runs; seeding from the environment must still yield a
+    # clean pass here, or env -i would falsely block.
+    r = run('env -i git commit -m Fix', env={"GIT_AUTHOR_NAME": "Claude"})
+    assert_allowed(r)
+
+
+def test_allow_unset_clears_ambient_identity():
+    # An `unset` of an ambient tool identity before the commit clears it, so the commit
+    # carries no tool author and must pass even though the environment seeded the var.
+    r = run('unset GIT_AUTHOR_NAME && git commit -m Fix', env={"GIT_AUTHOR_NAME": "Claude"})
+    assert_allowed(r)
+
+
+def test_block_ambient_identity_inside_nested_shell_runner():
+    # A `bash -c 'git commit'` still inherits an ambient tool identity from the parent
+    # shell, so the bypass of hiding the commit inside a shell runner must be closed: the
+    # outer segment propagates its effective identity into the recursion.
+    r = run("bash -c 'git commit -m Fix'", env={"GIT_AUTHOR_NAME": "Claude"})
+    assert_blocked(r)
+
+
+def test_allow_env_i_before_nested_shell_runner_commit():
+    # A nested `bash -c 'git commit'` inherits the environment the OUTER command set up.
+    # `env -i` cleared it, so the inner commit sees no tool identity: the propagated map is
+    # empty and the commit must pass, not misfire on the wiped ambient value.
+    r = run("env -i bash -c 'git commit -m Fix'", env={"GIT_AUTHOR_NAME": "Claude"})
+    assert_allowed(r)
+
+
+def test_allow_unset_before_nested_shell_runner_commit():
+    # Same, via `unset`: the outer command dropped the ambient identity before running the
+    # nested `bash -c 'git commit'`, so the propagated identity is empty and a clean commit
+    # must pass.
+    r = run("unset GIT_AUTHOR_NAME && bash -c 'git commit -m Fix'", env={"GIT_AUTHOR_NAME": "Claude"})
+    assert_allowed(r)
+
+
 def test_block_commit_tilde_home_message_file(tmp_path):
     # An unquoted `~/MSG` expands to $HOME/MSG before the command runs; resolving it
     # against cwd (reading cwd/~/MSG) would miss the byline in the real home file.


### PR DESCRIPTION
Closes one of the ten findings in #194 (the parser-hardening backlog from the #193 cloud review).

**Finding L1099 — seed identity tracking from the inherited environment.** The hook flagged a git commit only when the command itself set an AI identity (an inline `GIT_AUTHOR_NAME=Claude` prefix, an `export`, or `git -c user.name=...`). An identity var already exported in the parent shell was inherited by a bare `git commit` and slipped through — the exact case the env-var authorship guard is meant to close.

Fix:
- Seed the identity map from `os.environ` at the top level, so a bare `git commit` is judged against the identity it would really inherit.
- When recursing into a `bash -c '<script>'`, propagate the outer segment's effective identity (after `env -i`, `env -u`, and inline assigns) rather than re-reading `os.environ` — so the ambient identity is caught inside a shell runner, but a cleanup wrapper that cleared it first is not falsely blocked.

Both directions are pinned by regression tests: the ambient tool identity blocks (bare and nested in `bash -c`), and each of the three clearing paths — `env -i`, `unset`, and inline reassignment to a human — passes. Full suite: 212 passed.

Verified from code first: the other nine findings in #194 are already handled on current `master` (`--dry-run` at `_git_commit_is_dry_run`, `time -p` in `_strip_leading_keywords`, last-identity-wins in `_git_config_identity_hit`, the `#`-comment drop, and the bare-export tracking), so this PR closes the one that was still open. A determined author can bypass any client-side hook, so this is hardening, not a security boundary.

wake-20260724T0805-331447
