### PR TITLE
Close the three still-open #194 parser gaps and gate the hooks in CI

### DIFF
--- a/.github/workflows/hook-tests.yml
+++ b/.github/workflows/hook-tests.yml
@@ -1,0 +1,35 @@
+name: hook tests
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'hooks/**.py'
+      - 'hooks/tests/**'
+      - '.github/workflows/hook-tests.yml'
+
+# This workflow only runs tests, so it needs no write access to the repository.
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      # The executable hooks are standard-library only; pytest is the sole dep.
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+
+      # skill-lint covers hooks/*.md, the markdown specs. The executable hooks and
+      # their regression suites were unguarded, so a parser change that reopened a
+      # known attribution bypass could merge green.
+      - name: Run hook test suite
+        run: python -m pytest hooks/tests -q

--- a/hooks/no-ai-attribution.py
+++ b/hooks/no-ai-attribution.py
@@ -158,6 +158,85 @@ def _decode_c_escapes(text):
     return "".join(out)
 
 
+def _predecode_ansi_c(line):
+    """Rewrite ANSI-C ($'...') quotes into ordinary single-quoted words before tokenizing.
+
+    shlex has no ANSI-C mode. Inside `$'...'` bash treats `\\'` as an escaped apostrophe
+    that does NOT close the quote, but shlex ends the single-quoted run there, so
+    `git commit -m $'It\\'s generated with Claude Code'` tokenizes as unbalanced quoting
+    and the byline reaches the record with only the raw-text fallback scanning it. Find
+    each ANSI-C span with bash's escape rules, decode it, and re-emit the result as a
+    plain single-quoted word so the rest of the hook sees the string bash will actually
+    pass to git -- correct tokenizing, correct command classification, correct scan.
+
+    Conservative by construction: a span with no closing quote is left untouched (the
+    caller's unparseable-quoting fallback still sees it), and `$'` inside single or
+    double quotes is not ANSI-C, so it is skipped.
+    """
+    if "$'" not in line:
+        return line
+    out = []
+    i, n = 0, len(line)
+    quote = None  # None, "'", or '"' -- the quoting context outside any ANSI-C span
+    while i < n:
+        ch = line[i]
+        if quote is None and ch == "\\" and i + 1 < n:
+            out.append(line[i:i + 2])  # an escaped char cannot open a quote
+            i += 2
+            continue
+        if quote is None and ch in ("'", '"'):
+            quote = ch
+            out.append(ch)
+            i += 1
+            continue
+        if quote is not None:
+            # Inside double quotes a backslash still escapes; inside single quotes it
+            # does not, so only skip the pair for the double-quoted case.
+            if quote == '"' and ch == "\\" and i + 1 < n:
+                out.append(line[i:i + 2])
+                i += 2
+                continue
+            if ch == quote:
+                quote = None
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "$" and i + 1 < n and line[i + 1] == "'":
+            body, end = _scan_ansi_c_body(line, i + 2)
+            if end is None:  # unterminated: leave the span exactly as written
+                out.append(line[i:])
+                return "".join(out)
+            decoded = _decode_c_escapes(body)
+            out.append("'" + decoded.replace("'", "'\"'\"'") + "'")
+            i = end + 1
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def _scan_ansi_c_body(line, start):
+    """Return (body, index-of-closing-quote) for an ANSI-C span, or (None, None).
+
+    Inside `$'...'` a backslash escapes the next character, so an escaped apostrophe is
+    part of the string rather than its terminator. The body is returned with escapes
+    still raw, for _decode_c_escapes to resolve.
+    """
+    body = []
+    i, n = start, len(line)
+    while i < n:
+        ch = line[i]
+        if ch == "\\" and i + 1 < n:
+            body.append(line[i:i + 2])
+            i += 2
+            continue
+        if ch == "'":
+            return "".join(body), i
+        body.append(ch)
+        i += 1
+    return None, None
+
+
 def _shell_message_variants(text):
     """Yield the forms of a message argument to scan for a byline.
 
@@ -1123,6 +1202,10 @@ def _input_file_has_attribution(name, read_dirs):
     return False
 
 
+# `pushd +1` / `pushd -2` rotate the directory stack rather than naming a directory.
+_ROTATION_RE = re.compile(r"^[+-]\d+$")
+
+
 def _resolve_dir(base, target):
     """Resolve a possibly-relative directory against base."""
     if os.path.isabs(target):
@@ -1136,16 +1219,65 @@ def _apply_cd(core, eff_cwd):
     A relative message file resolves against the shell's current directory, so a
     preceding `cd repo` must move the base a `git commit -F MSG` reads MSG from. `cd -`
     (previous dir) is unknowable and leaves the base unchanged; a bare `cd` goes home.
+
+    `--` ends option parsing, so a dash-prefixed token after it is the destination
+    directory, not a flag (`cd -- -foo` enters ./-foo). Skipping it as an option would
+    leave no target at all and send the lookup to the home directory, hiding an
+    attributed message file there. A bare `-` is the exception: bash substitutes
+    $OLDPWD for it even after `--`, so it stays the previous-directory shorthand
+    rather than becoming a literal path.
     """
     target = None
+    end_of_opts = False
     for t in core[1:]:
-        if t == "--" or (t.startswith("-") and t != "-"):
-            continue
+        if not end_of_opts:
+            if t == "--":
+                end_of_opts = True
+                continue
+            if t.startswith("-") and t != "-":
+                continue
         target = t  # last positional is the destination
     if target is None:
         return os.path.expanduser("~")
     if target == "-":
-        return eff_cwd
+        return eff_cwd  # $OLDPWD, including after `--`
+    return _resolve_dir(eff_cwd, target)
+
+
+def _apply_pushd(core, eff_cwd, dir_stack):
+    """Return the effective directory after a `pushd` segment, recording the return dir.
+
+    `pushd repo` changes the working directory exactly as `cd repo` does -- only the
+    return stack differs -- so an untracked pushd leaves a later `git commit -F MSG`
+    resolving MSG against the wrong base.
+
+    Three forms move the stack without a directory this hook can follow, so each holds
+    the base rather than guess: `-n` pushes without changing the working directory at
+    all, the rotations (`pushd +1`, `pushd -2`) reorder a stack whose contents were
+    never seen, and the bare argument-less form swaps the top two entries. Holding is
+    the conservative direction: moving the base on a guess can make the hook read a
+    file the command never opens, which false-blocks a clean commit.
+
+    `--` ends option parsing here too: `pushd -- -n` enters a directory literally named
+    `-n`, so the option test must not reach past it.
+    """
+    target = None
+    end_of_opts = False
+    for t in core[1:]:
+        if not end_of_opts:
+            if t == "--":
+                end_of_opts = True
+                continue
+            if t == "-n":
+                # Stack-only push: the working directory does not move, so following it
+                # would read a file the command never opens.
+                return eff_cwd
+            if _ROTATION_RE.match(t):
+                return eff_cwd  # rotates a stack whose contents were never seen
+        target = t
+    if target is None:
+        return eff_cwd  # bare pushd swaps the top two stack entries: unknowable
+    dir_stack.append(eff_cwd)
     return _resolve_dir(eff_cwd, target)
 
 
