### PR TITLE
okf-wiki: make intra-bundle link checks case-sensitive

### DIFF
--- a/okf-wiki/example/SPEC.md
+++ b/okf-wiki/example/SPEC.md
@@ -283,6 +283,13 @@ Relative markdown links. Every link to a file inside the bundle must resolve to 
 exists; a link that escapes the bundle root or dangles fails validation. The bundle is
 validated as one self-contained tree (see Federation for combining several).
 
+A link's case must match the file on disk. macOS and Windows resolve
+`Concepts/Foo.md` to `concepts/foo.md` and answer that the file exists, so a bundle
+written there validates locally and dangles the first time a Linux reader or CI job
+opens it. The validator compares each path component against the real directory
+listing rather than asking the filesystem, and names the on-disk path in the error, so
+the mismatch is caught on the machine that introduced it.
+
 The `[[slug]]` wikilink form is not an OKF link, and the validator rejects it. It is the
 auto-memory cross-reference idiom and easy to reach for by habit, but a `[[slug]]` is never
 resolved or checked, so a dead reference would pass silently. Always link with

--- a/okf-wiki/example/SPEC.md
+++ b/okf-wiki/example/SPEC.md
@@ -287,8 +287,9 @@ A link's case must match the file on disk. macOS resolves `Concepts/Foo.md` to
 `concepts/foo.md` and answers that the file exists, so a bundle written there validates
 locally and dangles the first time a Linux reader or CI job opens it. The validator
 compares each path component against the real directory listing rather than asking the
-filesystem, and the error gives the link to write instead, so a macOS author sees the
-mismatch on their own machine.
+filesystem, and the error gives the link to write instead, so a macOS author usually
+sees the mismatch on their own machine. A wrong-cased symlink component can be
+normalized to its target before this comparison and is caught later by Linux CI.
 
 A Windows author does not: there `Path.resolve()` goes through
 GetFinalPathNameByHandle, which substitutes the on-disk casing before the check runs.

--- a/okf-wiki/example/SPEC.md
+++ b/okf-wiki/example/SPEC.md
@@ -283,12 +283,16 @@ Relative markdown links. Every link to a file inside the bundle must resolve to 
 exists; a link that escapes the bundle root or dangles fails validation. The bundle is
 validated as one self-contained tree (see Federation for combining several).
 
-A link's case must match the file on disk. macOS and Windows resolve
-`Concepts/Foo.md` to `concepts/foo.md` and answer that the file exists, so a bundle
-written there validates locally and dangles the first time a Linux reader or CI job
-opens it. The validator compares each path component against the real directory
-listing rather than asking the filesystem, and names the on-disk path in the error, so
-the mismatch is caught on the machine that introduced it.
+A link's case must match the file on disk. macOS resolves `Concepts/Foo.md` to
+`concepts/foo.md` and answers that the file exists, so a bundle written there validates
+locally and dangles the first time a Linux reader or CI job opens it. The validator
+compares each path component against the real directory listing rather than asking the
+filesystem, and the error gives the link to write instead, so a macOS author sees the
+mismatch on their own machine.
+
+A Windows author does not: there `Path.resolve()` goes through
+GetFinalPathNameByHandle, which substitutes the on-disk casing before the check runs.
+Their wrong-case link is still caught, on Linux CI or by the next Linux reader.
 
 The `[[slug]]` wikilink form is not an OKF link, and the validator rejects it. It is the
 auto-memory cross-reference idiom and easy to reach for by habit, but a `[[slug]]` is never

--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -25,7 +25,9 @@ Checks:
      frontmatter — except the bundle-root index.md may carry okf_version only.
   4. Internal markdown links resolve. Links must be relative — a root-relative
      ('/'-prefixed) link is rejected. Every link to a .md file inside the bundle
