### PR TITLE
chore: stop emitting session attribution in commits and PRs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "attribution": {
+    "sessionUrl": false,
+    "commit": "",
+    "pr": ""
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,3 +344,18 @@ Seven rules keep it honest, all covered by tests in
 - Keep descriptions terse and actionable
 - Include examples and templates
 - Avoid AI writing patterns (see ai-writing-detox)
+
+## Commits and attribution
+
+No AI attribution in commits, PR bodies, issues, docs, or code. `.claude/settings.json` sets `attribution.sessionUrl` to false and blanks `attribution.commit` and `attribution.pr`, which stops Claude Code from appending a `Claude-Session:` trailer to commits, adding the session link to PR bodies, and emitting the "Generated with Claude Code" strings. Web and Remote Control sessions both emit these by default. The setting lives in the repo rather than `~/.claude/settings.json` because cloud sessions clone the repo and never read user-level config. Don't reintroduce any of it by hand.
+
+No `Co-authored-by` trailers of any kind, including Joe's own aliases.
+
+Git identity — set before committing, in every worktree and every agent session:
+
+```sh
+git config user.name "Joe Amditis"
+git config user.email "6799804+jamditis@users.noreply.github.com"
+```
+
+Any other author email either trips GitHub's email-privacy push block (GH007) or makes a squash merge inject a `Co-authored-by` line into the merge body.


### PR DESCRIPTION
Claude Code appends a `Claude-Session:` trailer to commits and a session link to PR bodies for any commit made from a web or Remote Control session. Because Remote Control auto-connects on this fleet, that has been every agent commit, and 34 such trailers have already landed across seven repos. This repo is one of them.

`.claude/settings.json` now sets `attribution.sessionUrl` to false and blanks `attribution.commit` and `attribution.pr`, which suppresses the trailer, the PR-body link, and the "Generated with Claude Code" byline.

The setting has to be committed rather than set in `~/.claude/settings.json` because cloud sessions clone the repo and never read user-level config.

Existing trailers in merged history are left alone — removing them would mean rewriting published branches.