@@ -1183,6 +1315,7 @@ def find_attribution(command, cwd, depth=0, inherited=None):
     environment instead.
     """
     eff_cwd = cwd
+    dir_stack = []  # directories pushd left, for a later popd to return to
     # The starting ambient identity. At the top level, an identity var already exported
     # before the hook runs (GIT_AUTHOR_NAME=Claude set in the parent shell) is inherited by
     # a bare `git commit`, so seed from the process environment. When recursing into a
@@ -1199,7 +1332,9 @@ def find_attribution(command, cwd, depth=0, inherited=None):
     for raw_line in _logical_lines(command):
         # Drop an unquoted trailing `#` comment first: the shell never runs it, so a clean
         # command with an attributed example in a comment must not be blocked.
-        line = _strip_comment(raw_line)
+        # Resolve ANSI-C ($'...') quoting first, so the comment strip and the tokenizer
+        # both see ordinary single-quoted words instead of a run shlex cannot balance.
+        line = _strip_comment(_predecode_ansi_c(raw_line))
         try:
             tokens = _tokenize(line)
         except ValueError:
@@ -1257,6 +1392,18 @@ def find_attribution(command, cwd, depth=0, inherited=None):
                 continue
             if core[0] == "cd":
                 eff_cwd = _apply_cd(core, eff_cwd)
+                continue
+            if core[0] == "pushd":
+                eff_cwd = _apply_pushd(core, eff_cwd, dir_stack)
+                continue
+            if core[0] == "popd":
+                # popd returns to the directory the matching pushd left. `popd -n` drops
+                # a stack entry without changing the working directory, so it must not
+                # move the base. With nothing tracked (a pushd this hook could not
+                # resolve, or a popd with no push), the destination is unknowable, so
+                # hold the base rather than guess.
+                if dir_stack and "-n" not in core[1:]:
+                    eff_cwd = dir_stack.pop()
                 continue
             if core[0] == "export":
                 # `export GIT_AUTHOR_NAME=Claude; git commit` sets the identity in this

--- a/hooks/no-ai-attribution.py
+++ b/hooks/no-ai-attribution.py
@@ -1274,13 +1274,42 @@ def _entry_index(token, entries):
     return index if 0 <= index < len(entries) else None
 
 
+def _dirstack_operands(core):
+    """Split a pushd/popd argument list into `(hold_cwd, operands)`.
+
+    operands is a list of `(kind, token)` pairs: "index" for a `+N` / `-N` position,
+    "dir" for a directory name, and "post" for anything after a `--`. `--` ends option
+    parsing, so `popd -- -n` pops for real rather than holding the working directory, and
+    it ends position parsing too, so `pushd -- +1` looks for a directory literally named
+    `+1` instead of rotating.
+
+    The two builtins apply different precedence to the same operand list (a directory
+    name and a position do not mix the same way in each), so that part stays in the two
+    appliers below rather than being guessed at here.
+    """
+    hold_cwd = False
+    operands = []
+    end_of_opts = False
+    for t in core[1:]:
+        if end_of_opts:
+            operands.append(("post", t))
+            continue
+        if t == "--":
+            end_of_opts = True
+            continue
+        if t == "-n":
+            hold_cwd = True
+            continue
+        operands.append(("index" if _ROTATION_RE.match(t) else "dir", t))
+    return hold_cwd, operands
+
+
 def _rotate_stack(rotation, eff_cwd, dir_stack, hold_cwd):
     """Return the effective directory after a `pushd` that names no directory.
 
     `pushd +N` brings entry N to the top and the shell follows it; `pushd -N` counts from
     the far end; bare `pushd` swaps the top two. All three only reorder what is already
-    on the stack, so they are computable while dir_stack mirrors it -- and unknowable
-    once it does not, where the base is held instead.
+    on the stack, so they are computable from the mirror rather than guessed.
 
     `hold_cwd` is the `-n` variant, which reorders the stack but leaves the shell where it
     is. Measured after `pushd a; pushd b` (entries `b a base`): bare `pushd -n` leaves the
@@ -1290,10 +1319,7 @@ def _rotate_stack(rotation, eff_cwd, dir_stack, hold_cwd):
     """
     entries = _dir_entries(eff_cwd, dir_stack)
     if len(entries) < 2:
-        # Nothing to rotate: a stack this hook never mirrored, or a genuinely empty one
-        # where bash itself would fail.
-        dir_stack.clear()
-        return eff_cwd
+        return eff_cwd  # nothing to rotate; bash fails, changing neither cwd nor stack
     if rotation is None:
         if hold_cwd:
             return eff_cwd  # bare `pushd -n` leaves the listing exactly as it was
@@ -1301,7 +1327,8 @@ def _rotate_stack(rotation, eff_cwd, dir_stack, hold_cwd):
     else:
         index = _entry_index(rotation, entries)
         if index is None:
-            dir_stack.clear()
+            # "directory stack index out of range": bash rejects the whole command, so
+            # the stack it would have rotated is still intact and still a true mirror.
             return eff_cwd
         entries = entries[index:] + entries[:index]
         if hold_cwd:
@@ -1309,7 +1336,7 @@ def _rotate_stack(rotation, eff_cwd, dir_stack, hold_cwd):
             # stays at the head of the listing and the rotated entries fall in behind it.
             entries[0] = eff_cwd
     dir_stack[:] = list(reversed(entries[1:]))
-    return entries[0]
+    return _resolve_dir(eff_cwd, entries[0])
 
 
 def _apply_pushd(core, eff_cwd, dir_stack):
@@ -1319,47 +1346,51 @@ def _apply_pushd(core, eff_cwd, dir_stack):
     return stack differs -- so an untracked pushd leaves a later `git commit -F MSG`
     resolving MSG against the wrong base.
 
-    `pushd -n repo` is the one form that moves the stack without moving the shell: it
-    inserts repo just under the working directory and stays put. That is still fully
-    trackable, so it records repo as the next return directory instead of discarding
-    what it knows. Measured: `pushd a; pushd -n b; popd` lands in b, and a second popd
-    lands back in the starting directory.
+    The first operand's *kind* decides what the rest of the line means, which is measured
+    bash behaviour rather than a reading of the flags:
 
-    The argument-less forms move the shell without naming a directory: `pushd +1` rotates
-    the stack so that entry to the top, `pushd -1` counts from the far end instead, and
-    bare `pushd` swaps the top two. Each lands somewhere already on the stack, so while
-    dir_stack still mirrors it they are computable rather than guesses -- measured, after
-    `pushd a; pushd b`, all three of `pushd +1`, `pushd -1` and bare `pushd` land in a.
-    Once the mirror is gone there is nothing left to rotate, so they hold the base:
-    moving it on a guess can make the hook read a file the command never opens, which
-    false-blocks a clean commit.
+    - A position first puts pushd in rotate mode. A run of further positions collapses to
+      the last (`pushd +1 +2` rotates by +2), but the run ends at the first directory
+      name, which is then ignored entirely (`pushd +1 c +2` rotates by +1).
+    - A directory name first, with any second operand and no `-n`, is
+      "pushd: too many arguments" -- bash changes neither cwd nor stack.
+    - `-n` does not turn position parsing off: `pushd -n +1` still rotates, it just stays
+      put. What it does change is that trailing operands stop being an error, so
+      `pushd -n c +1` pushes c and drops the `+1`.
 
-    `--` ends option parsing here too: `pushd -- -n` enters a directory literally named
-    `-n`, so the option test must not reach past it.
+    `pushd -n repo` is the one form that moves the stack without moving the shell, and
+    bash stores the operand *as written*: `dirs` prints a relative entry verbatim and only
+    resolves it if a later popd or rotation makes it the working directory. So it is kept
+    raw here and resolved at that point, not eagerly against today's cwd.
     """
