### PR TITLE
Prepare v2.4.0 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-skills-journalism",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "description": "Claude Code plugins for journalism, research, and media organizations",
   "owner": {
     "name": "Joe Amditis",
@@ -32,7 +32,7 @@
     {
       "name": "journalism-core",
       "description": "Fourteen core journalism skills for reporting, verification, publishing, and digital investigations. Covers AP-style writing, AI-slop detoxing, source verification (2026 deepfake/C2PA detection), FOIA and OPRA requests with current statutory citations, fact-checking workflows, interview prep and transcription, story pitches, editorial workflow, crisis communications, newsletter publishing (2024-2026 Gmail/Yahoo/Outlook bulk-sender requirements), data journalism (with 2025-2026 federal-data-portal currency notes and AI-assisted-analysis cautions), and social-media intelligence / OSINT (post-CrowdTangle Meta Content Library, X pay-per-use API, TikTok Research API, Bluesky/Threads/Mastodon/Telegram coverage). Adds embedded photo metadata (IPTC/EXIF/XMP captions, byline, alt text, keywords, Creative Commons or copyright licensing, AI-source labeling via IPTC Digital Source Type, Google-Images licensing, GPS stripping for source protection, and C2PA Content Credentials reading) for wire and archive use.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": {
         "name": "Joe Amditis",
         "email": "jamditis@gmail.com"
@@ -43,7 +43,7 @@
     {
       "name": "okf-wiki",
       "description": "Scaffold an Open Knowledge Format (OKF) knowledge base from existing docs, plans, notes, or a repository: one-concept-per-file Markdown with YAML frontmatter, directory navigation, and validation. Generate a starter wiki that passes conformance and secret-leak checks, or bootstrap an optional GitHub wiki. Session-start hooks orient Claude to the knowledge base. Built for newsroom institutional memory, research atlases, decision logs, and infrastructure maps.",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "author": {
         "name": "Joe Amditis",
         "email": "jamditis@gmail.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.4.0] - 2026-07-24
+## [2.4.0] - 2026-07-25
 
 This release advances photo provenance and OKF secret detection, records a
 no-Claude runtime boundary for okf-wiki, and finishes the attribution-hook

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-07-24
+
+This release advances photo provenance and OKF secret detection, records a
+no-Claude runtime boundary for okf-wiki, and finishes the attribution-hook
+parser hardening with required CI coverage.
+
+### Added
+
+- **okf-wiki provider detectors:** added default high-signal checks for
+  Anthropic, GitLab, npm, OpenAI, SendGrid, and Stripe secrets. Prefix-based
+  formats use provider-specific shape, boundary, and entropy checks so
+  human-readable vault paths remain valid (#248).
+- **okf-wiki runtime evidence:** added a repeatable isolated Codex pilot that
+  verifies skill and spec reads, exact generated output, an immutable install,
+  and the boundary between the portable OKF bundle and its inert Claude adapter
+  files (#251).
+
 ### Changed
 
-- **photo-metadata:** modernized for the provenance era after deep web research
-  against IPTC, C2PA, Google, and exiftool primary sources. Adds AI/synthetic
+- **photo-metadata:** modernized for current provenance practice using IPTC,
+  C2PA, Google, and exiftool primary sources. Adds AI/synthetic
   labeling via IPTC `DigitalSourceType` (full controlled vocabulary, with the
   `trainedAlgorithmicMedia` / `compositeWithTrainedAlgorithmicMedia` /
   `compositeSynthetic` distinctions and the IPTC 2025.1 AI-system/prompt fields);
@@ -22,7 +39,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   HEIC/AVIF/WebP format table; and a corrected caption vs. alt-text vs. extended-
   description distinction. `embed.py` gains `digital_source_type` (shorthand→URI,
   per-image override), licensing, and `ext_description` manifest fields, with
-  nine new tests (19 total).
+  black-box round-trip coverage (#255).
+- **Published versions:** marketplace `2.3.3 → 2.4.0`; journalism-core
+  `1.2.0 → 1.3.0`; and okf-wiki `0.6.1 → 0.7.0`.
+
+### Fixed
+
+- **Document design updates:** added a fail-closed migration, verifier, fixture,
+  and live canary for the historical project-lock key that blocked updates in
+  Skills CLI 1.5.20 (#252).
+- **Attribution hook:** catches an inherited Git identity and models measured
+  Bash `cd`, `pushd`, `popd`, ANSI-C quoting, and directory-stack behavior when
+  resolving commit message files. A required hook-test workflow now gates
+  changes to the executable parser (#253, #258).
 
 ## [2.3.3] - 2026-07-23
 
@@ -584,7 +613,8 @@ Initial commit with foundational skills.
 
 ---
 
-[Unreleased]: https://github.com/jamditis/claude-skills-journalism/compare/v2.3.3...HEAD
+[Unreleased]: https://github.com/jamditis/claude-skills-journalism/compare/v2.4.0...HEAD
+[2.4.0]: https://github.com/jamditis/claude-skills-journalism/compare/v2.3.3...v2.4.0
 [2.3.3]: https://github.com/jamditis/claude-skills-journalism/compare/v2.2.0...v2.3.3
 [2.2.0]: https://github.com/jamditis/claude-skills-journalism/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/jamditis/claude-skills-journalism/compare/v2.0.0...v2.1.0

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Codex desktop can [import skills from another agent](https://learn.chatgpt.com/d
 
 Codex's bundled skill installer writes to a different Codex-specific directory and is not a tested installation path for this repository. Codex does not deduplicate same-name skills across install roots, so don't combine it with the `.agents/skills` route above.
 
-See the checked-in [Codex compatibility matrix](./plans/codex-compatibility-matrix.md) for tested versions, package boundaries, and pending runtime gates. A valid install is not yet a package-wide runtime support claim.
+See the checked-in [Codex compatibility matrix](./plans/codex-compatibility-matrix.md) for tested versions, package boundaries, and pending runtime gates. A valid install is not yet a package-wide runtime support claim. As of v2.4.0 the tested versions lag the released ones: the matrix records evidence gathered against the previous release, and the install commands above deliver the newer packages.
 
 ### Claude.ai
 

--- a/journalism-core/.claude-plugin/plugin.json
+++ b/journalism-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "journalism-core",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Fourteen core journalism skills for reporting, verification, publishing, and digital investigations. Covers AP-style writing, AI-slop detoxing, source verification (2026 deepfake/C2PA detection), FOIA and OPRA requests with current statutory citations, fact-checking workflows, interview prep and transcription, story pitches, editorial workflow, crisis communications, newsletter publishing (2024-2026 Gmail/Yahoo/Outlook bulk-sender requirements), data journalism (with 2025-2026 federal-data-portal currency notes and AI-assisted-analysis cautions), and social-media intelligence / OSINT (post-CrowdTangle Meta Content Library, X pay-per-use API, TikTok Research API, Bluesky/Threads/Mastodon/Telegram coverage). Adds embedded photo metadata (IPTC/EXIF/XMP captions, byline, alt text, keywords, Creative Commons or copyright licensing, AI-source labeling via IPTC Digital Source Type, Google-Images licensing, GPS stripping for source protection, and C2PA Content Credentials reading) for wire and archive use.",
   "author": {
     "name": "Joe Amditis",

--- a/okf-wiki/.claude-plugin/plugin.json
+++ b/okf-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "okf-wiki",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Scaffold an Open Knowledge Format (OKF) knowledge base from existing docs, plans, notes, or a repository: one-concept-per-file Markdown with YAML frontmatter, directory navigation, and validation. Generate a starter wiki that passes conformance and secret-leak checks, or bootstrap an optional GitHub wiki. Session-start hooks orient Claude to the knowledge base. Built for newsroom institutional memory, research atlases, decision logs, and infrastructure maps.",
   "author": {
     "name": "Joe Amditis",

--- a/okf-wiki/SKILL.md
+++ b/okf-wiki/SKILL.md
@@ -11,7 +11,7 @@ description: >-
 license: MIT
 metadata:
   author: jamditis
-  version: "0.6.1"
+  version: "0.7.0"
   okf_spec: v1
 ---
 

--- a/plans/codex-compatibility-matrix.md
+++ b/plans/codex-compatibility-matrix.md
@@ -5,7 +5,7 @@
 - Architecture: [Codex compatibility architecture decision](2026-07-21-codex-compatibility-architecture.md)
 
 > **The released packages are now newer than everything tested here.** The v2.4.0
-> release (July 24, 2026) publishes marketplace 2.4.0, `journalism-core` 1.3.0,
+> release (July 25, 2026) publishes marketplace 2.4.0, `journalism-core` 1.3.0,
 > and `okf-wiki` 0.7.0. Every version recorded below is the version that was
 > actually exercised — marketplace 2.3.3, `journalism-core` 1.2.0, `okf-wiki`
 > 0.6.1 — and those are deliberately **not** bumped to match the release, because

--- a/plans/codex-compatibility-matrix.md
+++ b/plans/codex-compatibility-matrix.md
@@ -4,6 +4,20 @@
 - Last evidence update: July 23, 2026
 - Architecture: [Codex compatibility architecture decision](2026-07-21-codex-compatibility-architecture.md)
 
+> **The released packages are now newer than everything tested here.** The v2.4.0
+> release (July 24, 2026) publishes marketplace 2.4.0, `journalism-core` 1.3.0,
+> and `okf-wiki` 0.7.0. Every version recorded below is the version that was
+> actually exercised — marketplace 2.3.3, `journalism-core` 1.2.0, `okf-wiki`
+> 0.6.1 — and those are deliberately **not** bumped to match the release, because
+> this file records evidence and the rule under [Tool baseline](#tool-baseline) is
+> to never rewrite an older result as if it ran on the newer version.
+>
+> The practical consequence for a reader: the unversioned install commands in the
+> README now deliver packages that no pilot here has covered. Treat the passes
+> below as evidence for the 2.3.3-era packages, not as a support claim for 2.4.0,
+> until the pilots are re-run against the released versions. Re-running them is
+> what clears this note.
+
 ## How to read this matrix
 
 This file records what has been proved for each package. Installation alone is

--- a/scripts/journalism-core-install-canary.mjs
+++ b/scripts/journalism-core-install-canary.mjs
@@ -32,7 +32,7 @@ export const EXPECTED_SKILL_NAMES = [
 ];
 
 const PLUGIN_ID = 'journalism-core@claude-skills-journalism';
-const EXPECTED_VERSION = '1.2.0';
+const EXPECTED_VERSION = '1.3.0';
 export const SUBPROCESS_TIMEOUT_MS = 180_000;
 
 export function buildCommandPlan(client, repoRoot, tempRoot) {

--- a/scripts/journalism-core-install-canary.test.mjs
+++ b/scripts/journalism-core-install-canary.test.mjs
@@ -85,7 +85,7 @@ test('Claude and Codex canaries use isolated config homes and local source', () 
 test('Claude and Codex install records must contain the exact journalism-core skill set', (t) => {
   const root = mkdtempSync(join(tmpdir(), 'journalism-core-canary-test-'));
   t.after(() => rmSync(root, { recursive: true, force: true }));
-  const installPath = join(root, 'plugins', 'journalism-core', '1.2.0');
+  const installPath = join(root, 'plugins', 'journalism-core', '1.3.0');
 
   for (const name of EXPECTED_SKILL_NAMES) {
     const directory = join(installPath, 'skills', name);
@@ -95,14 +95,14 @@ test('Claude and Codex install records must contain the exact journalism-core sk
 
   const claude = JSON.stringify([{
     id: 'journalism-core@claude-skills-journalism',
-    version: '1.2.0',
+    version: '1.3.0',
     enabled: true,
     installPath,
   }]);
   const codex = JSON.stringify({
     installed: [{
       pluginId: 'journalism-core@claude-skills-journalism',
-      version: '1.2.0',
+      version: '1.3.0',
       installed: true,
       enabled: true,
       source: { source: 'local', path: '/repo/journalism-core' },
@@ -126,7 +126,7 @@ test('the canary rejects a partial package install', (t) => {
 
   const output = JSON.stringify([{
     id: 'journalism-core@claude-skills-journalism',
-    version: '1.2.0',
+    version: '1.3.0',
     enabled: true,
     installPath,
   }]);

--- a/scripts/skill-frontmatter.test.mjs
+++ b/scripts/skill-frontmatter.test.mjs
@@ -112,12 +112,14 @@ test('every SKILL.md follows the Agent Skills frontmatter contract', () => {
   assert.deepEqual(errors, []);
 });
 
-test('frontmatter repairs advance the affected Claude package versions', () => {
+test('published package versions stay aligned with the marketplace', () => {
   const marketplace = JSON.parse(
     readFileSync(join(ROOT, '.claude-plugin', 'marketplace.json'), 'utf8'),
   );
-  assert.equal(marketplace.version, '2.3.3', 'marketplace version');
+  assert.equal(marketplace.version, '2.4.0', 'marketplace version');
   const expected = new Map([
+    ['journalism-core', '1.3.0'],
+    ['okf-wiki', '0.7.0'],
     ['pdf-playground', '1.3.2'],
     ['video-toolkit', '1.0.3'],
   ]);


### PR DESCRIPTION
## Summary

- cut the changelog from the complete `v2.3.3...master` range
- advance the marketplace rollup from 2.3.3 to 2.4.0
- publish journalism-core 1.3.0 for the photo-metadata provenance update
- publish okf-wiki 0.7.0 for provider secret detection and the isolated runtime boundary
- keep clean-install canary expectations aligned with the published manifests

## Verification

- `npm test` — 160 passed
- `npm run validate:agent-skills` — 60 passed, 0 failed
- `npm run check:docs-css` — 49 stylesheets verified
- `python3 -m pytest hooks/tests -q` — 253 passed
- `python3 -m pytest okf-wiki/tests -q` — 214 passed
- `ruff check hooks/` — passed
- `git diff --check` — passed
- local Codex 5.5/low review — no actionable findings

The photo-metadata test module collected 22 tests but skipped them because `exiftool` is not installed on this host. The implementation passed all 22 before #255 merged; this branch changes only its package version and release notes.