-     must point at a file that exists; a link that escapes the bundle root or
+     must point at a file that exists, with the case it has on disk (a
+     case-insensitive filesystem would otherwise let a wrong-case link pass on
+     macOS and dangle on Linux); a link that escapes the bundle root or
      dangles is a hard failure. Optional link titles and <>-wrapped destinations
      are handled. The bundle is validated as one self-contained tree (to validate
      federated content, assemble the bundles into one tree and point --bundle at
@@ -51,6 +53,7 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import math
+import os
 import re
 import sys
 from collections import Counter
@@ -327,6 +330,41 @@ def resolve_link(target: str, md_file: Path) -> Path:
     .resolve() collapses ../ so the bundle-boundary check is not fooled by a path
     like ../../outside.md."""
     return (md_file.parent / target).resolve()
+
+
+def real_case_path(dest: Path, bundle: Path) -> Path | None:
+    """The path on disk that `dest` names, ignoring case, or None if nothing matches.
+
+    Returns `dest` unchanged when every component already matches the real name.
+
+    Path.exists() asks the filesystem, and macOS and Windows answer yes for
+    `Concepts/Foo.md` when the file is really `concepts/foo.md`. A bundle written
+    there passes validation on the author's machine and dangles the first time
+    Linux CI or a Linux reader opens it, which is the class of break this
+    validator exists to catch before it ships. So walk the components against the
+    real directory listings instead of asking whether the path exists.
+
+    The walk doubles as the existence check: a component that matches nothing,
+    case or no case, means the link dangles.
+
+    `dest` must be inside `bundle`; the caller checks that first.
+    """
+    current = bundle
+    for part in dest.relative_to(bundle).parts:
+        try:
+            names = set(os.listdir(current))
+        except OSError:
+            return None  # not a directory, or unreadable: nothing below it resolves
+        if part in names:
+            current = current / part
+            continue
+        # Exactly one case-variant is a mismatch worth naming. Several means a
+        # case-sensitive filesystem holding both, and no way to say which was meant.
+        variants = [n for n in names if n.lower() == part.lower()]
+        if len(variants) != 1:
+            return None
+        current = current / variants[0]
+    return current
 
 
 def strip_code(text: str) -> str:
@@ -1121,8 +1159,16 @@ def main() -> int:
             inside = dest == bundle or bundle in dest.parents
             if not inside:
                 errors.append(f"{f.relative_to(bundle)}: link escapes bundle root -> {target}")
-            elif not dest.exists():
-                errors.append(f"{f.relative_to(bundle)}: dangling link -> {target}")
+            else:
+                real = real_case_path(dest, bundle)
+                if real is None:
+                    errors.append(f"{f.relative_to(bundle)}: dangling link -> {target}")
+                elif real != dest:
+                    errors.append(
+                        f"{f.relative_to(bundle)}: link case does not match the file on "
+                        f"disk -> {target}; the file is "
+                        f"{real.relative_to(bundle).as_posix()}. Links are case-sensitive "
+                        f"on Linux, so this resolves on macOS and breaks in CI.")
 
     # report
     print(f"Bundle: {bundle}")

--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -333,7 +333,9 @@ def resolve_link(target: str, md_file: Path) -> Path:
     return (md_file.parent / target).resolve()
 
 
-def real_case_path(dest: Path, bundle: Path) -> Path | None:
+def real_case_path(
+    dest: Path, bundle: Path, *, allow_nonconforming_md: bool = False
+) -> Path | None:
     """The path on disk that `dest` names, ignoring case, or None if nothing matches.
 
     Returns `dest` unchanged when every component already matches the real name.
@@ -369,7 +371,12 @@ def real_case_path(dest: Path, bundle: Path) -> Path | None:
             continue
         # Exactly one case-variant is a mismatch worth naming. Several means a
         # case-sensitive filesystem holding both, and no way to say which was meant.
+        # Do not recommend a file with an uppercase .md extension as a link fix: that
+        # filename is rejected elsewhere in this validator. The caller can opt into a
+        # second lookup solely to give that non-conforming file a rename diagnostic.
         variants = [n for n in names if n.lower() == part.lower()]
+        if not allow_nonconforming_md and Path(part).suffix.lower() == ".md":
+            variants = [n for n in variants if Path(n).suffix == ".md"]
         if len(variants) != 1:
             return None
         current = current / variants[0]
@@ -1171,7 +1178,20 @@ def main() -> int:
             else:
                 real = real_case_path(dest, bundle)
                 if real is None:
-                    errors.append(f"{f.relative_to(bundle)}: dangling link -> {target}")
+                    nonconforming = real_case_path(
+                        dest, bundle, allow_nonconforming_md=True
+                    )
+                    if (nonconforming is not None
+                            and nonconforming.suffix.lower() == ".md"
+                            and nonconforming.suffix != ".md"):
+                        found = os.path.relpath(nonconforming, f.parent).replace(os.sep, "/")
+                        expected = os.path.relpath(dest, f.parent).replace(os.sep, "/")
+                        errors.append(
+                            f"{f.relative_to(bundle)}: link target exists only as a "
+                            f"non-conforming markdown filename -> {target}; rename "
+                            f"{found} to {expected}")
+                    else:
+                        errors.append(f"{f.relative_to(bundle)}: dangling link -> {target}")
                 elif real != dest:
                     # Report the fix as a link, relative to the file doing the linking,
                     # so it can be pasted straight in. Bundle-relative would be the

--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -27,8 +27,9 @@ Checks:
      ('/'-prefixed) link is rejected. Every link to a .md file inside the bundle
      must point at a file that exists, with the case it has on disk (a
      case-insensitive filesystem would otherwise let a wrong-case link pass on
-     macOS and dangle on Linux); a link that escapes the bundle root or
-     dangles is a hard failure. Optional link titles and <>-wrapped destinations
+     macOS and dangle on Linux; see real_case_path for why a Windows author is
+     not covered); a link that escapes the bundle root or dangles is a hard
+     failure. Optional link titles and <>-wrapped destinations
      are handled. The bundle is validated as one self-contained tree (to validate
      federated content, assemble the bundles into one tree and point --bundle at
      that root).
@@ -337,15 +338,23 @@ def real_case_path(dest: Path, bundle: Path) -> Path | None:
 
     Returns `dest` unchanged when every component already matches the real name.
 
-    Path.exists() asks the filesystem, and macOS and Windows answer yes for
-    `Concepts/Foo.md` when the file is really `concepts/foo.md`. A bundle written
-    there passes validation on the author's machine and dangles the first time
-    Linux CI or a Linux reader opens it, which is the class of break this
-    validator exists to catch before it ships. So walk the components against the
-    real directory listings instead of asking whether the path exists.
+    Path.exists() asks the filesystem, and macOS answers yes for `Concepts/Foo.md`
+    when the file is really `concepts/foo.md`. A bundle written there passes
+    validation on the author's machine and dangles the first time Linux CI or a
+    Linux reader opens it, which is the class of break this validator exists to
+    catch before it ships. So walk the components against the real directory
+    listings instead of asking whether the path exists.
 
     The walk doubles as the existence check: a component that matches nothing,
     case or no case, means the link dangles.