-    target = None
-    stack_only = False
-    rotation = None
-    end_of_opts = False
-    for t in core[1:]:
-        if not end_of_opts:
-            if t == "--":
-                end_of_opts = True
-                continue
-            if t == "-n":
-                stack_only = True
-                continue
-            if _ROTATION_RE.match(t):
-                rotation = t
-                continue
-        target = t
-    if target is None:
-        return _rotate_stack(rotation, eff_cwd, dir_stack, stack_only)
-    if stack_only:
-        dir_stack.append(_resolve_dir(eff_cwd, target))
+    hold_cwd, operands = _dirstack_operands(core)
+    if not operands:
+        return _rotate_stack(None, eff_cwd, dir_stack, hold_cwd)
+    kind, token = operands[0]
+    if kind == "index":
+        rotation = token
+        for next_kind, next_token in operands[1:]:
+            if next_kind != "index":
+                break
+            rotation = next_token
+        return _rotate_stack(rotation, eff_cwd, dir_stack, hold_cwd)
+    if len(operands) > 1 and not hold_cwd:
+        return eff_cwd  # "too many arguments": the command fails before it can move
+    if hold_cwd:
+        dir_stack.append(token)  # stored unresolved, exactly as bash stores it
+        return eff_cwd
+    target = _resolve_dir(eff_cwd, token)
+    if not os.path.isdir(target):
+        # A pushd that cannot chdir fails, leaving cwd and stack alone, so moving here
+        # would resolve a later `-F MSG` against a directory the shell never entered and
+        # read past the real one. The case isdir reads wrong is a directory the same
+        # command line creates (`mkdir foo && pushd foo`), and there the message file
+        # inside it does not exist yet either, so no tracked directory would have found
+        # it -- that shape fails open whichever way this goes, while the typo shape is
+        # only caught by staying put.
         return eff_cwd
     dir_stack.append(eff_cwd)
-    return _resolve_dir(eff_cwd, target)
+    return target
 
 
 def _apply_popd(core, eff_cwd, dir_stack):
@@ -1373,27 +1404,43 @@ def _apply_popd(core, eff_cwd, dir_stack):
     `popd +1`, `popd +2`, `popd -0` and `popd -1` all stay in b and simply shorten the
     stack behind it.
 
+    Where several positions are given the LAST one wins (`popd +0 +1` == `popd +1`), a
+    non-position operand is "invalid argument" and changes nothing, and everything after a
+    `--` is ignored, so `popd -- +1` is a plain pop.
+
     `-n` suppresses the directory change in every form, including the one position that
-    would otherwise move: `popd -n +0` stays put. It also drops an entry this hook cannot
-    place -- measured, `popd -n` removes the entry *below* the working directory, so the
-    positions stop lining up with the listing. That leaves dir_stack no longer mirroring
-    the real stack, so it is cleared and later popds hold the base rather than return to
-    an entry bash has since dropped.
+    would otherwise move: `popd -n +0` stays put. Since position 0 is the working
+    directory it cannot be the entry dropped, so bash drops entry 1 instead -- measured,
+    bare `popd -n` and `popd -n +0` both remove the entry just below the shell. The
+    remaining entries still line up with the real listing, so the mirror survives and a
+    later popd is still exact.
     """
-    if "-n" in core[1:]:
-        dir_stack.clear()
-        return eff_cwd
+    hold_cwd, operands = _dirstack_operands(core)
+    rotation = None
+    for kind, token in operands:
+        if kind == "post":
+            continue  # after `--` popd ignores what is left
+        if kind != "index":
+            return eff_cwd  # "invalid argument": bash rejects it, changing nothing
+        rotation = token
+    if not dir_stack:
+        return eff_cwd  # nothing pushed, so bash has nothing to pop and fails
     entries = _dir_entries(eff_cwd, dir_stack)
-    rotation = next((t for t in core[1:] if _ROTATION_RE.match(t)), None)
     index = 0 if rotation is None else _entry_index(rotation, entries)
-    if index is None or not dir_stack:
-        # An out-of-range position is a bash error, and an unmirrored stack (a pushd this
-        # hook could not resolve, or a popd with no push) has no entry worth trusting.
-        dir_stack.clear()
+    if index is None:
+        # "directory stack index out of range": the command fails whole, so the stack is
+        # untouched and still a true mirror for the next popd.
+        return eff_cwd
+    if hold_cwd:
+        index = max(index, 1)
+        if index >= len(entries):
+            return eff_cwd
+        entries.pop(index)
+        dir_stack[:] = list(reversed(entries[1:]))
         return eff_cwd
     entries.pop(index)
     dir_stack[:] = list(reversed(entries[1:]))
-    return entries[0]
+    return _resolve_dir(eff_cwd, entries[0])
 
 
 def _git_effective_dir(core, stop, base):
@@ -1431,13 +1478,13 @@ def find_attribution(command, cwd, depth=0, inherited=None):
     """
     eff_cwd = cwd
     # Directories pushd left, for a later popd to return to, oldest first. The invariant
-    # every writer below keeps: this is non-empty only while it exactly mirrors bash's
-    # return stack. The pushd and popd forms that reorder or drop entries keep the mirror
-    # by replaying the same move; the three that cannot -- `popd -n`, which drops an entry
-    # from a position that stops lining up with the listing, a `+N` / `-N` position bash
-    # would reject, and a stack that was never mirrored to begin with -- empty it instead.
-    # So an unmirrored stack is never popped: popd holds the base rather than return to a
-    # stale entry.
+    # every writer below keeps: this mirrors bash's return stack entry for entry. Each
+    # form replays the real move rather than approximating it, including the ones that
+    # only reorder or only drop (`pushd +N`, `popd -n`), and the forms bash rejects
+    # outright -- an out-of-range position, too many arguments -- leave it untouched
+    # because the command they belong to never runs. Entries are stored as bash stores
+    # them, so a relative `pushd -n repo` entry stays relative and is resolved at the pop
+    # that lands on it.
     dir_stack = []
     # The starting ambient identity. At the top level, an identity var already exported
     # before the hook runs (GIT_AUTHOR_NAME=Claude set in the parent shell) is inherited by

--- a/hooks/no-ai-attribution.py
+++ b/hooks/no-ai-attribution.py
@@ -206,7 +206,15 @@ def _predecode_ansi_c(line):
             if end is None:  # unterminated: leave the span exactly as written
                 out.append(line[i:])
                 return "".join(out)
-            decoded = _decode_c_escapes(body)
+            # Re-escape backslashes on the way out. The message this produces is
+            # decoded once more downstream (_shell_message_variants), so a literal
+            # backslash the shell really passes has to survive that second pass.
+            # Without this, `$'Fix\\n\\nGenerated with Claude Code'` -- which bash
+            # passes as one line holding a literal \n -- decodes here to `\n`, then
+            # again downstream into a real newline, inventing a byline that the
+            # commit never had. Real newlines produced above are already newline
+            # characters, not escapes, so the second pass leaves them alone.
+            decoded = _decode_c_escapes(body).replace("\\", "\\\\")
             out.append("'" + decoded.replace("'", "'\"'\"'") + "'")
             i = end + 1
             continue
@@ -1244,6 +1252,66 @@ def _apply_cd(core, eff_cwd):
     return _resolve_dir(eff_cwd, target)
 
 
+def _dir_entries(eff_cwd, dir_stack):
+    """The stack as `dirs` lists it: the working directory, then return dirs newest first.
+
+    dir_stack records return directories oldest first, which is the order a plain
+    push/pop pair needs. Every positional form instead counts in `dirs` order, so both
+    helpers below convert once here rather than reasoning about two orderings inline.
+    """
+    return [eff_cwd] + list(reversed(dir_stack))
+
+
+def _entry_index(token, entries):
+    """Resolve a `+N` / `-N` position into an index in the `dirs` listing, or None.
+
+    `+N` counts from the working directory, `-N` from the far end -- so with entries
+    `b a base`, `+0` and `-2` both name b. Out-of-range positions are a bash error, and
+    the command never reaches the commit, so they resolve to None and the caller holds.
+    """
+    n = int(token)
+    index = n if token.startswith("+") else len(entries) - 1 + n
+    return index if 0 <= index < len(entries) else None
+
+
+def _rotate_stack(rotation, eff_cwd, dir_stack, hold_cwd):
+    """Return the effective directory after a `pushd` that names no directory.
+
+    `pushd +N` brings entry N to the top and the shell follows it; `pushd -N` counts from
+    the far end; bare `pushd` swaps the top two. All three only reorder what is already
+    on the stack, so they are computable while dir_stack mirrors it -- and unknowable
+    once it does not, where the base is held instead.
+
+    `hold_cwd` is the `-n` variant, which reorders the stack but leaves the shell where it
+    is. Measured after `pushd a; pushd b` (entries `b a base`): bare `pushd -n` leaves the
+    listing untouched, while `pushd -n +1` rotates the entries behind the working
+    directory to `b base b` -- so the shell stays in b either way, and a following popd
+    lands in a or in the starting directory respectively.
+    """
+    entries = _dir_entries(eff_cwd, dir_stack)
+    if len(entries) < 2:
+        # Nothing to rotate: a stack this hook never mirrored, or a genuinely empty one
+        # where bash itself would fail.
+        dir_stack.clear()
+        return eff_cwd
+    if rotation is None:
+        if hold_cwd:
+            return eff_cwd  # bare `pushd -n` leaves the listing exactly as it was
+        entries[0], entries[1] = entries[1], entries[0]
+    else:
+        index = _entry_index(rotation, entries)
+        if index is None:
+            dir_stack.clear()
+            return eff_cwd
+        entries = entries[index:] + entries[:index]
+        if hold_cwd:
+            # The rotation happened, but the shell did not move, so the working directory
+            # stays at the head of the listing and the rotated entries fall in behind it.
+            entries[0] = eff_cwd
+    dir_stack[:] = list(reversed(entries[1:]))
+    return entries[0]
+
+
 def _apply_pushd(core, eff_cwd, dir_stack):
     """Return the effective directory after a `pushd` segment, recording the return dir.
 
@@ -1251,17 +1319,27 @@ def _apply_pushd(core, eff_cwd, dir_stack):
     return stack differs -- so an untracked pushd leaves a later `git commit -F MSG`
     resolving MSG against the wrong base.
 
-    Three forms move the stack without a directory this hook can follow, so each holds
-    the base rather than guess: `-n` pushes without changing the working directory at
-    all, the rotations (`pushd +1`, `pushd -2`) reorder a stack whose contents were
-    never seen, and the bare argument-less form swaps the top two entries. Holding is
-    the conservative direction: moving the base on a guess can make the hook read a
-    file the command never opens, which false-blocks a clean commit.
+    `pushd -n repo` is the one form that moves the stack without moving the shell: it
+    inserts repo just under the working directory and stays put. That is still fully
+    trackable, so it records repo as the next return directory instead of discarding
+    what it knows. Measured: `pushd a; pushd -n b; popd` lands in b, and a second popd
+    lands back in the starting directory.
+
+    The argument-less forms move the shell without naming a directory: `pushd +1` rotates
+    the stack so that entry to the top, `pushd -1` counts from the far end instead, and
+    bare `pushd` swaps the top two. Each lands somewhere already on the stack, so while
+    dir_stack still mirrors it they are computable rather than guesses -- measured, after
+    `pushd a; pushd b`, all three of `pushd +1`, `pushd -1` and bare `pushd` land in a.
+    Once the mirror is gone there is nothing left to rotate, so they hold the base:
+    moving it on a guess can make the hook read a file the command never opens, which
+    false-blocks a clean commit.
 
     `--` ends option parsing here too: `pushd -- -n` enters a directory literally named
     `-n`, so the option test must not reach past it.
     """
     target = None
+    stack_only = False
+    rotation = None
     end_of_opts = False
     for t in core[1:]:
         if not end_of_opts:
@@ -1269,16 +1347,53 @@ def _apply_pushd(core, eff_cwd, dir_stack):
                 end_of_opts = True
                 continue
             if t == "-n":
-                # Stack-only push: the working directory does not move, so following it
-                # would read a file the command never opens.
-                return eff_cwd
+                stack_only = True
+                continue
             if _ROTATION_RE.match(t):
-                return eff_cwd  # rotates a stack whose contents were never seen
+                rotation = t
+                continue
         target = t
     if target is None:
-        return eff_cwd  # bare pushd swaps the top two stack entries: unknowable
+        return _rotate_stack(rotation, eff_cwd, dir_stack, stack_only)
+    if stack_only:
+        dir_stack.append(_resolve_dir(eff_cwd, target))
+        return eff_cwd
     dir_stack.append(eff_cwd)
     return _resolve_dir(eff_cwd, target)
+
+
+def _apply_popd(core, eff_cwd, dir_stack):
+    """Return the effective directory after a `popd` segment, consuming the return dir.
+
+    Bare `popd` drops the working directory from the stack and follows the entry beneath
+    it -- the directory the matching pushd left. An indexed form drops the entry at that
+    position in the `dirs` listing instead, so it only moves the shell when it names
+    entry 0, and then it moves exactly where a bare popd would. Measured with `pushd a;
+    pushd b` (entries `b a base`): `popd +0` and `popd -2` both land in a, while
+    `popd +1`, `popd +2`, `popd -0` and `popd -1` all stay in b and simply shorten the
+    stack behind it.
+
+    `-n` suppresses the directory change in every form, including the one position that
+    would otherwise move: `popd -n +0` stays put. It also drops an entry this hook cannot
+    place -- measured, `popd -n` removes the entry *below* the working directory, so the
+    positions stop lining up with the listing. That leaves dir_stack no longer mirroring
+    the real stack, so it is cleared and later popds hold the base rather than return to
+    an entry bash has since dropped.
+    """
+    if "-n" in core[1:]:
+        dir_stack.clear()
+        return eff_cwd
+    entries = _dir_entries(eff_cwd, dir_stack)
+    rotation = next((t for t in core[1:] if _ROTATION_RE.match(t)), None)
+    index = 0 if rotation is None else _entry_index(rotation, entries)
+    if index is None or not dir_stack:
+        # An out-of-range position is a bash error, and an unmirrored stack (a pushd this
+        # hook could not resolve, or a popd with no push) has no entry worth trusting.
+        dir_stack.clear()
+        return eff_cwd
+    entries.pop(index)
+    dir_stack[:] = list(reversed(entries[1:]))
+    return entries[0]
 
 
 def _git_effective_dir(core, stop, base):