+
+    This does not catch a Windows author, and saying so is the honest scope: there
+    os.path.realpath goes through GetFinalPathNameByHandle, so Path.resolve() has
+    already replaced the link's casing with the on-disk casing by the time the
+    walk sees it, and every component matches. A Windows-side wrong-case link is
+    still caught, just later, by Linux CI. Fixing it needs a lexically normalized
+    path here, which is not the same as the resolved one across a symlinked
+    directory, so it is tracked separately rather than bolted on.
 
     `dest` must be inside `bundle`; the caller checks that first.
     """
@@ -1164,10 +1173,13 @@ def main() -> int:
                 if real is None:
                     errors.append(f"{f.relative_to(bundle)}: dangling link -> {target}")
                 elif real != dest:
+                    # Report the fix as a link, relative to the file doing the linking,
+                    # so it can be pasted straight in. Bundle-relative would be the
+                    # error-line convention but is not what goes between the parens.
+                    fix = os.path.relpath(real, f.parent).replace(os.sep, "/")
                     errors.append(
                         f"{f.relative_to(bundle)}: link case does not match the file on "
-                        f"disk -> {target}; the file is "
-                        f"{real.relative_to(bundle).as_posix()}. Links are case-sensitive "
+                        f"disk -> {target}; write {fix}. Links are case-sensitive "
                         f"on Linux, so this resolves on macOS and breaks in CI.")
 
     # report

--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -350,13 +350,12 @@ def real_case_path(
     The walk doubles as the existence check: a component that matches nothing,
     case or no case, means the link dangles.
 
-    This does not catch a Windows author, and saying so is the honest scope: there
-    os.path.realpath goes through GetFinalPathNameByHandle, so Path.resolve() has
-    already replaced the link's casing with the on-disk casing by the time the
-    walk sees it, and every component matches. A Windows-side wrong-case link is
-    still caught, just later, by Linux CI. Fixing it needs a lexically normalized
-    path here, which is not the same as the resolved one across a symlinked
-    directory, so it is tracked separately rather than bolted on.
+    This does not catch a Windows author, and a wrong-cased symlink component can
+    escape the local check on case-insensitive macOS. In both cases Path.resolve()
+    may replace the link's spelling with the on-disk target before the walk sees
+    it. The wrong-case link is still caught later by Linux CI. Fixing it needs a
+    lexically normalized path here, which is not the same as the resolved one
+    across a symlinked directory, so it is tracked separately rather than bolted on.
 
     `dest` must be inside `bundle`; the caller checks that first.
     """
@@ -1177,15 +1176,19 @@ def main() -> int:
                 errors.append(f"{f.relative_to(bundle)}: link escapes bundle root -> {target}")
             else:
                 real = real_case_path(dest, bundle)
+                if real is not None and not real.exists():
+                    real = None
                 if real is None:
                     nonconforming = real_case_path(
                         dest, bundle, allow_nonconforming_md=True
                     )
                     if (nonconforming is not None
+                            and nonconforming.exists()
                             and nonconforming.suffix.lower() == ".md"
                             and nonconforming.suffix != ".md"):
                         found = os.path.relpath(nonconforming, f.parent).replace(os.sep, "/")
-                        expected = os.path.relpath(dest, f.parent).replace(os.sep, "/")
+                        expected_path = nonconforming.parent / dest.name
+                        expected = os.path.relpath(expected_path, f.parent).replace(os.sep, "/")
                         errors.append(
                             f"{f.relative_to(bundle)}: link target exists only as a "
                             f"non-conforming markdown filename -> {target}; rename "

--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -1187,7 +1187,7 @@ def main() -> int:
                             and nonconforming.suffix.lower() == ".md"
                             and nonconforming.suffix != ".md"):
                         found = os.path.relpath(nonconforming, f.parent).replace(os.sep, "/")
-                        expected_path = nonconforming.parent / dest.name
+                        expected_path = nonconforming.parent / Path(dest.name).with_suffix(".md")
                         expected = os.path.relpath(expected_path, f.parent).replace(os.sep, "/")
                         errors.append(
                             f"{f.relative_to(bundle)}: link target exists only as a "

--- a/okf-wiki/example/scripts/validate.py
+++ b/okf-wiki/example/scripts/validate.py
@@ -312,18 +312,21 @@ def frontmatter_block(text: str) -> str | None:
     return m.group(1) if m else None
 
 
-def link_destination(raw: str) -> str:
-    """Pull the destination out of a markdown link's (...) contents: strip <...>
-    wrapping, an optional "title"/'title', and any #anchor. Markdown allows
+def link_destination(raw: str) -> tuple[str, str]:
+    """Pull the path and fragment out of a markdown link's (...) contents: strip
+    <...> wrapping and an optional "title"/'title'. Markdown allows
     [text](dest "title") and [text](<dest with spaces>) — treating the whole
     contents as the path would falsely flag those as dangling."""
     s = raw.strip()
     if s.startswith("<"):
         end = s.find(">")
         if end != -1:
-            return s[1:end].split("#", 1)[0].strip()
+            destination = s[1:end].strip()
+            path, separator, fragment = destination.partition("#")
+            return path, separator + fragment
     s = s.split(None, 1)[0] if s else s  # dest ends at first space; rest is a title
-    return s.split("#", 1)[0]
+    path, separator, fragment = s.partition("#")
+    return path, separator + fragment
 
 
 def resolve_link(target: str, md_file: Path) -> Path:
@@ -1151,7 +1154,7 @@ def main() -> int:
                 f"relative markdown link like [text]({slug}.md). The [[slug]] form is "
                 f"the auto-memory convention, not OKF.")
         for raw in LINK_RE.findall(text):
-            target = link_destination(raw)
+            target, fragment = link_destination(raw)
             if not target:
                 continue
             low = target.lower()
@@ -1199,7 +1202,7 @@ def main() -> int:
                     # Report the fix as a link, relative to the file doing the linking,
                     # so it can be pasted straight in. Bundle-relative would be the
                     # error-line convention but is not what goes between the parens.
-                    fix = os.path.relpath(real, f.parent).replace(os.sep, "/")
+                    fix = os.path.relpath(real, f.parent).replace(os.sep, "/") + fragment
                     errors.append(
                         f"{f.relative_to(bundle)}: link case does not match the file on "
                         f"disk -> {target}; write {fix}. Links are case-sensitive "

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -25,7 +25,9 @@ Checks:
      frontmatter — except the bundle-root index.md may carry okf_version only.
   4. Internal markdown links resolve. Links must be relative — a root-relative
      ('/'-prefixed) link is rejected. Every link to a .md file inside the bundle
-     must point at a file that exists; a link that escapes the bundle root or
+     must point at a file that exists, with the case it has on disk (a
+     case-insensitive filesystem would otherwise let a wrong-case link pass on
+     macOS and dangle on Linux); a link that escapes the bundle root or
      dangles is a hard failure. Optional link titles and <>-wrapped destinations
      are handled. The bundle is validated as one self-contained tree (to validate
      federated content, assemble the bundles into one tree and point --bundle at
@@ -51,6 +53,7 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import math
+import os
 import re
 import sys
 from collections import Counter
@@ -327,6 +330,41 @@ def resolve_link(target: str, md_file: Path) -> Path:
     .resolve() collapses ../ so the bundle-boundary check is not fooled by a path
     like ../../outside.md."""
     return (md_file.parent / target).resolve()
+
+
+def real_case_path(dest: Path, bundle: Path) -> Path | None:
+    """The path on disk that `dest` names, ignoring case, or None if nothing matches.
+
+    Returns `dest` unchanged when every component already matches the real name.
+
+    Path.exists() asks the filesystem, and macOS and Windows answer yes for
+    `Concepts/Foo.md` when the file is really `concepts/foo.md`. A bundle written
+    there passes validation on the author's machine and dangles the first time
+    Linux CI or a Linux reader opens it, which is the class of break this
+    validator exists to catch before it ships. So walk the components against the
+    real directory listings instead of asking whether the path exists.
+
+    The walk doubles as the existence check: a component that matches nothing,
+    case or no case, means the link dangles.
+
+    `dest` must be inside `bundle`; the caller checks that first.
+    """
+    current = bundle
+    for part in dest.relative_to(bundle).parts:
+        try:
+            names = set(os.listdir(current))
+        except OSError:
+            return None  # not a directory, or unreadable: nothing below it resolves
+        if part in names:
+            current = current / part
+            continue
+        # Exactly one case-variant is a mismatch worth naming. Several means a
+        # case-sensitive filesystem holding both, and no way to say which was meant.
+        variants = [n for n in names if n.lower() == part.lower()]
+        if len(variants) != 1:
+            return None
+        current = current / variants[0]
+    return current
 
 
 def strip_code(text: str) -> str:
@@ -1121,8 +1159,16 @@ def main() -> int:
             inside = dest == bundle or bundle in dest.parents
             if not inside:
                 errors.append(f"{f.relative_to(bundle)}: link escapes bundle root -> {target}")
-            elif not dest.exists():
-                errors.append(f"{f.relative_to(bundle)}: dangling link -> {target}")
+            else:
+                real = real_case_path(dest, bundle)
+                if real is None:
+                    errors.append(f"{f.relative_to(bundle)}: dangling link -> {target}")
+                elif real != dest:
+                    errors.append(
+                        f"{f.relative_to(bundle)}: link case does not match the file on "
+                        f"disk -> {target}; the file is "
+                        f"{real.relative_to(bundle).as_posix()}. Links are case-sensitive "
+                        f"on Linux, so this resolves on macOS and breaks in CI.")
 
     # report
     print(f"Bundle: {bundle}")

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -333,7 +333,9 @@ def resolve_link(target: str, md_file: Path) -> Path:
     return (md_file.parent / target).resolve()
 
 
-def real_case_path(dest: Path, bundle: Path) -> Path | None:
+def real_case_path(
+    dest: Path, bundle: Path, *, allow_nonconforming_md: bool = False
+) -> Path | None:
     """The path on disk that `dest` names, ignoring case, or None if nothing matches.
 
     Returns `dest` unchanged when every component already matches the real name.
@@ -369,7 +371,12 @@ def real_case_path(dest: Path, bundle: Path) -> Path | None:
             continue
         # Exactly one case-variant is a mismatch worth naming. Several means a
         # case-sensitive filesystem holding both, and no way to say which was meant.
+        # Do not recommend a file with an uppercase .md extension as a link fix: that
+        # filename is rejected elsewhere in this validator. The caller can opt into a
+        # second lookup solely to give that non-conforming file a rename diagnostic.
         variants = [n for n in names if n.lower() == part.lower()]
+        if not allow_nonconforming_md and Path(part).suffix.lower() == ".md":
+            variants = [n for n in variants if Path(n).suffix == ".md"]
         if len(variants) != 1:
             return None
         current = current / variants[0]
@@ -1171,7 +1178,20 @@ def main() -> int:
             else:
                 real = real_case_path(dest, bundle)
                 if real is None:
-                    errors.append(f"{f.relative_to(bundle)}: dangling link -> {target}")
+                    nonconforming = real_case_path(
+                        dest, bundle, allow_nonconforming_md=True
+                    )
+                    if (nonconforming is not None
+                            and nonconforming.suffix.lower() == ".md"
+                            and nonconforming.suffix != ".md"):
+                        found = os.path.relpath(nonconforming, f.parent).replace(os.sep, "/")
+                        expected = os.path.relpath(dest, f.parent).replace(os.sep, "/")
+                        errors.append(
+                            f"{f.relative_to(bundle)}: link target exists only as a "
+                            f"non-conforming markdown filename -> {target}; rename "
+                            f"{found} to {expected}")
+                    else:
+                        errors.append(f"{f.relative_to(bundle)}: dangling link -> {target}")
                 elif real != dest:
                     # Report the fix as a link, relative to the file doing the linking,
                     # so it can be pasted straight in. Bundle-relative would be the

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -27,8 +27,9 @@ Checks:
      ('/'-prefixed) link is rejected. Every link to a .md file inside the bundle
      must point at a file that exists, with the case it has on disk (a
      case-insensitive filesystem would otherwise let a wrong-case link pass on
-     macOS and dangle on Linux); a link that escapes the bundle root or
-     dangles is a hard failure. Optional link titles and <>-wrapped destinations
+     macOS and dangle on Linux; see real_case_path for why a Windows author is
+     not covered); a link that escapes the bundle root or dangles is a hard
+     failure. Optional link titles and <>-wrapped destinations
      are handled. The bundle is validated as one self-contained tree (to validate
      federated content, assemble the bundles into one tree and point --bundle at
      that root).
@@ -337,15 +338,23 @@ def real_case_path(dest: Path, bundle: Path) -> Path | None:
 
     Returns `dest` unchanged when every component already matches the real name.
 
-    Path.exists() asks the filesystem, and macOS and Windows answer yes for
-    `Concepts/Foo.md` when the file is really `concepts/foo.md`. A bundle written
-    there passes validation on the author's machine and dangles the first time
-    Linux CI or a Linux reader opens it, which is the class of break this
-    validator exists to catch before it ships. So walk the components against the
-    real directory listings instead of asking whether the path exists.
+    Path.exists() asks the filesystem, and macOS answers yes for `Concepts/Foo.md`
+    when the file is really `concepts/foo.md`. A bundle written there passes
+    validation on the author's machine and dangles the first time Linux CI or a
+    Linux reader opens it, which is the class of break this validator exists to
+    catch before it ships. So walk the components against the real directory
+    listings instead of asking whether the path exists.
 
     The walk doubles as the existence check: a component that matches nothing,
     case or no case, means the link dangles.
+
+    This does not catch a Windows author, and saying so is the honest scope: there
+    os.path.realpath goes through GetFinalPathNameByHandle, so Path.resolve() has
+    already replaced the link's casing with the on-disk casing by the time the
+    walk sees it, and every component matches. A Windows-side wrong-case link is
+    still caught, just later, by Linux CI. Fixing it needs a lexically normalized
+    path here, which is not the same as the resolved one across a symlinked
+    directory, so it is tracked separately rather than bolted on.
 
     `dest` must be inside `bundle`; the caller checks that first.
     """
@@ -1164,10 +1173,13 @@ def main() -> int:
                 if real is None:
                     errors.append(f"{f.relative_to(bundle)}: dangling link -> {target}")
                 elif real != dest:
+                    # Report the fix as a link, relative to the file doing the linking,
+                    # so it can be pasted straight in. Bundle-relative would be the
+                    # error-line convention but is not what goes between the parens.
+                    fix = os.path.relpath(real, f.parent).replace(os.sep, "/")
                     errors.append(
                         f"{f.relative_to(bundle)}: link case does not match the file on "
-                        f"disk -> {target}; the file is "
-                        f"{real.relative_to(bundle).as_posix()}. Links are case-sensitive "
+                        f"disk -> {target}; write {fix}. Links are case-sensitive "
                         f"on Linux, so this resolves on macOS and breaks in CI.")
 
     # report

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -350,13 +350,12 @@ def real_case_path(
     The walk doubles as the existence check: a component that matches nothing,
     case or no case, means the link dangles.
 
-    This does not catch a Windows author, and saying so is the honest scope: there
-    os.path.realpath goes through GetFinalPathNameByHandle, so Path.resolve() has
-    already replaced the link's casing with the on-disk casing by the time the
-    walk sees it, and every component matches. A Windows-side wrong-case link is
-    still caught, just later, by Linux CI. Fixing it needs a lexically normalized
-    path here, which is not the same as the resolved one across a symlinked
-    directory, so it is tracked separately rather than bolted on.
+    This does not catch a Windows author, and a wrong-cased symlink component can
+    escape the local check on case-insensitive macOS. In both cases Path.resolve()
+    may replace the link's spelling with the on-disk target before the walk sees
+    it. The wrong-case link is still caught later by Linux CI. Fixing it needs a
+    lexically normalized path here, which is not the same as the resolved one
+    across a symlinked directory, so it is tracked separately rather than bolted on.
 
     `dest` must be inside `bundle`; the caller checks that first.
     """
@@ -1177,15 +1176,19 @@ def main() -> int:
                 errors.append(f"{f.relative_to(bundle)}: link escapes bundle root -> {target}")
             else:
                 real = real_case_path(dest, bundle)
+                if real is not None and not real.exists():
+                    real = None
                 if real is None:
                     nonconforming = real_case_path(
                         dest, bundle, allow_nonconforming_md=True
                     )
                     if (nonconforming is not None
+                            and nonconforming.exists()
                             and nonconforming.suffix.lower() == ".md"
                             and nonconforming.suffix != ".md"):
                         found = os.path.relpath(nonconforming, f.parent).replace(os.sep, "/")
-                        expected = os.path.relpath(dest, f.parent).replace(os.sep, "/")
+                        expected_path = nonconforming.parent / dest.name
+                        expected = os.path.relpath(expected_path, f.parent).replace(os.sep, "/")
                         errors.append(
                             f"{f.relative_to(bundle)}: link target exists only as a "
                             f"non-conforming markdown filename -> {target}; rename "

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -1187,7 +1187,7 @@ def main() -> int:
                             and nonconforming.suffix.lower() == ".md"
                             and nonconforming.suffix != ".md"):
                         found = os.path.relpath(nonconforming, f.parent).replace(os.sep, "/")
-                        expected_path = nonconforming.parent / dest.name
+                        expected_path = nonconforming.parent / Path(dest.name).with_suffix(".md")
                         expected = os.path.relpath(expected_path, f.parent).replace(os.sep, "/")
                         errors.append(
                             f"{f.relative_to(bundle)}: link target exists only as a "

--- a/okf-wiki/scripts/validate.py
+++ b/okf-wiki/scripts/validate.py
@@ -312,18 +312,21 @@ def frontmatter_block(text: str) -> str | None:
     return m.group(1) if m else None
 
 
-def link_destination(raw: str) -> str:
-    """Pull the destination out of a markdown link's (...) contents: strip <...>
-    wrapping, an optional "title"/'title', and any #anchor. Markdown allows
+def link_destination(raw: str) -> tuple[str, str]:
+    """Pull the path and fragment out of a markdown link's (...) contents: strip
+    <...> wrapping and an optional "title"/'title'. Markdown allows
     [text](dest "title") and [text](<dest with spaces>) — treating the whole
     contents as the path would falsely flag those as dangling."""
     s = raw.strip()
     if s.startswith("<"):
         end = s.find(">")
         if end != -1:
-            return s[1:end].split("#", 1)[0].strip()
+            destination = s[1:end].strip()
+            path, separator, fragment = destination.partition("#")
+            return path, separator + fragment
     s = s.split(None, 1)[0] if s else s  # dest ends at first space; rest is a title
-    return s.split("#", 1)[0]
+    path, separator, fragment = s.partition("#")
+    return path, separator + fragment
 
 
 def resolve_link(target: str, md_file: Path) -> Path:
@@ -1151,7 +1154,7 @@ def main() -> int:
                 f"relative markdown link like [text]({slug}.md). The [[slug]] form is "
                 f"the auto-memory convention, not OKF.")
         for raw in LINK_RE.findall(text):
-            target = link_destination(raw)
+            target, fragment = link_destination(raw)
             if not target:
                 continue
             low = target.lower()
@@ -1199,7 +1202,7 @@ def main() -> int:
                     # Report the fix as a link, relative to the file doing the linking,
                     # so it can be pasted straight in. Bundle-relative would be the
                     # error-line convention but is not what goes between the parens.
-                    fix = os.path.relpath(real, f.parent).replace(os.sep, "/")
+                    fix = os.path.relpath(real, f.parent).replace(os.sep, "/") + fragment
                     errors.append(
                         f"{f.relative_to(bundle)}: link case does not match the file on "
                         f"disk -> {target}; write {fix}. Links are case-sensitive "

--- a/okf-wiki/spec/SPEC.md
+++ b/okf-wiki/spec/SPEC.md
@@ -283,6 +283,13 @@ Relative markdown links. Every link to a file inside the bundle must resolve to 
 exists; a link that escapes the bundle root or dangles fails validation. The bundle is
 validated as one self-contained tree (see Federation for combining several).
 
+A link's case must match the file on disk. macOS and Windows resolve
+`Concepts/Foo.md` to `concepts/foo.md` and answer that the file exists, so a bundle
+written there validates locally and dangles the first time a Linux reader or CI job
+opens it. The validator compares each path component against the real directory
+listing rather than asking the filesystem, and names the on-disk path in the error, so
+the mismatch is caught on the machine that introduced it.
+
 The `[[slug]]` wikilink form is not an OKF link, and the validator rejects it. It is the
 auto-memory cross-reference idiom and easy to reach for by habit, but a `[[slug]]` is never
 resolved or checked, so a dead reference would pass silently. Always link with

--- a/okf-wiki/spec/SPEC.md
+++ b/okf-wiki/spec/SPEC.md
@@ -287,8 +287,9 @@ A link's case must match the file on disk. macOS resolves `Concepts/Foo.md` to
 `concepts/foo.md` and answers that the file exists, so a bundle written there validates
 locally and dangles the first time a Linux reader or CI job opens it. The validator
 compares each path component against the real directory listing rather than asking the
-filesystem, and the error gives the link to write instead, so a macOS author sees the
-mismatch on their own machine.
+filesystem, and the error gives the link to write instead, so a macOS author usually
+sees the mismatch on their own machine. A wrong-cased symlink component can be
+normalized to its target before this comparison and is caught later by Linux CI.
 
 A Windows author does not: there `Path.resolve()` goes through
 GetFinalPathNameByHandle, which substitutes the on-disk casing before the check runs.

--- a/okf-wiki/spec/SPEC.md
+++ b/okf-wiki/spec/SPEC.md
@@ -283,12 +283,16 @@ Relative markdown links. Every link to a file inside the bundle must resolve to 
 exists; a link that escapes the bundle root or dangles fails validation. The bundle is
 validated as one self-contained tree (see Federation for combining several).
 
-A link's case must match the file on disk. macOS and Windows resolve
-`Concepts/Foo.md` to `concepts/foo.md` and answer that the file exists, so a bundle
-written there validates locally and dangles the first time a Linux reader or CI job
-opens it. The validator compares each path component against the real directory
-listing rather than asking the filesystem, and names the on-disk path in the error, so
-the mismatch is caught on the machine that introduced it.
+A link's case must match the file on disk. macOS resolves `Concepts/Foo.md` to
+`concepts/foo.md` and answers that the file exists, so a bundle written there validates
+locally and dangles the first time a Linux reader or CI job opens it. The validator
+compares each path component against the real directory listing rather than asking the
+filesystem, and the error gives the link to write instead, so a macOS author sees the
+mismatch on their own machine.
+
+A Windows author does not: there `Path.resolve()` goes through
+GetFinalPathNameByHandle, which substitutes the on-disk casing before the check runs.
+Their wrong-case link is still caught, on Linux CI or by the next Linux reader.
 
 The `[[slug]]` wikilink form is not an OKF link, and the validator rejects it. It is the
 auto-memory cross-reference idiom and easy to reach for by habit, but a `[[slug]]` is never

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -969,6 +969,21 @@ def test_nonconforming_extension_rename_uses_real_parent_case(tmp_path):
     assert "rename Target.MD to ../Concepts/target.md" not in out
 
 
+def test_nonconforming_extension_rename_normalizes_link_extension(tmp_path):
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD, name="concepts/Target.MD")
+    write_concept(
+        b,
+        GOOD.rstrip() + "\n\nSee [target](target.MD).\n",
+        name="concepts/c.md",
+    )
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "rename Target.MD to target.md" in out
+    assert "rename Target.MD to target.MD" not in out
+
+
 def test_wrong_case_dangling_symlink_is_reported_as_dangling(tmp_path):
     scaffold(tmp_path / "kb", "--no-validate")
     b = tmp_path / "kb" / "bundle"

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -2697,6 +2697,23 @@ def test_wrong_case_link_names_the_real_file(tmp_path):
     assert "dangling link -> Target.md" not in out
 
 
+def test_wrong_case_link_fix_preserves_fragment(tmp_path):
+    # The diagnostic promises a replacement that can be pasted into the link.
+    # Correcting path casing must not discard the section the author targeted.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD, name="concepts/target.md")
+    write_concept(
+        b,
+        GOOD.rstrip() + "\nSee [x](Target.md#usage).\n",
+        name="concepts/c.md",
+    )
+    rc, out = validate(b)
+    assert rc == 1
+    assert "link case does not match" in out
+    assert "write target.md#usage" in out
+
+
 def test_wrong_case_directory_in_link_caught(tmp_path):
     # Every component is walked, not just the filename: a mac-side bundle can get
     # the directory wrong just as easily.

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -2642,7 +2642,8 @@ def test_wrong_case_link_names_the_real_file(tmp_path):
     rc, out = validate(b)
     assert rc == 1
     assert "link case does not match" in out
-    assert "concepts/target.md" in out
+    # Relative to the linking file, so it can be pasted straight into the link.
+    assert "write target.md" in out
     # The unhelpful wording must not also fire for the same link.
     assert "dangling link -> Target.md" not in out
 
@@ -2689,3 +2690,17 @@ def test_real_case_path_reports_the_on_disk_name(tmp_path):
     assert real_case_path(tmp_path / "concepts" / "nowhere.md", tmp_path) is None
     # A file where a directory is expected is not a resolvable parent.
     assert real_case_path(tmp_path / "concepts" / "target.md" / "deeper.md", tmp_path) is None
+
+
+def test_two_case_variants_report_dangling_not_a_guess(tmp_path):
+    # A Linux checkout of a bundle that went through a case-rename on macOS holds
+    # both spellings. There is no way to say which the link meant, and picking
+    # whichever os.listdir returned first would be an order-dependent guess.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD, name="concepts/target.md")
+    write_concept(b, GOOD, name="concepts/Target.md")
+    write_concept(b, GOOD.rstrip() + "\nSee [x](TARGET.md).\n", name="concepts/c.md")
+    rc, out = validate(b)
+    assert rc == 1 and "dangling link -> TARGET.md" in out
+    assert "link case does not match" not in out

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -947,10 +947,11 @@ def test_link_to_existing_uppercase_md_fails(tmp_path):
     scaffold(tmp_path / "kb", "--no-validate")
     b = tmp_path / "kb" / "bundle"
     write_concept(b, GOOD, name="concepts/Target.MD")
-    write_concept(b, GOOD.rstrip() + "\n\nSee [target](Target.MD).\n", name="concepts/c.md")
+    write_concept(b, GOOD.rstrip() + "\n\nSee [target](target.md).\n", name="concepts/c.md")
     rc, out = validate(b)
     assert rc == 1, out
-    assert "Target.MD" in out
+    assert "rename Target.MD to target.md" in out
+    assert "write Target.MD" not in out
 
 
 def test_uppercase_scheme_link_not_flagged(tmp_path):
@@ -2698,6 +2699,11 @@ def test_two_case_variants_report_dangling_not_a_guess(tmp_path):
     # whichever os.listdir returned first would be an order-dependent guess.
     scaffold(tmp_path / "kb", "--no-validate")
     b = tmp_path / "kb" / "bundle"
+    probe = tmp_path / "case-sensitivity-probe"
+    probe.mkdir()
+    (probe / "lower").write_text("x", encoding="utf-8")
+    if (probe / "LOWER").exists():
+        pytest.skip("filesystem cannot represent two names that differ only by case")
     write_concept(b, GOOD, name="concepts/target.md")
     write_concept(b, GOOD, name="concepts/Target.md")
     write_concept(b, GOOD.rstrip() + "\nSee [x](TARGET.md).\n", name="concepts/c.md")

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -2628,3 +2628,64 @@ def test_skill_authoring_workflow_is_version_aware():
     skill = (SKILL / "SKILL.md").read_text(encoding="utf-8")
     assert '`verified` for `okf_version` `0.1` through `0.3`' in skill
     assert '`verified_on` for `okf_version` `0.4`' in skill
+
+
+def test_wrong_case_link_names_the_real_file(tmp_path):
+    # The link resolves on macOS and Windows, where the filesystem answers
+    # case-insensitively, and dangles on Linux. Reporting it as "dangling" leaves
+    # the author of the mac-side bundle reading a CI failure about a file they can
+    # see on their own disk, so name the real path instead.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD, name="concepts/target.md")
+    write_concept(b, GOOD.rstrip() + "\nSee [x](Target.md).\n", name="concepts/c.md")
+    rc, out = validate(b)
+    assert rc == 1
+    assert "link case does not match" in out
+    assert "concepts/target.md" in out
+    # The unhelpful wording must not also fire for the same link.
+    assert "dangling link -> Target.md" not in out
+
+
+def test_wrong_case_directory_in_link_caught(tmp_path):
+    # Every component is walked, not just the filename: a mac-side bundle can get
+    # the directory wrong just as easily.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD, name="concepts/target.md")
+    write_concept(b, GOOD.rstrip() + "\nSee [x](../Concepts/target.md).\n", name="concepts/c.md")
+    rc, out = validate(b)
+    assert rc == 1 and "link case does not match" in out
+
+
+def test_missing_file_is_still_reported_as_dangling(tmp_path):
+    # A link matching nothing on disk, case or no case, keeps the plain wording.
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD.rstrip() + "\nSee [x](nowhere.md).\n")
+    rc, out = validate(b)
+    assert rc == 1 and "dangling link -> nowhere.md" in out
+    assert "link case does not match" not in out
+
+
+def test_exact_case_link_passes(tmp_path):
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD, name="concepts/target.md")
+    write_concept(b, GOOD.rstrip() + "\nSee [x](target.md).\n", name="concepts/c.md")
+    rc, out = validate(b)
+    assert rc == 0, out
+
+
+def test_real_case_path_reports_the_on_disk_name(tmp_path):
+    # Unit-level: the walk answers with the real name, so the caller can name it.
+    real_case_path = _validate_module().real_case_path
+    (tmp_path / "concepts").mkdir()
+    (tmp_path / "concepts" / "target.md").write_text("x", encoding="utf-8")
+    assert real_case_path(tmp_path / "concepts" / "target.md", tmp_path) \
+        == tmp_path / "concepts" / "target.md"
+    assert real_case_path(tmp_path / "Concepts" / "TARGET.md", tmp_path) \
+        == tmp_path / "concepts" / "target.md"
+    assert real_case_path(tmp_path / "concepts" / "nowhere.md", tmp_path) is None
+    # A file where a directory is expected is not a resolvable parent.
+    assert real_case_path(tmp_path / "concepts" / "target.md" / "deeper.md", tmp_path) is None