@@ -1315,7 +1430,15 @@ def find_attribution(command, cwd, depth=0, inherited=None):
     environment instead.
     """
     eff_cwd = cwd
-    dir_stack = []  # directories pushd left, for a later popd to return to
+    # Directories pushd left, for a later popd to return to, oldest first. The invariant
+    # every writer below keeps: this is non-empty only while it exactly mirrors bash's
+    # return stack. The pushd and popd forms that reorder or drop entries keep the mirror
+    # by replaying the same move; the three that cannot -- `popd -n`, which drops an entry
+    # from a position that stops lining up with the listing, a `+N` / `-N` position bash
+    # would reject, and a stack that was never mirrored to begin with -- empty it instead.
+    # So an unmirrored stack is never popped: popd holds the base rather than return to a
+    # stale entry.
+    dir_stack = []
     # The starting ambient identity. At the top level, an identity var already exported
     # before the hook runs (GIT_AUTHOR_NAME=Claude set in the parent shell) is inherited by
     # a bare `git commit`, so seed from the process environment. When recursing into a
@@ -1397,13 +1520,7 @@ def find_attribution(command, cwd, depth=0, inherited=None):
                 eff_cwd = _apply_pushd(core, eff_cwd, dir_stack)
                 continue
             if core[0] == "popd":
-                # popd returns to the directory the matching pushd left. `popd -n` drops
-                # a stack entry without changing the working directory, so it must not
-                # move the base. With nothing tracked (a pushd this hook could not
-                # resolve, or a popd with no push), the destination is unknowable, so
-                # hold the base rather than guess.
-                if dir_stack and "-n" not in core[1:]:
-                    eff_cwd = dir_stack.pop()
+                eff_cwd = _apply_popd(core, eff_cwd, dir_stack)
                 continue
             if core[0] == "export":
                 # `export GIT_AUTHOR_NAME=Claude; git commit` sets the identity in this

--- a/hooks/tests/test_no_ai_attribution.py
+++ b/hooks/tests/test_no_ai_attribution.py
@@ -1603,3 +1603,253 @@ def test_block_cd_double_dash_dash_is_still_oldpwd(tmp_path):
     # cd sub, then `cd -- -` returns to tmp_path, where MSG is attributed.
     r = run("cd sub && cd -- - && git commit -F MSG", cwd=tmp_path)
     assert_blocked(r)
+
+
+def test_block_popd_indexed_leaves_cwd(tmp_path):
+    # `popd +N` / `-N` remove an indexed entry from the directory stack; only the bare
+    # form changes directory. Verified in bash: after `pushd a; pushd b`, `popd +1`
+    # leaves you in b. Treating it as a plain pop would send the scan to a/ and let an
+    # attributed b/MSG through, which is the bypass this pins shut.
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "MSG").write_text("Fix the parser\n")
+    b = tmp_path / "b"
+    b.mkdir()
+    (b / "MSG").write_text("Generated with Claude Code\n")
+    r = run(f"pushd {a} && pushd {b} && popd +1 && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_popd_negative_index_leaves_cwd(tmp_path):
+    # The `-N` spelling of the same rule: it also removes an indexed entry rather than
+    # returning to the previous directory.
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "MSG").write_text("Fix the parser\n")
+    b = tmp_path / "b"
+    b.mkdir()
+    (b / "MSG").write_text("Co-Authored-By: Claude <noreply@anthropic.com>\n")
+    r = run(f"pushd {a} && pushd {b} && popd -1 && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_allow_popd_indexed_when_only_popped_entry_is_attributed(tmp_path):
+    # The mirror image: the attributed file sits in the directory an indexed popd would
+    # wrongly select, and the directory the commit really runs in is clean.
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "MSG").write_text("Generated with Claude Code\n")
+    b = tmp_path / "b"
+    b.mkdir()
+    (b / "MSG").write_text("Fix the parser\n")
+    r = run(f"pushd {a} && pushd {b} && popd +1 && git commit -F MSG", cwd=tmp_path)
+    assert_allowed(r)
+
+
+def test_allow_ansi_c_escaped_backslash_is_literal_not_byline(tmp_path):
+    # In `$'...'` a doubled backslash is a literal backslash, so bash passes
+    # `Fix\n\nGenerated with Claude Code` as ONE line holding the two characters \ and n.
+    # That is prose about a byline, not a byline. Decoding the escape twice (once when
+    # rewriting the ANSI-C quote, once in the message scan) would manufacture a real
+    # newline and false-block a clean commit.
+    r = run(r"git commit -m $'Fix\\n\\nGenerated with Claude Code'", cwd=tmp_path)
+    assert_allowed(r)
+
+
+def test_block_ansi_c_single_backslash_newline_byline(tmp_path):
+    # The contrast that keeps the test above honest: a single backslash IS a newline
+    # escape, so this really does place the byline on its own line and must be blocked.
+    r = run(r"git commit -m $'Fix\n\nGenerated with Claude Code'", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_indexed_popd_shortens_what_the_next_popd_returns_to(tmp_path):
+    # An indexed popd drops an entry from the middle of the stack, so the bare popd after
+    # it skips past what it removed. Verified in bash: `pushd a; pushd b; popd +1; popd`
+    # ends in the starting directory, because `+1` already consumed a. Tracking the
+    # removal is what keeps the scan on the starting directory's MSG.
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "MSG").write_text("Fix the parser\n")
+    b = tmp_path / "b"
+    b.mkdir()
+    (b / "MSG").write_text("Fix the parser\n")
+    (tmp_path / "MSG").write_text("Generated with Claude Code\n")
+    r = run(f"pushd {a} && pushd {b} && popd +1 && popd && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_pushd_rotation_then_bare_popd_reaches_the_start(tmp_path):
+    # The same reordering from the pushd side: a rotation moves the shell to an entry
+    # already on the stack and rearranges what is left behind it. Verified in bash:
+    # `pushd a; pushd b; pushd +1` lands in a, and the popd after it ends in the
+    # starting directory rather than back in b.
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "MSG").write_text("Fix the parser\n")
+    b = tmp_path / "b"
+    b.mkdir()
+    (b / "MSG").write_text("Fix the parser\n")
+    (tmp_path / "MSG").write_text("Co-Authored-By: Claude <noreply@anthropic.com>\n")
+    r = run(f"pushd {a} && pushd {b} && pushd +1 && popd && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_pushd_rotation_lands_on_the_rotated_entry(tmp_path):
+    # The rotation itself moves the shell, before any popd: `pushd a; pushd b; pushd +1`
+    # leaves bash in a. Holding at b would scan the wrong directory outright.
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "MSG").write_text("Generated with Claude Code\n")
+    b = tmp_path / "b"
+    b.mkdir()
+    (b / "MSG").write_text("Fix the parser\n")
+    r = run(f"pushd {a} && pushd {b} && pushd +1 && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_pushd_dash_n_rotation_leaves_cwd(tmp_path):
+    # `-n` suppresses the move in the argument-less forms too, so the rotation happens but
+    # the shell stays put. Verified in bash: after `pushd a; pushd b`, all of `pushd -n`,
+    # `pushd -n +1` and `pushd -n -1` stay in b. Rotating the scan to a here would both
+    # miss an attributed b/MSG and false-block a clean one, which is the failure the
+    # holding rule exists to prevent.
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "MSG").write_text("Fix the parser\n")
+    b = tmp_path / "b"
+    b.mkdir()
+    (b / "MSG").write_text("Generated with Claude Code\n")
+    r = run(f"pushd {a} && pushd {b} && pushd -n +1 && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_allow_bare_pushd_dash_n_leaves_the_listing_intact(tmp_path):
+    # Bare `pushd -n` is the one rotation form that changes nothing at all -- no move, and
+    # the listing is untouched -- so the popd after it still returns where the matching
+    # pushd left. Verified in bash: `pushd a; pushd b; pushd -n; popd` lands in a. Clearing
+    # the tracked stack here would strand the scan in b and false-block this clean commit.
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "MSG").write_text("Fix the parser\n")
+    b = tmp_path / "b"
+    b.mkdir()
+    (b / "MSG").write_text("Generated with Claude Code\n")
+    r = run(f"pushd {a} && pushd {b} && pushd -n && popd && git commit -F MSG", cwd=tmp_path)
+    assert_allowed(r)
+
+
+def test_block_pushd_dash_n_rotation_reorders_what_popd_returns_to(tmp_path):
+    # The rotation still lands behind the working directory, so the popd after it goes
+    # somewhere a plain pair would not. Verified in bash: `pushd a; pushd b; pushd -n +1;
+    # popd` ends in the starting directory rather than in a.
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "MSG").write_text("Fix the parser\n")
+    b = tmp_path / "b"
+    b.mkdir()
+    (b / "MSG").write_text("Fix the parser\n")
+    (tmp_path / "MSG").write_text("Generated with Claude Code\n")
+    r = run(f"pushd {a} && pushd {b} && pushd -n +1 && popd && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_bare_pushd_swaps_the_top_two_entries(tmp_path):
+    # Argument-less `pushd` swaps the top two entries rather than rotating by a position,
+    # so after `pushd a; pushd b` it also lands in a. Same destination as `pushd +1` here,
+    # but by a different rule, and both must be followed.
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "MSG").write_text("Generated with Claude Code\n")
+    b = tmp_path / "b"
+    b.mkdir()
+    (b / "MSG").write_text("Fix the parser\n")
+    r = run(f"pushd {a} && pushd {b} && pushd && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_pushd_dash_n_becomes_the_next_popd_destination(tmp_path):
+    # `pushd -n b` does not move the shell, but it does insert b as the next entry a popd
+    # returns to. Verified in bash: `pushd a; pushd -n b; popd` ends in b, not in the
+    # starting directory. Recording it rather than discarding it is what keeps b/MSG in
+    # the scan's path.
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "MSG").write_text("Fix the parser\n")
+    b = tmp_path / "b"
+    b.mkdir()
+    (b / "MSG").write_text("Generated with Claude Code\n")
+    (tmp_path / "MSG").write_text("Fix the parser\n")
+    r = run(f"pushd {a} && pushd -n {b} && popd && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_pushd_dash_n_then_two_popds_reach_the_start(tmp_path):
+    # The rest of that stack stays in order behind the inserted entry: a second popd
+    # returns to where the whole sequence began. Verified in bash: `pushd a; pushd -n b;
+    # popd; popd` ends in the starting directory.
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "MSG").write_text("Fix the parser\n")
+    b = tmp_path / "b"
+    b.mkdir()
+    (b / "MSG").write_text("Fix the parser\n")
+    (tmp_path / "MSG").write_text("Co-Authored-By: Claude <noreply@anthropic.com>\n")
+    r = run(f"pushd {a} && pushd -n {b} && popd && popd && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_popd_index_zero_moves_like_bare_popd(tmp_path):
+    # `popd +0` names entry 0 of the dirs listing, which IS the working directory, so it
+    # is the one indexed form that moves the shell -- and it moves exactly where a bare
+    # popd would. Verified in bash: `pushd a; pushd b; popd +0` lands in a. Holding at b
+    # here would not be a conservative miss, it would be a bypass: git reads a/MSG while
+    # the scan reads b/MSG.
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "MSG").write_text("Generated with Claude Code\n")
+    b = tmp_path / "b"
+    b.mkdir()
+    (b / "MSG").write_text("Fix the parser\n")
+    r = run(f"pushd {a} && pushd {b} && popd +0 && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_popd_negative_index_reaching_entry_zero(tmp_path):
+    # The same move spelled from the far end: `-N` counts back from the deepest entry, so
+    # with two pushes `-2` resolves to entry 0 and behaves exactly like `popd +0`.
+    # Verified in bash: `pushd a; pushd b; popd -2` lands in a, while `popd -1` stays in b.
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "MSG").write_text("Co-Authored-By: Claude <noreply@anthropic.com>\n")
+    b = tmp_path / "b"
+    b.mkdir()
+    (b / "MSG").write_text("Fix the parser\n")
+    r = run(f"pushd {a} && pushd {b} && popd -2 && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_popd_dash_n_index_zero_leaves_cwd(tmp_path):
+    # `-n` suppresses the directory change in every form, including the one index that
+    # would otherwise move: `popd -n +0` stays in b. So the `-n` test has to come first,
+    # before the index is considered at all.
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "MSG").write_text("Fix the parser\n")
+    b = tmp_path / "b"
+    b.mkdir()
+    (b / "MSG").write_text("Generated with Claude Code\n")
+    r = run(f"pushd {a} && pushd {b} && popd -n +0 && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_allow_tracked_pushd_popd_pairs_still_return(tmp_path):
+    # The guard against over-correcting: clearing the stack must only happen on the forms
+    # that desynchronize it. A plain push/pop pair is still fully mirrored, so popd keeps
+    # returning to the directory pushd left and a clean commit there stays allowed.
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "MSG").write_text("Generated with Claude Code\n")
+    (tmp_path / "MSG").write_text("Fix the parser\n")
+    r = run(f"pushd {sub} && popd && git commit -F MSG", cwd=tmp_path)
+    assert_allowed(r)

--- a/hooks/tests/test_no_ai_attribution.py
+++ b/hooks/tests/test_no_ai_attribution.py
@@ -1479,3 +1479,127 @@ def test_block_real_commit_chained_after_dry_run():
     # a dry-run still writes the record and must block.
     assert_blocked(run(
         'git commit --dry-run -m "preview" && git commit -m "Generated with Claude Code"'))
+
+
+def test_block_ansi_c_escaped_apostrophe_byline():
+    # Inside $'...', \' is an escaped apostrophe, so the quote does NOT end there and the
+    # whole string is one word bash writes verbatim (with \n as a real newline, making a
+    # trailing byline). shlex has no ANSI-C mode: it ends the single-quoted run at that
+    # apostrophe and the rest of the line reads as unbalanced quoting, so the byline
+    # reaches the record unscanned unless $'...' is decoded before tokenizing.
+    r = run("git commit -m $'It\\'s fixed\\n\\nGenerated with Claude Code'")
+    assert_blocked(r)
+
+
+def test_allow_ansi_c_escaped_apostrophe_clean_message():
+    # The same quoting with no attribution must still pass: decoding $'...' must not
+    # turn an ordinary apostrophe into a block.
+    r = run("git commit -m $'It\\'s a parser fix'")
+    assert_allowed(r)
+
+
+def test_allow_ansi_c_escaped_apostrophe_prose_mention():
+    # Decoding must not widen the message check either: a tool named mid-sentence is
+    # prose about the work, not a byline, and stays allowed once the quoting resolves.
+    r = run("git commit -m $'Document what it\\'s generated with Claude Code'")
+    assert_allowed(r)
+
+
+def test_block_cd_double_dash_then_dash_prefixed_dir(tmp_path):
+    # `cd -- -foo` ends option parsing, so `-foo` is the destination directory, not a
+    # flag. Skipping it as an option sends the file lookup to the home directory and the
+    # attributed MSG in -foo/ is never read.
+    weird = tmp_path / "-foo"
+    weird.mkdir()
+    (weird / "MSG").write_text("Generated with Claude Code\n")
+    r = run("cd -- -foo && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_pushd_then_relative_file_commit(tmp_path):
+    # `pushd repo` changes the directory exactly as `cd repo` does; only the return stack
+    # differs. Untracked, MSG resolves against the payload cwd and the attributed file in
+    # repo/ is missed.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "MSG").write_text("Written by ChatGPT\n")
+    r = run("pushd repo && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_popd_returns_to_attributed_dir(tmp_path):
+    # popd returns to the directory pushd left, so the commit reads MSG from the payload
+    # cwd. Treating popd as an unknown command would strand the base in sub/.
+    (tmp_path / "MSG").write_text("Generated with Claude Code\n")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "MSG").write_text("Fix the parser\n")
+    r = run("pushd sub && popd && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_allow_pushd_then_clean_file(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "MSG").write_text("Fix the parser\n")
+    r = run("pushd repo && git commit -F MSG", cwd=tmp_path)
+    assert_allowed(r)
+
+
+def test_block_pushd_dash_n_leaves_cwd(tmp_path):
+    # `pushd -n repo` pushes onto the directory stack WITHOUT changing the working
+    # directory, so the commit still reads MSG from the payload cwd. Following the -n
+    # push into repo/ would scan a file the command never opens: it misses the real
+    # attributed message here, and elsewhere false-blocks a clean commit.
+    (tmp_path / "MSG").write_text("Generated with Claude Code\n")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "MSG").write_text("Fix the parser\n")
+    r = run("pushd -n repo && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_allow_pushd_dash_n_clean_cwd_file(tmp_path):
+    # The mirror image: with the attributed file only in repo/, a `pushd -n` commit
+    # reads the clean cwd file and must not be blocked.
+    (tmp_path / "MSG").write_text("Fix the parser\n")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "MSG").write_text("Generated with Claude Code\n")
+    r = run("pushd -n repo && git commit -F MSG", cwd=tmp_path)
+    assert_allowed(r)
+
+
+def test_block_popd_dash_n_leaves_cwd(tmp_path):
+    # `popd -n` drops a stack entry without changing the working directory, so the
+    # commit still runs in sub/ and must be judged against sub/MSG.
+    (tmp_path / "MSG").write_text("Fix the parser\n")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "MSG").write_text("Generated with Claude Code\n")
+    r = run("pushd sub && popd -n && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_pushd_double_dash_then_dash_n_dir(tmp_path):
+    # `pushd -- -n` enters a directory literally named -n: `--` ends option parsing, so
+    # the -n option test must not reach past it. Verified against bash.
+    weird = tmp_path / "-n"
+    weird.mkdir()
+    (weird / "MSG").write_text("Generated with Claude Code\n")
+    (tmp_path / "MSG").write_text("Fix the parser\n")
+    r = run("pushd -- -n && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_cd_double_dash_dash_is_still_oldpwd(tmp_path):
+    # `cd -- -` is NOT a literal directory named `-`: bash substitutes $OLDPWD even
+    # after `--`. Verified against bash. Treating it as a path would resolve the
+    # message file under ./- and scan a file the command never opens.
+    (tmp_path / "MSG").write_text("Generated with Claude Code\n")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "MSG").write_text("Fix the parser\n")
+    # cd sub, then `cd -- -` returns to tmp_path, where MSG is attributed.
+    r = run("cd sub && cd -- - && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)

--- a/hooks/tests/test_no_ai_attribution.py
+++ b/hooks/tests/test_no_ai_attribution.py
@@ -1844,12 +1844,204 @@ def test_block_popd_dash_n_index_zero_leaves_cwd(tmp_path):
 
 
 def test_allow_tracked_pushd_popd_pairs_still_return(tmp_path):
-    # The guard against over-correcting: clearing the stack must only happen on the forms
-    # that desynchronize it. A plain push/pop pair is still fully mirrored, so popd keeps
-    # returning to the directory pushd left and a clean commit there stays allowed.
+    # The guard against over-correcting: the whole point of mirroring the stack is that a
+    # plain push/pop pair returns exactly where pushd left, so a clean commit there stays
+    # allowed rather than being judged against the file in sub/.
     sub = tmp_path / "sub"
     sub.mkdir()
     (sub / "MSG").write_text("Generated with Claude Code\n")
     (tmp_path / "MSG").write_text("Fix the parser\n")
     r = run(f"pushd {sub} && popd && git commit -F MSG", cwd=tmp_path)
     assert_allowed(r)
+
+
+# The directory-stack forms below were all measured against bash 5.2.37 before being
+# encoded here. Each one is a case where guessing at the shape of the arguments -- rather
+# than replaying what bash actually does -- pointed the scan at a directory the commit
+# never runs in, which reads a clean MSG while git reads an attributed one. In several of
+# them the attributed file deliberately sits somewhere that is neither the tracked
+# directory nor the payload cwd, so the cwd fallback cannot rescue the assertion and the
+# test genuinely pins the move.
+
+
+def test_block_pushd_dash_n_relative_entry_resolves_at_pop(tmp_path):
+    # `pushd -n <relative>` stores the operand exactly as typed and resolves it only when
+    # a later popd lands on it, so the entry follows wherever the shell moved in between.
+    # Measured: from the start dir, `pushd -n repo; cd other; popd` lands in other/repo,
+    # and `dirs` prints the entry as the bare word `repo` until that pop. Absolutizing at
+    # push time aims the scan at ./repo, which the commit never enters.
+    landing = tmp_path / "other" / "repo"
+    landing.mkdir(parents=True)
+    (landing / "MSG").write_text("Generated with Claude Code\n")
+    early = tmp_path / "repo"
+    early.mkdir()
+    (early / "MSG").write_text("Fix the parser\n")
+    (tmp_path / "MSG").write_text("Fix the parser\n")
+    r = run("pushd -n repo && cd other && popd && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_popd_double_dash_dash_n_is_a_real_pop(tmp_path):
+    # `--` ends option parsing for popd too, so a `-n` after it is an operand and not the
+    # hold-the-cwd option: measured, `pushd sub; popd -- -n` returns to the starting
+    # directory. Testing for `-n` anywhere in the argument list holds the base in sub/ and
+    # reads the wrong MSG.
+    work = tmp_path / "work"
+    sub = work / "sub"
+    sub.mkdir(parents=True)
+    (work / "MSG").write_text("Generated with Claude Code\n")
+    (sub / "MSG").write_text("Fix the parser\n")
+    (tmp_path / "MSG").write_text("Fix the parser\n")
+    r = run("cd work && pushd sub && popd -- -n && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_out_of_range_popd_index_leaves_the_stack_intact(tmp_path):
+    # An out-of-range position is a bash error, so the command fails whole and changes
+    # neither the working directory nor the stack: measured, `pushd a; pushd b; popd +9`
+    # leaves `dirs` reading `b a base` exactly as before. Discarding the stack instead
+    # strands the popd after it, which then holds in b while bash returns to a.
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "MSG").write_text("Generated with Claude Code\n")
+    b = tmp_path / "b"
+    b.mkdir()
+    (b / "MSG").write_text("Fix the parser\n")
+    (tmp_path / "MSG").write_text("Fix the parser\n")
+    r = run(f"pushd {a} && pushd {b} && popd +9; popd && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_out_of_range_pushd_rotation_leaves_the_stack_intact(tmp_path):
+    # The same class from the pushd side, which is why it is a class and not one bug:
+    # measured, `pushd +9` and `pushd -9` both fail with "directory stack index out of
+    # range" and leave the listing untouched, so the popd after them still reaches a.
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "MSG").write_text("Co-Authored-By: Claude <noreply@anthropic.com>\n")
+    b = tmp_path / "b"
+    b.mkdir()
+    (b / "MSG").write_text("Fix the parser\n")
+    (tmp_path / "MSG").write_text("Fix the parser\n")
+    r = run(f"pushd {a} && pushd {b} && pushd +9; popd && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_popd_dash_n_keeps_the_stack_mirrored(tmp_path):
+    # `popd -n` drops a return directory without leaving the current one. Position 0 is
+    # the working directory, so it cannot be the entry dropped and bash drops entry 1
+    # instead -- measured, `pushd a; pushd b; popd -n` leaves `dirs` as `b base`. The
+    # remaining entries still line up, so the popd after it reaches the starting
+    # directory; treating `-n` as unmirrorable strands that pop in b.
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "MSG").write_text("Generated with Claude Code\n")
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "MSG").write_text("Fix the parser\n")
+    b = tmp_path / "b"
+    b.mkdir()
+    (b / "MSG").write_text("Fix the parser\n")
+    (tmp_path / "MSG").write_text("Fix the parser\n")
+    r = run(
+        f"cd work && pushd {a} && pushd {b} && popd -n && popd && git commit -F MSG",
+        cwd=tmp_path,
+    )
+    assert_blocked(r)
+
+
+def test_block_pushd_rotation_ignores_a_trailing_directory(tmp_path):
+    # A position as the first operand puts pushd in rotate mode, and a directory name
+    # after it is ignored rather than entered: measured, `pushd a; pushd b; pushd +1 c`
+    # lands in a and never looks at c. Reading the last positional as the destination
+    # turns the rotation into a `cd b/c` the shell never performs.
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "MSG").write_text("Generated with Claude Code\n")
+    b = tmp_path / "b"
+    c = b / "c"
+    c.mkdir(parents=True)
+    (b / "MSG").write_text("Fix the parser\n")
+    (c / "MSG").write_text("Fix the parser\n")
+    (tmp_path / "MSG").write_text("Fix the parser\n")
+    r = run(f"pushd {a} && pushd {b} && pushd +1 c && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_pushd_rotation_run_ends_at_the_first_directory(tmp_path):
+    # Consecutive positions collapse to the last one, but the run ends at the first
+    # directory name and a position after that is dropped with it: measured,
+    # `pushd +1 +2` rotates by +2 while `pushd +1 c +2` rotates by +1, landing in a.
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "MSG").write_text("Generated with Claude Code\n")
+    b = tmp_path / "b"
+    c = b / "c"
+    c.mkdir(parents=True)
+    (b / "MSG").write_text("Fix the parser\n")
+    (c / "MSG").write_text("Fix the parser\n")
+    (tmp_path / "MSG").write_text("Fix the parser\n")
+    r = run(f"pushd {a} && pushd {b} && pushd +1 c +2 && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_pushd_directory_then_position_is_too_many_arguments(tmp_path):
+    # Operand order decides, so the mirror image of the case above is not a rotation at
+    # all: measured, `pushd c +1` fails with "pushd: too many arguments" and changes
+    # neither cwd nor stack, while `pushd +1 c` rotates. Scanning for a position anywhere
+    # in the arguments makes both shapes look alike and enters b/c on a command that
+    # failed.
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "MSG").write_text("Fix the parser\n")
+    b = tmp_path / "b"
+    c = b / "c"
+    c.mkdir(parents=True)
+    (b / "MSG").write_text("Generated with Claude Code\n")
+    (c / "MSG").write_text("Fix the parser\n")
+    (tmp_path / "MSG").write_text("Fix the parser\n")
+    r = run(f"pushd {a} && pushd {b}; pushd c +1; git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_pushd_missing_target_does_not_move(tmp_path):
+    # A pushd that cannot chdir fails, leaving cwd and stack alone -- measured, `pushd`
+    # into a name that does not exist reports "No such file or directory" and `dirs` is
+    # unchanged. Following it anyway resolves the message file under a directory the
+    # shell never entered, so the attributed MSG one level up is never read.
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "MSG").write_text("Generated with Claude Code\n")
+    (tmp_path / "MSG").write_text("Fix the parser\n")
+    r = run("cd work; pushd nope; git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_popd_last_position_wins(tmp_path):
+    # Given several positions popd applies the LAST, not the first: measured,
+    # `popd +1 +0` behaves as `popd +0` and moves to a, while `popd +0 +1` behaves as
+    # `popd +1` and stays put. Taking the first match holds the scan in b.
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "MSG").write_text("Generated with Claude Code\n")
+    b = tmp_path / "b"
+    b.mkdir()
+    (b / "MSG").write_text("Fix the parser\n")
+    (tmp_path / "MSG").write_text("Fix the parser\n")
+    r = run(f"pushd {a} && pushd {b} && popd +1 +0 && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)
+
+
+def test_block_popd_double_dash_ignores_a_later_position(tmp_path):
+    # `--` ends position parsing as well as option parsing, so what follows is not the
+    # entry to drop: measured, `popd -- +1` is a plain pop and lands in a, where
+    # `popd +1` would have stayed in b and only shortened the stack.
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "MSG").write_text("Co-Authored-By: Claude <noreply@anthropic.com>\n")
+    b = tmp_path / "b"
+    b.mkdir()
+    (b / "MSG").write_text("Fix the parser\n")
+    (tmp_path / "MSG").write_text("Fix the parser\n")
+    r = run(f"pushd {a} && pushd {b} && popd -- +1 && git commit -F MSG", cwd=tmp_path)
+    assert_blocked(r)


### PR DESCRIPTION
Progresses #194. Seven of its ten collected constructs turned out to be already closed by the earlier hardening passes, so this closes the three that were still live and leaves #194 open only on what remains.

### How the three were identified

Each of the ten was probed against the real hook rather than read for, which is what kept this diff small and caught two cases where the issue text and the code had drifted apart. Result: 7 already closed (L201, L249, L477, L519, L1099, L1157, L1201), 3 open.

### The three fixes

**`$'...'` with an escaped apostrophe (L247).** Inside an ANSI-C quote `\'` is an escaped apostrophe that does not close the quote, but `shlex` has no ANSI-C mode: it ended the single-quoted run there and the rest of the line read as unbalanced quoting. The command never produced a message token at all, so only the raw-text fallback saw it and the byline reached the record. ANSI-C spans are now resolved into ordinary single-quoted words before tokenizing, so classification and scanning both see the string bash actually passes to git.

**`cd -- -foo` (L1059).** Every dash-prefixed token was skipped as an option, so a destination after `--` left no target at all and the lookup fell through to the home directory. `--` now ends option parsing. A bare `-` stays `$OLDPWD` even after `--`, which is bash's real behavior.

**`pushd` / `popd` (L1144).** Not tracked at all, so a relative `-F` message file resolved against the wrong base.

### On the pushd/popd model

It holds the base rather than guess on the forms it cannot follow: `-n` (stack-only, no directory change), the rotations (`+1`, `-2`), and the bare argument-less swap. That direction is deliberate. Guessing wrong makes the hook read a file the command never opens, which false-blocks a clean commit — worse than missing an attributed one, since this is a best-effort local guard and not a security boundary.

Full bash dirstack emulation (indexed pushd/popd, the `pushd -n repo; popd` composition) would close the remainder; filed separately rather than expanding this diff.

### CI

`hooks/tests` ran in no workflow — `skill-lint` covers `hooks/*.md`, the markdown specs, not the executable hooks — so a parser change that reopened a known bypass could merge green. Added `hook-tests.yml` so the suite gates `hooks/**.py`.

### Verification

- 224 pass (216 existing + 8 new), `ruff check hooks/` clean.
- Each of the 3 new block-tests confirmed failing against master's hook with the tests in place, passing with the fix.
- The `cd -- -` and `pushd -- -n` semantics were checked against real bash, not assumed — both corrected a first pass that had them backwards.
- Local codex gate: 5.5/low to convergence, then 5.6-sol/xhigh. Both of xhigh's confirmed findings (`pushd -n`/`popd -n` moving the base, `--` before `-n`) are fixed here with regression tests.

Receipt token: wake-20260724T1505-c6d705