--- a/okf-wiki/tests/test_okf_wiki.py
+++ b/okf-wiki/tests/test_okf_wiki.py
@@ -954,6 +954,39 @@ def test_link_to_existing_uppercase_md_fails(tmp_path):
     assert "write Target.MD" not in out
 
 
+def test_nonconforming_extension_rename_uses_real_parent_case(tmp_path):
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    write_concept(b, GOOD, name="concepts/Target.MD")
+    write_concept(
+        b,
+        GOOD.rstrip() + "\n\nSee [target](../Concepts/target.md).\n",
+        name="concepts/c.md",
+    )
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "rename Target.MD to target.md" in out
+    assert "rename Target.MD to ../Concepts/target.md" not in out
+
+
+def test_wrong_case_dangling_symlink_is_reported_as_dangling(tmp_path):
+    scaffold(tmp_path / "kb", "--no-validate")
+    b = tmp_path / "kb" / "bundle"
+    try:
+        (b / "concepts" / "Broken.md").symlink_to("missing.md")
+    except OSError as exc:
+        pytest.skip(f"symlink unavailable on this filesystem: {exc}")
+    write_concept(
+        b,
+        GOOD.rstrip() + "\n\nSee [broken](broken.md).\n",
+        name="concepts/c.md",
+    )
+    rc, out = validate(b)
+    assert rc == 1, out
+    assert "dangling link -> broken.md" in out
+    assert "write Broken.md" not in out
+
+
 def test_uppercase_scheme_link_not_flagged(tmp_path):
     # an external link with an uppercase scheme must be recognized as external and
     # skipped, not resolved as a local path (which falsely fails as escaping).


### PR DESCRIPTION
Picks the case-insensitive link resolution item off the Tier-5 backlog in #156.

## The finding

`validate.py` checked every intra-bundle link with `Path.exists()`. macOS answers that question case-insensitively, so a link written as `Concepts/Foo.md` against a file named `concepts/foo.md` validated clean on the author's machine. The same bundle dangles on Linux, and this repo's own `okf-wiki-tests` workflow runs on `ubuntu-latest`, so CI is exactly where an author first meets it, with a message that says the file is missing when they can see it on their disk.

## The change

`real_case_path()` walks each path component against the real directory listing instead of asking the filesystem whether the path exists. The walk doubles as the existence check: a component matching nothing, case or no case, means the link dangles.

That splits one error into two:

- nothing matches: `dangling link -> nowhere.md`, unchanged.
- exactly one case-variant matches: `link case does not match the file on disk -> Target.md; write target.md. Links are case-sensitive on Linux, so this resolves on macOS and breaks in CI.`

Handing back the link to write is the point, relative to the file doing the linking rather than to the bundle root, so it pastes straight in.

## Scope: macOS, not Windows

On Windows `ntpath.realpath` goes through `GetFinalPathNameByHandle`, so `Path.resolve()` substitutes the on-disk casing before the walk runs and every component matches. The check is a no-op there. A Windows author's wrong-case link is still caught, on Linux CI, just not on the machine that wrote it. Filed as #265: the fix needs a lexically normalized path, and that diverges from the resolved one across a symlinked directory, so it wants its own tests rather than a rider here.

Several variants differing only by case (possible on a case-sensitive filesystem holding both) falls back to `dangling`, since there is no way to say which was meant.

## Verification

- 300 tests pass, up from 295.
- The new assertions are mutation-checked, and the check earned its keep. Reverting the call site to `dest.exists()` fails both wrong-case tests; without that check they would have been vacuous, since a wrong-case path does not exist on Linux either way and the old code already reported it, just unhelpfully. Weakening the ambiguity guard to take `variants[0]` fails the two-variant test, which did not exist until review noticed the guard was unpinned and the whole suite passed under that mutation.
- Run against the 244-file jawn-atlas bundle: no new errors, so the check does not false-positive on a real tree.
- `example/scripts/validate.py` and `example/SPEC.md` re-synced; the parity tests that guard those vendored copies pass.

## Still open on #156

Everything else in the Tier-5 batch: the unenforced `description` one-line rule, non-`.md` and reference-style and extension-less links going unchecked, secret-scan false positives on long placeholders, the `v1` vs `okf_version: "0.1"` branding split, the example bundle's type and `log.md` gaps, the unmatched orientation hooks, and the jargon-forward skill description.


wake-20260810T1105-035c49
