### PR TITLE
publish context-engineering-fundamentals into dev-toolkit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,8 +20,8 @@
     },
     {
       "name": "dev-toolkit",
-      "description": "Eleven development-focused skills for journalists, researchers, and small newsroom dev teams. Covers accessibility (WCAG 2.2), Electron app patterns, mobile/remote debugging, irreversible-decision discipline, Python data pipelines, test-first bug fixing, AI-assisted development workflows, ethical web scraping, no-build frontend patterns, signs-of-taste guidance for web UI, and CLAUDE.md context maintenance.",
-      "version": "1.1.1",
+      "description": "Twelve development-focused skills for journalists, researchers, and small newsroom dev teams. Covers accessibility (WCAG 2.2), Electron app patterns, mobile/remote debugging, irreversible-decision discipline, Python data pipelines, test-first bug fixing, AI-assisted development workflows, ethical web scraping, no-build frontend patterns, signs-of-taste guidance for web UI, CLAUDE.md context maintenance, and context-engineering fundamentals for managing attention across long sessions.",
+      "version": "1.2.0",
       "author": {
         "name": "Joe Amditis",
         "email": "jamditis@gmail.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **dev-toolkit context-engineering-fundamentals:** published the context
+  engineering skill from the tools repo standouts (group 4 of #115). Teaches the
+  attention budget, the lost-in-middle effect, five context degradation patterns
+  with mitigations, and practical size thresholds. Stripped the project-bound
+  "Amditis Resource Kit" section, the dangling related-skill references, and the
+  dated version footer before publishing (#220).
+
 ## [2.4.0] - 2026-07-25
 
 This release advances photo provenance and OKF secret detection, records a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **dev-toolkit context-engineering-fundamentals:** published the context
   engineering skill from the tools repo standouts (group 4 of #115). Teaches the
   attention budget, the lost-in-middle effect, five context degradation patterns
-  with mitigations, and practical size thresholds. Stripped the project-bound
+  with mitigations, and how to measure retrieval quality before compression. Stripped the project-bound
   "Amditis Resource Kit" section, the dangling related-skill references, and the
   dated version footer before publishing (#220).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,12 +75,14 @@ claude-skills-journalism/
 │       ├── page-monitoring/            # Change detection, availability tracking
 │       └── web-archiving/              # Wayback, Archive.today, evidence preservation
 │
-├── # Plugin: dev-toolkit (10 skills) — registered in marketplace.json
+├── # Plugin: dev-toolkit (12 skills) — registered in marketplace.json
 ├── dev-toolkit/
 │   ├── .claude-plugin/plugin.json
 │   ├── README.md
 │   └── skills/
 │       ├── accessibility-compliance/   # WCAG 2.2, alt text, focus management
+│       ├── claude-md-updater/          # Propose scoped CLAUDE.md updates
+│       ├── context-engineering-fundamentals/ # Preserve instructions, evidence, and state
 │       ├── electron-dev/               # Electron security model, packaging
 │       ├── mobile-debugging/           # Eruda, vConsole, remote debug
 │       ├── one-way-door/               # Block irreversible decisions

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Then restart Claude Code (close and reopen). See the [PDF Playground README](./p
 | Plugin | Description | Commands | Updated |
 |--------|-------------|----------|--------|
 | [autocontext](./autocontext/) | Cross-session knowledge persistence with skill evolution. Lessons accumulate per-skill, and `/autocontext:evolve` folds them back into skill files | `/autocontext:setup`, `/autocontext:init`, `/autocontext:review`, `/autocontext:status`, `/autocontext:evolve` | Apr 27, 2026 |
-| [dev-toolkit](./dev-toolkit/) | Eleven development-focused skills for journalists, researchers, and small newsroom dev teams: accessibility (WCAG 2.2), Electron app patterns, mobile/remote debugging, irreversible-decision discipline, Python data pipelines, test-first bug fixing, AI-assisted development workflows, ethical web scraping, no-build frontend patterns, signs-of-taste guidance for web UI, and CLAUDE.md context maintenance | n/a — skills only | Jul 21, 2026 |
+| [dev-toolkit](./dev-toolkit/) | Twelve development-focused skills for journalists, researchers, and small newsroom dev teams: accessibility (WCAG 2.2), Electron app patterns, mobile/remote debugging, irreversible-decision discipline, Python data pipelines, test-first bug fixing, AI-assisted development workflows, ethical web scraping, no-build frontend patterns, signs-of-taste guidance for web UI, CLAUDE.md context maintenance, and managing attention across long sessions | n/a — skills only | Aug 14, 2026 |
 | [journalism-core](./journalism-core/) | Fourteen core journalism skills, including AP-style writing, AI-slop detoxing, source verification (deepfakes/C2PA), FOIA + NJ OPRA requests, fact-checking, interview prep + transcription, story pitches, editorial workflow, crisis communications, newsletter publishing with current Gmail / Yahoo / Outlook bulk-sender requirements, and embedded photo metadata for wire distribution | n/a — skills only | Jul 25, 2026 |
 | [okf-wiki](./okf-wiki/) | Scaffold an Open Knowledge Format (OKF) knowledge base: one-concept-per-file markdown with YAML frontmatter, directory navigation, and a validator. Generates a starter wiki that passes its own conformance and secret-leak checks, ships session-start hooks that orient Claude on the knowledge base before it works, and includes an optional GitHub-wiki bootstrap. For newsroom institutional memory, research atlases, decision logs, and infrastructure maps | n/a — skill only | Aug 12, 2026 |
 | [pdf-design](./pdf-design/) | PDF report and proposal design system with brand variables, budget tables, and reusable content blocks (stats strips, three-column, four-tile pillars, partner grids) | n/a — skill-only | Jul 21, 2026 |
@@ -210,12 +210,13 @@ These three skills ship together as the [project-templates-toolkit](./project-te
 
 ### Development skills (in `dev-toolkit` plugin)
 
-These eleven skills ship together as the [dev-toolkit](./dev-toolkit/) plugin. Install via `/plugin install dev-toolkit@claude-skills-journalism` to get all of them at once, or copy individual skills from `dev-toolkit/skills/<name>/`.
+These twelve skills ship together as the [dev-toolkit](./dev-toolkit/) plugin. Install via `/plugin install dev-toolkit@claude-skills-journalism` to get all of them at once, or copy individual skills from `dev-toolkit/skills/<name>/`.
 
 | Skill | Description | Updated |
 |-------|-------------|--------|
 | [accessibility-compliance](./dev-toolkit/skills/accessibility-compliance/) | WCAG 2.2 baseline, alt text, focus management, motion preferences, accessible charts | Jul 21, 2026 |
 | [claude-md-updater](./dev-toolkit/skills/claude-md-updater/) | Detect session lessons, new paths, infra changes, and workflows and propose scoped CLAUDE.md edits for approval | Jul 21, 2026 |
+| [context-engineering-fundamentals](./dev-toolkit/skills/context-engineering-fundamentals/) | Attention budget, lost-in-middle recall, context degradation patterns, and mitigations for long sessions | Aug 14, 2026 |
 | [electron-dev](./dev-toolkit/skills/electron-dev/) | Electron security model (contextIsolation, sandbox), IPC patterns, packaging | May 8, 2026 |
 | [mobile-debugging](./dev-toolkit/skills/mobile-debugging/) | Eruda, vConsole, Chrome DevTools on Android, Safari Web Inspector for iOS, console capture | Jul 21, 2026 |
 | [one-way-door](./dev-toolkit/skills/one-way-door/) | Flag irreversible architectural decisions (data models, infra, auth, APIs) before committing | Jun 10, 2026 |

--- a/dev-toolkit/.claude-plugin/plugin.json
+++ b/dev-toolkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-toolkit",
-  "version": "1.1.1",
-  "description": "Eleven development-focused skills for journalists, researchers, and small newsroom dev teams. Covers accessibility (WCAG 2.2), Electron app patterns, mobile/remote debugging, irreversible-decision discipline, Python data pipelines, test-first bug fixing, AI-assisted development workflows, ethical web scraping, no-build frontend patterns, signs-of-taste guidance for web UI, and CLAUDE.md context maintenance.",
+  "version": "1.2.0",
+  "description": "Twelve development-focused skills for journalists, researchers, and small newsroom dev teams. Covers accessibility (WCAG 2.2), Electron app patterns, mobile/remote debugging, irreversible-decision discipline, Python data pipelines, test-first bug fixing, AI-assisted development workflows, ethical web scraping, no-build frontend patterns, signs-of-taste guidance for web UI, CLAUDE.md context maintenance, and context-engineering fundamentals for managing attention across long sessions.",
   "author": {
     "name": "Joe Amditis",
     "email": "jamditis@gmail.com"

--- a/dev-toolkit/README.md
+++ b/dev-toolkit/README.md
@@ -1,6 +1,6 @@
 # dev-toolkit
 
-Eleven development-focused skills for journalists, researchers, and small newsroom dev teams.
+Twelve development-focused skills for journalists, researchers, and small newsroom dev teams.
 
 ## Skills in this plugin
 
@@ -8,6 +8,7 @@ Eleven development-focused skills for journalists, researchers, and small newsro
 |---|---|
 | accessibility-compliance | WCAG 2.2 baseline, alt text, focus management, motion preferences |
 | claude-md-updater | Detect session lessons, new paths, infra changes, and workflows and propose scoped CLAUDE.md edits |
+| context-engineering-fundamentals | Attention budget, lost-in-middle recall, context degradation patterns, and mitigations for long sessions |
 | electron-dev | Electron security model (contextIsolation, sandbox), IPC patterns, packaging |
 | mobile-debugging | Eruda, vConsole, Chrome DevTools on Android, Safari Web Inspector for iOS |
 | one-way-door | Block irreversible architectural decisions during planning |

--- a/dev-toolkit/skills/context-engineering-fundamentals/SKILL.md
+++ b/dev-toolkit/skills/context-engineering-fundamentals/SKILL.md
@@ -60,6 +60,8 @@ Contradictory information from multiple sources causes derailing conflicts.
 
 ## Practical degradation thresholds
 
+These bands are illustrative heuristics, not model-independent guarantees. The transition points move with the model, its version, and the retrieval or reasoning task: a short context is not always reliable, and a long one is not always lossy. Measure recall on your own model and workload before you treat a threshold as a hard cutoff for discarding or summarizing context.
+
 | Context Size | Expected Behavior |
 |--------------|-------------------|
 | < 8K tokens | Full attention, reliable recall |
@@ -70,10 +72,10 @@ Contradictory information from multiple sources causes derailing conflicts.
 ## Mitigation strategies
 
 ### Write externally
-Don't rely on Claude to remember across turns. Write important state to files:
+Don't rely on Claude to remember across turns. Write important state to files, but agree the path with the user first and prefer a gitignored workspace so you never overwrite project-owned content:
 ```
-After each major step, write progress to PROGRESS.md
-Before starting, read PROGRESS.md to restore context
+With the user's approval, after each major step write progress to an agreed scratch file (for example a gitignored PROGRESS.md or a path they choose)
+Before starting, read that file back to restore context
 ```
 
 ### Select carefully

--- a/dev-toolkit/skills/context-engineering-fundamentals/SKILL.md
+++ b/dev-toolkit/skills/context-engineering-fundamentals/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: context-engineering-fundamentals
+description: Understand how Claude manages attention and when context degrades. Activate for long sessions, complex tasks, or when Claude seems to "forget" information.
+---
+
+# Context Engineering Fundamentals
+
+Context engineering is the practice of managing an LLM's limited attention budget. This skill helps you understand why Claude sometimes "forgets" things and how to work within context limitations.
+
+## When to activate
+
+- Working on long, multi-step tasks
+- Claude seems to forget earlier instructions or context
+- Debugging "why didn't Claude use the information I gave it?"
+- Planning how to structure complex prompts
+- Optimizing for token efficiency
+
+## Core concept
+
+**Context windows are constrained by attention mechanics, not just token capacity.** A 200K token window doesn't mean 200K tokens of useful information. Attention degrades, especially in the middle of long contexts.
+
+## The lost-in-middle effect
+
+Research shows information position dramatically affects recall:
+
+| Position | Recall Accuracy |
+|----------|----------------|
+| Beginning | High (~90%) |
+| Middle | Low (50-70%) |
+| End | High (~85%) |
+
+**Implication:** Put critical information at the start or end, not buried in the middle.
+
+## Context degradation patterns
+
+### 1. Lost-in-middle
+Information in the middle of long context gets lower attention weight.
+
+**Mitigation:** Structure with explicit sections. Put critical constraints at start AND end.
+
+### 2. Context poisoning
+Errors compound when incorrect information enters context (from tool outputs, summaries, or earlier mistakes).
+
+**Mitigation:** Validate intermediate outputs. Don't blindly trust previous responses.
+
+### 3. Context distraction
+Irrelevant information forces attention allocation away from relevant content. Models can't "skip" irrelevant context.
+
+**Mitigation:** Be selective about what goes into context. More isn't better.
+
+### 4. Context confusion
+Multiple task types or conflicting instructions create ambiguous responses.
+
+**Mitigation:** One task per interaction when possible. Clear task boundaries.
+
+### 5. Context clash
+Contradictory information from multiple sources causes derailing conflicts.
+
+**Mitigation:** Resolve contradictions explicitly before asking Claude to use the information.
+
+## Practical degradation thresholds
+
+| Context Size | Expected Behavior |
+|--------------|-------------------|
+| < 8K tokens | Full attention, reliable recall |
+| 8-32K tokens | Good performance, some middle-loss |
+| 32-100K tokens | Noticeable degradation, need explicit structure |
+| > 100K tokens | Significant loss, use summarization/chunking |
+
+## Mitigation strategies
+
+### Write externally
+Don't rely on Claude to remember across turns. Write important state to files:
+```
+After each major step, write progress to PROGRESS.md
+Before starting, read PROGRESS.md to restore context
+```
+
+### Select carefully
+Filter irrelevant context before loading:
+```
+Instead of: "Here are all 50 files, find the bug"
+Do: "Here are the 3 files involved in the error"
+```
+
+### Compress strategically
+Summarize while maintaining signal:
+```
+Instead of: Full 1000-line file
+Do: Key functions and their signatures, with context on the specific area
+```
+
+### Isolate contexts
+For complex tasks, use sub-agents with focused contexts rather than one agent with everything.
+
+## Signs of context degradation
+
+| Symptom | Likely Cause |
+|---------|--------------|
+| Ignores earlier instructions | Lost-in-middle or context too long |
+| Contradicts itself | Context confusion or clash |
+| Repeats information you gave | Attention not reaching that content |
+| Misses obvious details | Context distraction |
+| Gets progressively worse | Context poisoning from errors |
+
+## References
+
+- "Lost in the Middle" (Liu et al., 2023) - Position effects in long context
+- "Needle in a Haystack" benchmark - Context retrieval testing
+- RULER benchmark - Multi-hop reasoning over long context

--- a/dev-toolkit/skills/context-engineering-fundamentals/SKILL.md
+++ b/dev-toolkit/skills/context-engineering-fundamentals/SKILL.md
@@ -1,35 +1,27 @@
 ---
 name: context-engineering-fundamentals
-description: Understand how Claude manages attention and when context degrades. Activate for long sessions, complex tasks, or when Claude seems to "forget" information.
+description: Manage attention and evidence in long AI-agent sessions. Use for complex tasks, large contexts, multi-agent work, or apparent instruction and evidence loss.
 ---
 
-# Context Engineering Fundamentals
+# Context engineering fundamentals
 
-Context engineering is the practice of managing an LLM's limited attention budget. This skill helps you understand why Claude sometimes "forgets" things and how to work within context limitations.
-
-## When to activate
-
-- Working on long, multi-step tasks
-- Claude seems to forget earlier instructions or context
-- Debugging "why didn't Claude use the information I gave it?"
-- Planning how to structure complex prompts
-- Optimizing for token efficiency
+Context engineering is the practice of managing an LLM's limited attention budget. Use this skill to keep instructions, evidence, and state available during long work.
 
 ## Core concept
 
-**Context windows are constrained by attention mechanics, not just token capacity.** A 200K token window doesn't mean 200K tokens of useful information. Attention degrades, especially in the middle of long contexts.
+**Context windows are constrained by attention mechanics, not only token capacity.** A large context limit does not guarantee equal use of every item.
 
 ## The lost-in-middle effect
 
-Research shows information position dramatically affects recall:
+The "Lost in the Middle" experiments show that retrieval quality can change with information position. The result depends on the model, task, context length, and number of documents.
 
-| Position | Recall Accuracy |
-|----------|----------------|
-| Beginning | High (~90%) |
-| Middle | Low (50-70%) |
-| End | High (~85%) |
+| Position | Common test result |
+|----------|--------------------|
+| Beginning | Often easier to retrieve |
+| Middle | Can be harder to retrieve |
+| End | Often benefits from recency |
 
-**Implication:** Put critical information at the start or end, not buried in the middle.
+**Implication:** Keep critical constraints easy to find and repeat them near the decision that uses them. Do not assume position alone predicts recall.
 
 ## Context degradation patterns
 
@@ -58,21 +50,16 @@ Contradictory information from multiple sources causes derailing conflicts.
 
 **Mitigation:** Resolve contradictions explicitly before asking Claude to use the information.
 
-## Practical degradation thresholds
+## Measure before compressing
 
-These bands are illustrative heuristics, not model-independent guarantees. The transition points move with the model, its version, and the retrieval or reasoning task: a short context is not always reliable, and a long one is not always lossy. Measure recall on your own model and workload before you treat a threshold as a hard cutoff for discarding or summarizing context.
+Do not use a fixed token threshold to decide when context is reliable. Measure retrieval and reasoning quality on your own model and task. Test representative evidence at several positions, then compare the result before and after summarization.
 
-| Context Size | Expected Behavior |
-|--------------|-------------------|
-| < 8K tokens | Full attention, reliable recall |
-| 8-32K tokens | Good performance, some middle-loss |
-| 32-100K tokens | Noticeable degradation, need explicit structure |
-| > 100K tokens | Significant loss, use summarization/chunking |
+Compress only when the measured result or the agent's behavior shows a problem. Preserve exact constraints, decisions, source links, unresolved questions, and verification evidence.
 
 ## Mitigation strategies
 
 ### Write externally
-Don't rely on Claude to remember across turns. Write important state to files, but agree the path with the user first and prefer a gitignored workspace so you never overwrite project-owned content:
+Do not rely on the agent to remember across turns. Write important state to files, but agree the path with the user first. Prefer a gitignored workspace so you never overwrite project-owned content:
 ```
 With the user's approval, after each major step write progress to an agreed scratch file (for example a gitignored PROGRESS.md or a path they choose)
 Before starting, read that file back to restore context
@@ -93,11 +80,11 @@ Do: Key functions and their signatures, with context on the specific area
 ```
 
 ### Isolate contexts
-For complex tasks, use sub-agents with focused contexts rather than one agent with everything.
+For complex tasks, use subagents with focused contexts rather than one agent with everything.
 
 ## Signs of context degradation
 
-| Symptom | Likely Cause |
+| Symptom | Likely cause |
 |---------|--------------|
 | Ignores earlier instructions | Lost-in-middle or context too long |
 | Contradicts itself | Context confusion or clash |

--- a/docs/assets/tailwind/context-engineering-fundamentals.css
+++ b/docs/assets/tailwind/context-engineering-fundamentals.css
@@ -1,0 +1,716 @@
+/* Generated for context-engineering-fundamentals/index.html by Tailwind CSS 3.4.19. */
+*, ::before, ::after {
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x:  ;
+  --tw-pan-y:  ;
+  --tw-pinch-zoom:  ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position:  ;
+  --tw-gradient-via-position:  ;
+  --tw-gradient-to-position:  ;
+  --tw-ordinal:  ;
+  --tw-slashed-zero:  ;
+  --tw-numeric-figure:  ;
+  --tw-numeric-spacing:  ;
+  --tw-numeric-fraction:  ;
+  --tw-ring-inset:  ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgb(59 130 246 / 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur:  ;
+  --tw-brightness:  ;
+  --tw-contrast:  ;
+  --tw-grayscale:  ;
+  --tw-hue-rotate:  ;
+  --tw-invert:  ;
+  --tw-saturate:  ;
+  --tw-sepia:  ;
+  --tw-drop-shadow:  ;
+  --tw-backdrop-blur:  ;
+  --tw-backdrop-brightness:  ;
+  --tw-backdrop-contrast:  ;
+  --tw-backdrop-grayscale:  ;
+  --tw-backdrop-hue-rotate:  ;
+  --tw-backdrop-invert:  ;
+  --tw-backdrop-opacity:  ;
+  --tw-backdrop-saturate:  ;
+  --tw-backdrop-sepia:  ;
+  --tw-contain-size:  ;
+  --tw-contain-layout:  ;
+  --tw-contain-paint:  ;
+  --tw-contain-style:  ;
+}
+
+::backdrop {
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x:  ;
+  --tw-pan-y:  ;
+  --tw-pinch-zoom:  ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position:  ;
+  --tw-gradient-via-position:  ;
+  --tw-gradient-to-position:  ;
+  --tw-ordinal:  ;
+  --tw-slashed-zero:  ;
+  --tw-numeric-figure:  ;
+  --tw-numeric-spacing:  ;
+  --tw-numeric-fraction:  ;
+  --tw-ring-inset:  ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgb(59 130 246 / 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur:  ;
+  --tw-brightness:  ;
+  --tw-contrast:  ;
+  --tw-grayscale:  ;
+  --tw-hue-rotate:  ;
+  --tw-invert:  ;
+  --tw-saturate:  ;
+  --tw-sepia:  ;
+  --tw-drop-shadow:  ;
+  --tw-backdrop-blur:  ;
+  --tw-backdrop-brightness:  ;
+  --tw-backdrop-contrast:  ;
+  --tw-backdrop-grayscale:  ;
+  --tw-backdrop-hue-rotate:  ;
+  --tw-backdrop-invert:  ;
+  --tw-backdrop-opacity:  ;
+  --tw-backdrop-saturate:  ;
+  --tw-backdrop-sepia:  ;
+  --tw-contain-size:  ;
+  --tw-contain-layout:  ;
+  --tw-contain-paint:  ;
+  --tw-contain-style:  ;
+}/*
+! tailwindcss v3.4.19 | MIT License | https://tailwindcss.com
+*//*
+1. Prevent padding and border from affecting element width. (https://github.com/mozdevs/cssremedy/issues/4)
+2. Allow adding a border to an element by just adding a border-width. (https://github.com/tailwindcss/tailwindcss/pull/116)
+*/
+
+*,
+::before,
+::after {
+  box-sizing: border-box; /* 1 */
+  border-width: 0; /* 2 */
+  border-style: solid; /* 2 */
+  border-color: #e5e7eb; /* 2 */
+}
+
+::before,
+::after {
+  --tw-content: '';
+}
+
+/*
+1. Use a consistent sensible line-height in all browsers.
+2. Prevent adjustments of font size after orientation changes in iOS.
+3. Use a more readable tab size.
+4. Use the user's configured `sans` font-family by default.
+5. Use the user's configured `sans` font-feature-settings by default.
+6. Use the user's configured `sans` font-variation-settings by default.
+7. Disable tap highlights on iOS
+*/
+
+html,
+:host {
+  line-height: 1.5; /* 1 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+  -moz-tab-size: 4; /* 3 */
+  tab-size: 4; /* 3 */
+  font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; /* 4 */
+  font-feature-settings: normal; /* 5 */
+  font-variation-settings: normal; /* 6 */
+  -webkit-tap-highlight-color: transparent; /* 7 */
+}
+
+/*
+1. Remove the margin in all browsers.
+2. Inherit line-height from `html` so users can set them as a class directly on the `html` element.
+*/
+
+body {
+  margin: 0; /* 1 */
+  line-height: inherit; /* 2 */
+}
+
+/*
+1. Add the correct height in Firefox.
+2. Correct the inheritance of border color in Firefox. (https://bugzilla.mozilla.org/show_bug.cgi?id=190655)
+3. Ensure horizontal rules are visible by default.
+*/
+
+hr {
+  height: 0; /* 1 */
+  color: inherit; /* 2 */
+  border-top-width: 1px; /* 3 */
+}
+
+/*
+Add the correct text decoration in Chrome, Edge, and Safari.
+*/
+
+abbr:where([title]) {
+  text-decoration: underline dotted;
+}
+
+/*
+Remove the default font size and weight for headings.
+*/
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+/*
+Reset links to optimize for opt-in styling instead of opt-out.
+*/
+
+a {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+/*
+Add the correct font weight in Edge and Safari.
+*/
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/*
+1. Use the user's configured `mono` font-family by default.
+2. Use the user's configured `mono` font-feature-settings by default.
+3. Use the user's configured `mono` font-variation-settings by default.
+4. Correct the odd `em` font sizing in all browsers.
+*/
+
+code,
+kbd,
+samp,
+pre {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; /* 1 */
+  font-feature-settings: normal; /* 2 */
+  font-variation-settings: normal; /* 3 */
+  font-size: 1em; /* 4 */
+}
+
+/*
+Add the correct font size in all browsers.
+*/
+
+small {
+  font-size: 80%;
+}
+
+/*
+Prevent `sub` and `sup` elements from affecting the line height in all browsers.
+*/
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/*
+1. Remove text indentation from table contents in Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=999088, https://bugs.webkit.org/show_bug.cgi?id=201297)
+2. Correct table border color inheritance in all Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=935729, https://bugs.webkit.org/show_bug.cgi?id=195016)
+3. Remove gaps between table borders by default.
+*/
+
+table {
+  text-indent: 0; /* 1 */
+  border-color: inherit; /* 2 */
+  border-collapse: collapse; /* 3 */
+}
+
+/*
+1. Change the font styles in all browsers.
+2. Remove the margin in Firefox and Safari.
+3. Remove default padding in all browsers.
+*/
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit; /* 1 */
+  font-feature-settings: inherit; /* 1 */
+  font-variation-settings: inherit; /* 1 */
+  font-size: 100%; /* 1 */
+  font-weight: inherit; /* 1 */
+  line-height: inherit; /* 1 */
+  letter-spacing: inherit; /* 1 */
+  color: inherit; /* 1 */
+  margin: 0; /* 2 */
+  padding: 0; /* 3 */
+}
+
+/*
+Remove the inheritance of text transform in Edge and Firefox.
+*/
+
+button,
+select {
+  text-transform: none;
+}
+
+/*
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Remove default button styles.
+*/
+
+button,
+input:where([type='button']),
+input:where([type='reset']),
+input:where([type='submit']) {
+  -webkit-appearance: button; /* 1 */
+  background-color: transparent; /* 2 */
+  background-image: none; /* 2 */
+}
+
+/*
+Use the modern Firefox focus style for all focusable elements.
+*/
+
+:-moz-focusring {
+  outline: auto;
+}
+
+/*
+Remove the additional `:invalid` styles in Firefox. (https://github.com/mozilla/gecko-dev/blob/2f9eacd9d3d995c937b4251a5557d95d494c9be1/layout/style/res/forms.css#L728-L737)
+*/
+
+:-moz-ui-invalid {
+  box-shadow: none;
+}
+
+/*
+Add the correct vertical alignment in Chrome and Firefox.
+*/
+
+progress {
+  vertical-align: baseline;
+}
+
+/*
+Correct the cursor style of increment and decrement buttons in Safari.
+*/
+
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/*
+1. Correct the odd appearance in Chrome and Safari.
+2. Correct the outline style in Safari.
+*/
+
+[type='search'] {
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
+}
+
+/*
+Remove the inner padding in Chrome and Safari on macOS.
+*/
+
+::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/*
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Change font properties to `inherit` in Safari.
+*/
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
+}
+
+/*
+Add the correct display in Chrome and Safari.
+*/
+
+summary {
+  display: list-item;
+}
+
+/*
+Removes the default spacing and border for appropriate elements.
+*/
+
+blockquote,
+dl,
+dd,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+hr,
+figure,
+p,
+pre {
+  margin: 0;
+}
+
+fieldset {
+  margin: 0;
+  padding: 0;
+}
+
+legend {
+  padding: 0;
+}
+
+ol,
+ul,
+menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/*
+Reset default styling for dialogs.
+*/
+dialog {
+  padding: 0;
+}
+
+/*
+Prevent resizing textareas horizontally by default.
+*/
+
+textarea {
+  resize: vertical;
+}
+
+/*
+1. Reset the default placeholder opacity in Firefox. (https://github.com/tailwindlabs/tailwindcss/issues/3300)
+2. Set the default placeholder color to the user's configured gray 400 color.
+*/
+
+input::placeholder,
+textarea::placeholder {
+  opacity: 1; /* 1 */
+  color: #9ca3af; /* 2 */
+}
+
+/*
+Set the default cursor for buttons.
+*/
+
+button,
+[role="button"] {
+  cursor: pointer;
+}
+
+/*
+Make sure disabled buttons don't get the pointer cursor.
+*/
+:disabled {
+  cursor: default;
+}
+
+/*
+1. Make replaced elements `display: block` by default. (https://github.com/mozdevs/cssremedy/issues/14)
+2. Add `vertical-align: middle` to align replaced elements more sensibly by default. (https://github.com/jensimmons/cssremedy/issues/14#issuecomment-634934210)
+   This can trigger a poorly considered lint error in some tools but is included by design.
+*/
+
+img,
+svg,
+video,
+canvas,
+audio,
+iframe,
+embed,
+object {
+  display: block; /* 1 */
+  vertical-align: middle; /* 2 */
+}
+
+/*
+Constrain images and videos to the parent width and preserve their intrinsic aspect ratio. (https://github.com/mozdevs/cssremedy/issues/14)
+*/
+
+img,
+video {
+  max-width: 100%;
+  height: auto;
+}
+
+/* Make elements with the HTML hidden attribute stay hidden by default */
+[hidden]:where(:not([hidden="until-found"])) {
+  display: none;
+}
+.fixed {
+  position: fixed;
+}
+.absolute {
+  position: absolute;
+}
+.relative {
+  position: relative;
+}
+.z-10 {
+  z-index: 10;
+}
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+.mb-12 {
+  margin-bottom: 3rem;
+}
+.mb-4 {
+  margin-bottom: 1rem;
+}
+.mb-5 {
+  margin-bottom: 1.25rem;
+}
+.mt-2 {
+  margin-top: 0.5rem;
+}
+.mt-3 {
+  margin-top: 0.75rem;
+}
+.mt-5 {
+  margin-top: 1.25rem;
+}
+.mt-8 {
+  margin-top: 2rem;
+}
+.flex {
+  display: flex;
+}
+.grid {
+  display: grid;
+}
+.max-w-2xl {
+  max-width: 42rem;
+}
+.max-w-4xl {
+  max-width: 56rem;
+}
+.list-decimal {
+  list-style-type: decimal;
+}
+.list-disc {
+  list-style-type: disc;
+}
+.flex-wrap {
+  flex-wrap: wrap;
+}
+.items-center {
+  align-items: center;
+}
+.justify-between {
+  justify-content: space-between;
+}
+.gap-4 {
+  gap: 1rem;
+}
+.space-y-3 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.75rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.75rem * var(--tw-space-y-reverse));
+}
+.space-y-4 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1rem * var(--tw-space-y-reverse));
+}
+.overflow-x-auto {
+  overflow-x: auto;
+}
+.rounded-xl {
+  border-radius: 0.75rem;
+}
+.border {
+  border-width: 1px;
+}
+.border-b {
+  border-bottom-width: 1px;
+}
+.border-t {
+  border-top-width: 1px;
+}
+.border-mist\/40 {
+  border-color: rgb(196 191 180 / 0.4);
+}
+.bg-canvas {
+  --tw-bg-opacity: 1;
+  background-color: rgb(237 230 212 / var(--tw-bg-opacity, 1));
+}
+.bg-ink {
+  --tw-bg-opacity: 1;
+  background-color: rgb(18 18 18 / var(--tw-bg-opacity, 1));
+}
+.bg-white\/50 {
+  background-color: rgb(255 255 255 / 0.5);
+}
+.bg-white\/60 {
+  background-color: rgb(255 255 255 / 0.6);
+}
+.bg-gradient-to-br {
+  background-image: linear-gradient(to bottom right, var(--tw-gradient-stops));
+}
+.from-accent {
+  --tw-gradient-from: #4f46e5 var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(79 70 229 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+.to-accentDark {
+  --tw-gradient-to: #4338ca var(--tw-gradient-to-position);
+}
+.p-4 {
+  padding: 1rem;
+}
+.p-5 {
+  padding: 1.25rem;
+}
+.p-6 {
+  padding: 1.5rem;
+}
+.px-6 {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
+.py-12 {
+  padding-top: 3rem;
+  padding-bottom: 3rem;
+}
+.py-16 {
+  padding-top: 4rem;
+  padding-bottom: 4rem;
+}
+.py-4 {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+.py-8 {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+}
+.pl-6 {
+  padding-left: 1.5rem;
+}
+.pt-8 {
+  padding-top: 2rem;
+}
+.text-2xl {
+  font-size: 1.5rem;
+  line-height: 2rem;
+}
+.text-4xl {
+  font-size: 2.25rem;
+  line-height: 2.5rem;
+}
+.text-lg {
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+}
+.text-sm {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+.text-xl {
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+}
+.font-bold {
+  font-weight: 700;
+}
+.font-semibold {
+  font-weight: 600;
+}
+.text-accent {
+  --tw-text-opacity: 1;
+  color: rgb(79 70 229 / var(--tw-text-opacity, 1));
+}
+.text-clay {
+  --tw-text-opacity: 1;
+  color: rgb(45 42 38 / var(--tw-text-opacity, 1));
+}
+.text-ink {
+  --tw-text-opacity: 1;
+  color: rgb(18 18 18 / var(--tw-text-opacity, 1));
+}
+.text-white {
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+.text-white\/90 {
+  color: rgb(255 255 255 / 0.9);
+}
+.outline {
+  outline-style: solid;
+}
+.hover\:underline:hover {
+  text-decoration-line: underline;
+}
+@media (min-width: 768px) {
+
+  .md\:col-span-2 {
+    grid-column: span 2 / span 2;
+  }
+
+  .md\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .md\:text-5xl {
+    font-size: 3rem;
+    line-height: 1;
+  }
+}

--- a/docs/context-engineering-fundamentals/index.html
+++ b/docs/context-engineering-fundamentals/index.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Manage attention, evidence, and task state during long AI-agent sessions without relying on fixed token thresholds.">
+    <title>Context engineering fundamentals - Agent skills for journalism</title>
+    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+    <link rel="stylesheet" href="../assets/tailwind/context-engineering-fundamentals.css" data-tailwind-build="3.4.19">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        h1, h2, h3 { font-family: 'Fraunces', serif; }
+        .paper-overlay {
+            position: fixed;
+            inset: 0;
+            background-image: radial-gradient(circle at 50% 20%, rgba(255,255,255,0.45), transparent 60%);
+            pointer-events: none;
+        }
+        .skip-link { position: absolute; left: -9999px; top: 0; z-index: 100; }
+        .skip-link:focus { left: 1rem; top: 1rem; padding: 0.75rem 1rem; background: #121212; color: #fff; }
+        :focus-visible { outline: 2px solid #4f46e5; outline-offset: 4px; }
+        @media (prefers-reduced-motion: reduce) {
+            *, *::before, *::after { scroll-behavior: auto !important; }
+        }
+    </style>
+    <meta property="og:title" content="Context engineering fundamentals">
+    <meta property="og:description" content="Keep instructions, evidence, and task state usable during long AI-agent sessions.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://skills.amditis.tech/context-engineering-fundamentals/">
+    <meta property="og:image" content="https://skills.amditis.tech/og-image.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Context engineering fundamentals">
+    <meta name="twitter:description" content="Keep instructions, evidence, and task state usable during long AI-agent sessions.">
+    <meta name="twitter:image" content="https://skills.amditis.tech/og-image.png">
+    <link rel="stylesheet" href="../updated.css">
+    <script src="../ask-ai.js" defer></script>
+</head>
+<body class="bg-canvas text-ink">
+    <a href="#main" class="skip-link">Skip to main content</a>
+    <div class="paper-overlay" aria-hidden="true"></div>
+
+    <nav aria-label="Primary" class="relative z-10 border-b border-mist/40">
+        <div class="max-w-4xl mx-auto px-6 py-4 flex items-center justify-between">
+            <a href="../" class="text-sm font-semibold text-accent hover:underline">All skills</a>
+            <a href="https://github.com/jamditis/claude-skills-journalism/tree/master/dev-toolkit/skills/context-engineering-fundamentals" class="text-sm font-semibold text-accent hover:underline">View source</a>
+        </div>
+    </nav>
+
+    <header class="relative z-10 bg-gradient-to-br from-accent to-accentDark text-white">
+        <div class="max-w-4xl mx-auto px-6 py-16">
+            <p class="text-sm font-semibold mb-4">Development skill</p>
+            <h1 class="text-4xl md:text-5xl font-bold">Context engineering fundamentals</h1>
+            <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-14T12:31:33-04:00" data-updated-slug="context-engineering-fundamentals">Updated <time datetime="2026-08-14T12:31:33-04:00">Aug 14, 2026</time></p>
+            <p class="text-xl text-white/90 max-w-2xl mt-5">Keep instructions, evidence, and task state usable during long AI-agent sessions.</p>
+        </div>
+    </header>
+
+    <main id="main" class="relative z-10 max-w-4xl mx-auto px-6 py-12">
+        <section class="mb-12">
+            <h2 class="text-2xl font-semibold mb-4">Use this skill when</h2>
+            <ul class="space-y-3 list-disc pl-6 text-clay">
+                <li>A task spans many steps, files, tools, or agents.</li>
+                <li>An agent loses an instruction or misses supplied evidence.</li>
+                <li>You must decide what to preserve, compress, or remove.</li>
+                <li>You need a repeatable way to test long-context quality.</li>
+            </ul>
+        </section>
+
+        <section class="mb-12">
+            <h2 class="text-2xl font-semibold mb-4">Core rule</h2>
+            <div class="bg-white/60 border border-mist/40 rounded-xl p-6">
+                <p class="text-lg">A large context limit does not guarantee equal use of every item.</p>
+                <p class="mt-3 text-clay">Measure retrieval and reasoning quality on the model and task you use. Do not rely on universal token thresholds.</p>
+            </div>
+        </section>
+
+        <section class="mb-12">
+            <h2 class="text-2xl font-semibold mb-5">Five failure patterns</h2>
+            <div class="grid md:grid-cols-2 gap-4">
+                <article class="bg-white/50 border border-mist/40 rounded-xl p-5">
+                    <h3 class="text-lg font-semibold">Lost in the middle</h3>
+                    <p class="text-clay mt-2">Evidence can become harder to retrieve when it sits between other material.</p>
+                </article>
+                <article class="bg-white/50 border border-mist/40 rounded-xl p-5">
+                    <h3 class="text-lg font-semibold">Context poisoning</h3>
+                    <p class="text-clay mt-2">An early error can shape later reasoning when nobody verifies it.</p>
+                </article>
+                <article class="bg-white/50 border border-mist/40 rounded-xl p-5">
+                    <h3 class="text-lg font-semibold">Context distraction</h3>
+                    <p class="text-clay mt-2">Irrelevant material competes with the evidence that matters.</p>
+                </article>
+                <article class="bg-white/50 border border-mist/40 rounded-xl p-5">
+                    <h3 class="text-lg font-semibold">Context confusion</h3>
+                    <p class="text-clay mt-2">Mixed tasks and unclear boundaries make the next action ambiguous.</p>
+                </article>
+                <article class="bg-white/50 border border-mist/40 rounded-xl p-5 md:col-span-2">
+                    <h3 class="text-lg font-semibold">Context clash</h3>
+                    <p class="text-clay mt-2">Conflicting sources or instructions need an explicit decision before use.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="mb-12">
+            <h2 class="text-2xl font-semibold mb-4">Practical workflow</h2>
+            <ol class="space-y-4 list-decimal pl-6 text-clay">
+                <li>Keep critical constraints near the decision that uses them.</li>
+                <li>Verify intermediate outputs before later steps depend on them.</li>
+                <li>Remove irrelevant material before you add more context.</li>
+                <li>Write durable state only to a user-approved path.</li>
+                <li>Compare task quality before and after summarization.</li>
+            </ol>
+        </section>
+
+        <section class="border-t border-mist/40 pt-8">
+            <h2 class="text-2xl font-semibold mb-4">Install</h2>
+            <p class="text-clay mb-4">Install the dev-toolkit plugin or copy this skill with the standards-based skills CLI.</p>
+            <pre class="bg-ink text-white rounded-xl p-4 overflow-x-auto mb-4"><code>/plugin install dev-toolkit@claude-skills-journalism</code></pre>
+            <pre class="bg-ink text-white rounded-xl p-4 overflow-x-auto"><code>npx skills@latest add jamditis/claude-skills-journalism \
+  --skill context-engineering-fundamentals --agent codex --copy -g -y</code></pre>
+        </section>
+    </main>
+
+    <footer class="relative z-10 border-t border-mist/40 mt-8">
+        <div class="max-w-4xl mx-auto px-6 py-8 text-sm text-clay flex flex-wrap gap-4 justify-between">
+            <span>Joe Amditis</span>
+            <a href="https://github.com/jamditis/claude-skills-journalism" class="text-accent hover:underline">GitHub repository</a>
+        </div>
+    </footer>
+    <script defer src="../updated.js"></script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -227,7 +227,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Claude skills for journalism">
-    <meta property="og:description" content="60 skills, 12 plugins, and 17 hooks for journalists, researchers, academics, and media professionals.">
+    <meta property="og:description" content="61 skills, 12 plugins, and 17 hooks for journalists, researchers, academics, and media professionals.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/">
     <meta property="og:image" content="https://skills.amditis.tech/og-image.png">
@@ -237,7 +237,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Claude skills for journalism">
-    <meta name="twitter:description" content="60 skills, 12 plugins, and 17 hooks for journalists, researchers, academics, and media professionals.">
+    <meta name="twitter:description" content="61 skills, 12 plugins, and 17 hooks for journalists, researchers, academics, and media professionals.">
     <meta name="twitter:image" content="https://skills.amditis.tech/og-image.png">
 <script src="ask-ai.js" defer></script>
 
@@ -247,7 +247,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
   "@context": "https://schema.org",
   "@type": "SoftwareSourceCode",
   "name": "Claude skills for journalism",
-  "description": "60 Claude Code skills, 12 plugins, and 17 workflow hooks for verification, FOIA, data journalism, academic writing, and more. Built for journalists, researchers, and media professionals.",
+  "description": "61 agent skills, 12 plugins, and 17 workflow hooks for verification, FOIA, data journalism, academic writing, and more. Built for journalists, researchers, and media professionals.",
   "url": "https://skills.amditis.tech",
   "codeRepository": "https://github.com/jamditis/claude-skills-journalism",
   "programmingLanguage": "Markdown",
@@ -303,7 +303,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <!-- Hero -->
             <header class="mb-32 md:mb-44 animate-page-in">
                 <div class="inline-block px-4 py-1 border border-ink/10 mb-6">
-                    <span class="text-[9px] font-bold tracking-[0.4em] uppercase opacity-50">60 Skills // 12 Plugins // 17 Hooks</span>
+                    <span class="text-[9px] font-bold tracking-[0.4em] uppercase opacity-50">61 Skills // 12 Plugins // 17 Hooks</span>
                 </div>
                 <h1 class="font-display fluid-title text-[11vw] md:text-[8.5vw] font-light leading-[0.85] tracking-tight mb-12 text-ink">
                     Skills for <br> <span class="italic font-black">journalism.</span>
@@ -414,7 +414,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <div class="deckle-card-solid p-6 md:p-8">
                     <div class="flex flex-col md:flex-row md:items-center justify-between gap-3 mb-4">
                         <h2 class="font-display text-2xl font-light italic">Find a skill</h2>
-                        <span class="section-label" id="finder-count">60 skills, 12 plugins</span>
+                        <span class="section-label" id="finder-count">61 skills, 12 plugins</span>
                     </div>
                     <div class="relative">
                         <i data-lucide="search" class="w-5 h-5 text-mist absolute left-4 top-1/2 -translate-y-1/2 pointer-events-none"></i>
@@ -546,7 +546,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                             <span class="featured-badge">Plugin</span>
                         </div>
                         <h3 class="font-display text-lg font-bold mb-2 group-hover:text-accent transition-colors">dev-toolkit</h3>
-                        <p class="text-sm text-mist leading-relaxed">Eleven development skills for small newsroom teams: accessibility (WCAG 2.2), Electron, mobile debugging, Python pipelines, test-first bug fixing, ethical scraping, no-build frontend, signs-of-taste web UI, and CLAUDE.md context maintenance.</p>
+                        <p class="text-sm text-mist leading-relaxed">Twelve development skills for small newsroom teams: accessibility, context engineering, Electron, mobile debugging, Python pipelines, test-first bug fixing, ethical scraping, no-build frontend, web UI, and CLAUDE.md maintenance.</p>
                         <div class="flex flex-wrap gap-2 mt-3">
                             <span class="text-[8px] bg-accent/10 text-accent px-2 py-1 rounded font-semibold">Accessibility</span>
                             <span class="text-[8px] bg-accent/10 text-accent px-2 py-1 rounded font-semibold">Pipelines</span>
@@ -913,7 +913,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <section class="reveal-section mb-32">
                 <div class="section-header flex flex-col md:flex-row md:items-end justify-between gap-4">
                     <h2 class="font-display text-4xl font-light italic">08 / Development</h2>
-                    <span class="section-label">11 Skills</span>
+                    <span class="section-label">12 Skills</span>
                 </div>
 
                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -1024,6 +1024,16 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         <h3 class="font-display text-lg font-bold mb-2 group-hover:text-accent transition-colors">claude-md-updater</h3>
                         <p class="text-sm text-mist leading-relaxed">Propose scoped CLAUDE.md edits as a diff for approval: durable lessons, infra facts, and workflows, never transient session notes.</p>
                         <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-07-21T18:21:17-04:00" data-updated-slug="claude-md-updater">Updated <time datetime="2026-07-21T18:21:17-04:00">Jul 21, 2026</time></p>
+                    </a>
+
+                    <a href="context-engineering-fundamentals/" class="skill-card deckle-card p-6 transition-all duration-300 block group">
+                        <div class="flex items-start justify-between mb-3">
+                            <i data-lucide="braces" class="w-5 h-5 text-accent"></i>
+                            <span class="hook-badge bg-accent/10 text-accent">Dev</span>
+                        </div>
+                        <h3 class="font-display text-lg font-bold mb-2 group-hover:text-accent transition-colors">context-engineering-fundamentals</h3>
+                        <p class="text-sm text-mist leading-relaxed">Keep instructions, evidence, and task state usable during long AI-agent sessions.</p>
+                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-08-14T12:31:33-04:00" data-updated-slug="context-engineering-fundamentals">Updated <time datetime="2026-08-14T12:31:33-04:00">Aug 14, 2026</time></p>
                     </a>
                 </div>
             </section>
@@ -1419,7 +1429,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             const defaultCount = countEl ? countEl.textContent : '';
             // Searchable text = visible card text + any data-keywords. The keywords
             // let a parent plugin card (e.g. superjawn, pdf-playground) match the
-            // sub-skills it bundles but doesn't render as their own card, so all 60
+            // sub-skills it bundles but doesn't render as their own card, so all 61
             // advertised skills are findable, not just the cards on the page.
             // The last-updated tape is excluded: it would otherwise make every
             // card match "updated", and any card match the month it changed.

--- a/docs/index.html
+++ b/docs/index.html
@@ -552,7 +552,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                             <span class="text-[8px] bg-accent/10 text-accent px-2 py-1 rounded font-semibold">Pipelines</span>
                             <span class="text-[8px] bg-accent/10 text-accent px-2 py-1 rounded font-semibold">Test-first</span>
                         </div>
-                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-07-21T18:22:19-04:00" data-updated-slug="dev-toolkit">Updated <time datetime="2026-07-21T18:22:19-04:00">Jul 21, 2026</time></p>
+                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-08-14T12:31:33-04:00" data-updated-slug="dev-toolkit">Updated <time datetime="2026-08-14T12:31:33-04:00">Aug 14, 2026</time></p>
                     </a>
 
                     <a target="_blank" rel="noopener noreferrer" href="https://github.com/jamditis/claude-skills-journalism/tree/master/project-templates-toolkit" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -12,7 +12,7 @@ Source: https://github.com/jamditis/claude-skills-journalism
 Joe Amditis — associate director of operations, Center for Cooperative Media, Montclair State University.
 Personal site: https://jamditis.com
 
-## Skills (56 total)
+## Skills (61 total)
 
 ### Journalism and verification
 - source-verification — SIFT method, verification trails, source credibility, deepfakes/C2PA
@@ -54,6 +54,7 @@ Personal site: https://jamditis.com
 - accessibility-compliance — WCAG, alt text, a11y
 - web-ui-best-practices — signs of craft in web UI
 - claude-md-updater — propose scoped CLAUDE.md updates from a session
+- context-engineering-fundamentals — preserve instructions, evidence, and state in long agent sessions
 
 ### Security
 - security-checklist — pre-deployment security audit
@@ -71,6 +72,12 @@ Personal site: https://jamditis.com
 - pdf-playground — document design (proposals, reports)
 - visual-explainer — generate self-contained HTML pages that visually explain systems
 - okf-wiki — scaffold an Open Knowledge Format knowledge base (one-concept-per-file markdown, validator, session-start orientation hooks)
+
+### Video
+- video-download — download authorized video from supported social platforms
+- video-transcribe — transcribe audio and video with local Whisper workflows
+- video-frames — extract and inspect representative video frames
+- video-dashboard — build a local dashboard from transcript and frame analysis
 
 ### Workflow patterns (superjawn)
 - using-superjawn — establishes how to find and use skills
@@ -130,7 +137,7 @@ Skills above are distributed as Claude Code plugins. Install via:
 
 Restart your Claude Code session after installing or updating a plugin so the new skills and commands register.
 
-Plugins (12): `journalism-core` (14 skills), `research-toolkit` (6), `dev-toolkit` (11), `security-toolkit` (4 skills + /hotpatch command), `project-templates-toolkit` (3), `pdf-design` (1), `pdf-playground` (1), `visual-explainer` (1), `video-toolkit` (4), `okf-wiki` (1), `superjawn` (14), `autocontext` (cross-session knowledge persistence — hooks, commands, and agents rather than skills).
+Plugins (12): `journalism-core` (14 skills), `research-toolkit` (6), `dev-toolkit` (12), `security-toolkit` (4 skills + /hotpatch command), `project-templates-toolkit` (3), `pdf-design` (1), `pdf-playground` (1), `visual-explainer` (1), `video-toolkit` (4), `okf-wiki` (1), `superjawn` (14), `autocontext` (cross-session knowledge persistence — hooks, commands, and agents rather than skills).
 
 ## Alternate installation
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -55,6 +55,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://skills.amditis.tech/context-engineering-fundamentals/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://skills.amditis.tech/crisis-communications/</loc>
     <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>

--- a/docs/tailwind-pages.json
+++ b/docs/tailwind-pages.json
@@ -197,6 +197,30 @@
       }
     }
   },
+  "context-engineering-fundamentals/index.html": {
+    "theme": {
+      "extend": {
+        "fontFamily": {
+          "display": [
+            "Fraunces",
+            "serif"
+          ],
+          "body": [
+            "Plus Jakarta Sans",
+            "sans-serif"
+          ]
+        },
+        "colors": {
+          "canvas": "#ede6d4",
+          "ink": "#121212",
+          "clay": "#2d2a26",
+          "mist": "#c4bfb4",
+          "accent": "#4f46e5",
+          "accentDark": "#4338ca"
+        }
+      }
+    }
+  },
   "crisis-communications/index.html": {
     "theme": {
       "extend": {

--- a/okf-wiki/example/bundle/index.md
+++ b/okf-wiki/example/bundle/index.md
@@ -8,13 +8,13 @@ skill that lives in it. Every concept points its `source` at the real files it
 describes, so you can diff the wiki against the code. This is the working example
 linked from the okf-wiki page.
 
-The repository is a Claude Code plugin marketplace: 11 plugins, 56 skills, and 17
+The repository is a Claude Code plugin marketplace: 12 plugins, 61 skills, and 17
 standalone hooks. Start at the [repo overview](systems/repo-overview.md), browse by
 [plugin](plugins/index.md), or jump straight to a [skill](skills/index.md).
 
 ## Sections
 
-- [plugins](plugins/index.md) - the 11 plugins this marketplace ships
-- [skills](skills/index.md) - all 56 skills, one concept per file, grouped by plugin
+- [plugins](plugins/index.md) - the 12 plugins this marketplace ships
+- [skills](skills/index.md) - all 61 skills, one concept per file, grouped by plugin
 - [hooks](hooks/index.md) - the 17 standalone workflow hooks under `hooks/`
 - [systems](systems/index.md) - how the repo is built, validated, and published

--- a/okf-wiki/example/bundle/plugins/dev-toolkit.md
+++ b/okf-wiki/example/bundle/plugins/dev-toolkit.md
@@ -1,15 +1,15 @@
 ---
 type: Reference
 title: "dev-toolkit plugin"
-description: "Eleven development skills for small newsroom dev teams."
+description: "Twelve development skills for small newsroom dev teams."
 source: ["dev-toolkit/.claude-plugin/plugin.json", ".claude-plugin/marketplace.json"]
-verified: 2026-06-26
-timestamp: 2026-06-26
+verified: 2026-08-15
+timestamp: 2026-08-15
 tags: [plugin, development]
 ---
 # dev-toolkit plugin
 
-Eleven skills: accessibility (WCAG 2.2), Electron patterns, mobile/remote
+Twelve skills: accessibility (WCAG 2.2), context engineering, Electron patterns, mobile/remote
 debugging, irreversible-decision discipline, Python data pipelines, test-first bug
 fixing, AI-assisted development, ethical web scraping, no-build frontend patterns,
 web-UI taste, and CLAUDE.md context maintenance. Install with
@@ -19,6 +19,7 @@ web-UI taste, and CLAUDE.md context maintenance. Install with
 
 - [accessibility-compliance](../skills/accessibility-compliance.md)
 - [claude-md-updater](../skills/claude-md-updater.md)
+- [context-engineering-fundamentals](../skills/context-engineering-fundamentals.md)
 - [electron-dev](../skills/electron-dev.md)
 - [mobile-debugging](../skills/mobile-debugging.md)
 - [one-way-door](../skills/one-way-door.md)

--- a/okf-wiki/example/bundle/plugins/index.md
+++ b/okf-wiki/example/bundle/plugins/index.md
@@ -1,11 +1,11 @@
 # plugins
 
-The 11 plugins registered in [the marketplace](../systems/marketplace.md). Each
+The 12 plugins registered in [the marketplace](../systems/marketplace.md). Each
 concept records what the plugin is, its skill or command count, and where it
 lives. For individual skills, see the [skills section](../skills/index.md).
 
 - [autocontext](autocontext.md) - cross-session knowledge (hooks/commands/agents, no skills)
-- [dev-toolkit](dev-toolkit.md) - 11 development skills
+- [dev-toolkit](dev-toolkit.md) - 12 development skills
 - [journalism-core](journalism-core.md) - 14 journalism skills
 - [okf-wiki](okf-wiki.md) - the OKF scaffolder (1 skill)
 - [pdf-design](pdf-design.md) - PDF design system (1 skill)
@@ -14,4 +14,5 @@ lives. For individual skills, see the [skills section](../skills/index.md).
 - [research-toolkit](research-toolkit.md) - 6 research skills
 - [security-toolkit](security-toolkit.md) - 4 security skills, 1 command
 - [superjawn](superjawn.md) - 14 workflow skills
+- [video-toolkit](video-toolkit.md) - 4 social-video reporting skills
 - [visual-explainer](visual-explainer.md) - HTML diagrams (1 skill)

--- a/okf-wiki/example/bundle/plugins/video-toolkit.md
+++ b/okf-wiki/example/bundle/plugins/video-toolkit.md
@@ -1,0 +1,21 @@
+---
+type: Reference
+title: "video-toolkit plugin"
+description: "Four composable skills for public social-video reporting and analysis."
+source: ["video-toolkit/.claude-plugin/plugin.json", ".claude-plugin/marketplace.json"]
+verified: 2026-08-15
+timestamp: 2026-08-15
+tags: [plugin, video, reporting]
+---
+# video-toolkit plugin
+
+Four skills form a reporting pipeline for authorized public video collection,
+transcription, frame analysis, and interactive dashboard creation. Install with
+`/plugin install video-toolkit@claude-skills-journalism`.
+
+## Skills
+
+- [video-download](../skills/video-download.md)
+- [video-transcribe](../skills/video-transcribe.md)
+- [video-frames](../skills/video-frames.md)
+- [video-dashboard](../skills/video-dashboard.md)

--- a/okf-wiki/example/bundle/skills/context-engineering-fundamentals.md
+++ b/okf-wiki/example/bundle/skills/context-engineering-fundamentals.md
@@ -1,0 +1,16 @@
+---
+type: Reference
+title: "context-engineering-fundamentals skill"
+description: "Manage attention and evidence in long AI-agent sessions."
+source: ["dev-toolkit/skills/context-engineering-fundamentals/SKILL.md", ".claude-plugin/marketplace.json"]
+verified: 2026-08-15
+timestamp: 2026-08-15
+tags: ["skill", "dev-toolkit"]
+---
+# context-engineering-fundamentals skill
+
+Keep instructions, evidence, and state available during long work. Measure
+retrieval and reasoning quality on the current model and task before compressing
+context or relying on fixed thresholds.
+
+Part of the [dev-toolkit plugin](../plugins/dev-toolkit.md). Source: `dev-toolkit/skills/context-engineering-fundamentals/SKILL.md`.

--- a/okf-wiki/example/bundle/skills/index.md
+++ b/okf-wiki/example/bundle/skills/index.md
@@ -1,6 +1,6 @@
 # skills
 
-Every skill the marketplace ships, one concept per file, grouped by [plugin](../plugins/index.md). 56 skills across 10 plugins.
+Every skill the marketplace ships, one concept per file, grouped by [plugin](../plugins/index.md). 61 skills across 11 plugins.
 
 ## [journalism-core](../plugins/journalism-core.md)
 - [ai-writing-detox](ai-writing-detox.md)
@@ -29,6 +29,7 @@ Every skill the marketplace ships, one concept per file, grouped by [plugin](../
 ## [dev-toolkit](../plugins/dev-toolkit.md)
 - [accessibility-compliance](accessibility-compliance.md)
 - [claude-md-updater](claude-md-updater.md)
+- [context-engineering-fundamentals](context-engineering-fundamentals.md)
 - [electron-dev](electron-dev.md)
 - [mobile-debugging](mobile-debugging.md)
 - [one-way-door](one-way-door.md)
@@ -77,3 +78,9 @@ Every skill the marketplace ships, one concept per file, grouped by [plugin](../
 
 ## [okf-wiki](../plugins/okf-wiki.md)
 - [okf-wiki](okf-wiki.md)
+
+## [video-toolkit](../plugins/video-toolkit.md)
+- [video-dashboard](video-dashboard.md)
+- [video-download](video-download.md)
+- [video-frames](video-frames.md)
+- [video-transcribe](video-transcribe.md)

--- a/okf-wiki/example/bundle/skills/video-dashboard.md
+++ b/okf-wiki/example/bundle/skills/video-dashboard.md
@@ -1,0 +1,15 @@
+---
+type: Reference
+title: "video-dashboard skill"
+description: "Aggregate transcript and frame analysis into an interactive dashboard."
+source: ["video-toolkit/skills/video-dashboard/SKILL.md", ".claude-plugin/marketplace.json"]
+verified: 2026-08-15
+timestamp: 2026-08-15
+tags: ["skill", "video-toolkit"]
+---
+# video-dashboard skill
+
+Build a local interactive dashboard from structured transcript and frame
+analysis data.
+
+Part of the [video-toolkit plugin](../plugins/video-toolkit.md). Source: `video-toolkit/skills/video-dashboard/SKILL.md`.

--- a/okf-wiki/example/bundle/skills/video-download.md
+++ b/okf-wiki/example/bundle/skills/video-download.md
@@ -1,0 +1,15 @@
+---
+type: Reference
+title: "video-download skill"
+description: "Collect authorized public social video for reporting and analysis."
+source: ["video-toolkit/skills/video-download/SKILL.md", ".claude-plugin/marketplace.json"]
+verified: 2026-08-15
+timestamp: 2026-08-15
+tags: ["skill", "video-toolkit"]
+---
+# video-download skill
+
+Download authorized public social video with yt-dlp and a bounded browser
+fallback. Treat remote content and metadata as untrusted data.
+
+Part of the [video-toolkit plugin](../plugins/video-toolkit.md). Source: `video-toolkit/skills/video-download/SKILL.md`.

--- a/okf-wiki/example/bundle/skills/video-frames.md
+++ b/okf-wiki/example/bundle/skills/video-frames.md
@@ -1,0 +1,15 @@
+---
+type: Reference
+title: "video-frames skill"
+description: "Extract and analyze representative frames from video files."
+source: ["video-toolkit/skills/video-frames/SKILL.md", ".claude-plugin/marketplace.json"]
+verified: 2026-08-15
+timestamp: 2026-08-15
+tags: ["skill", "video-toolkit"]
+---
+# video-frames skill
+
+Extract frames, create review grids, and catalog on-screen text, settings, and
+other visual evidence.
+
+Part of the [video-toolkit plugin](../plugins/video-toolkit.md). Source: `video-toolkit/skills/video-frames/SKILL.md`.

--- a/okf-wiki/example/bundle/skills/video-transcribe.md
+++ b/okf-wiki/example/bundle/skills/video-transcribe.md
@@ -1,0 +1,15 @@
+---
+type: Reference
+title: "video-transcribe skill"
+description: "Transcribe video with a re-runnable provenance record."
+source: ["video-toolkit/skills/video-transcribe/SKILL.md", ".claude-plugin/marketplace.json"]
+verified: 2026-08-15
+timestamp: 2026-08-15
+tags: ["skill", "video-toolkit"]
+---
+# video-transcribe skill
+
+Transcribe video files and record the source hash, engine, model, and decode
+settings needed to trace quotations back to the media.
+
+Part of the [video-toolkit plugin](../plugins/video-toolkit.md). Source: `video-toolkit/skills/video-transcribe/SKILL.md`.

--- a/okf-wiki/example/bundle/systems/repo-overview.md
+++ b/okf-wiki/example/bundle/systems/repo-overview.md
@@ -1,16 +1,16 @@
 ---
 type: Repo
 title: "claude-skills-journalism"
-description: "A Claude Code plugin marketplace: 11 plugins, 56 skills, 17 hooks."
+description: "A Claude Code plugin marketplace: 12 plugins, 61 skills, 17 hooks."
 source: ["README.md", "CLAUDE.md", ".claude-plugin/marketplace.json"]
-verified: 2026-06-30
-timestamp: 2026-06-30
+verified: 2026-08-15
+timestamp: 2026-08-15
 tags: [repo, overview]
 ---
 # claude-skills-journalism
 
 A marketplace of Claude Code plugins for journalism, research, media, and
-technical work. It ships 11 plugins totaling 56 skills, plus 17 standalone hooks
+technical work. It ships 12 plugins totaling 61 skills, plus 17 standalone hooks
 under `hooks/`. Plugins are registered in [the marketplace](marketplace.md) and
 documented at [the docs site](pages-deploy.md). Browse the
 [plugins](../plugins/index.md), the [skills](../skills/index.md), or the

--- a/scripts/dev-toolkit-catalog.test.mjs
+++ b/scripts/dev-toolkit-catalog.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const DEV_SKILLS = join(ROOT, 'dev-toolkit', 'skills');
+const DOCS = join(ROOT, 'docs');
+
+test('every dev-toolkit skill has a public docs page', () => {
+  const missing = readdirSync(DEV_SKILLS, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => !existsSync(join(DOCS, name, 'index.html')));
+
+  assert.deepEqual(missing, []);
+});
+
+test('the public dev-toolkit card uses the current count and scope', () => {
+  const homepage = readFileSync(join(DOCS, 'index.html'), 'utf8');
+
+  assert.match(homepage, /Twelve development skills/u);
+  assert.match(homepage, /08 \/ Development[\s\S]*?<span class="section-label">12 Skills<\/span>/u);
+  assert.match(homepage, /context engineering/u);
+  assert.doesNotMatch(homepage, /Eleven development skills/u);
+});
+
+test('llms.txt skill total matches its listed skills', () => {
+  const catalog = readFileSync(join(DOCS, 'llms.txt'), 'utf8');
+  const skillsSection = catalog.match(/## Skills \((\d+) total\)\n([\s\S]*?)\n## Hooks/u);
+
+  assert.ok(skillsSection);
+  const listedSkills = skillsSection[2].match(/^- /gmu) ?? [];
+  assert.equal(listedSkills.length, Number(skillsSection[1]));
+});
+
+test('the context skill page shows plugin and standards-based install paths', () => {
+  const page = readFileSync(join(DOCS, 'context-engineering-fundamentals', 'index.html'), 'utf8');
+
+  assert.match(page, /\/plugin install dev-toolkit@claude-skills-journalism/u);
+  assert.match(page, /npx skills@latest add jamditis\/claude-skills-journalism/u);
+});
+
+test('context guidance does not present universal recall percentages', () => {
+  const skill = readFileSync(
+    join(DEV_SKILLS, 'context-engineering-fundamentals', 'SKILL.md'),
+    'utf8',
+  );
+
+  assert.doesNotMatch(skill, /Recall Accuracy/u);
+  assert.doesNotMatch(skill, /~?\d{2}(?:-\d{2})?%/u);
+  assert.doesNotMatch(skill, /Full attention, reliable recall/u);
+  assert.match(skill, /Measure retrieval and reasoning quality on your own model and task/u);
+});

--- a/scripts/docs-tailwind-security.test.mjs
+++ b/scripts/docs-tailwind-security.test.mjs
@@ -48,12 +48,12 @@ test('docs pages use committed Tailwind CSS instead of the Play CDN runtime', ()
   }
 
   assert.deepEqual(violations, []);
-  assert.equal(migrated.length, 49);
+  assert.equal(migrated.length, 50);
 });
 
 test('docs Tailwind build inputs and CI freshness gate are pinned', () => {
   const manifest = JSON.parse(readFileSync(join(DOCS, 'tailwind-pages.json'), 'utf8'));
-  assert.equal(Object.keys(manifest).length, 49);
+  assert.equal(Object.keys(manifest).length, 50);
 
   const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'));
   assert.equal(pkg.devDependencies.tailwindcss, '3.4.19');

--- a/scripts/video-toolkit-docs.test.mjs
+++ b/scripts/video-toolkit-docs.test.mjs
@@ -37,8 +37,8 @@ test('video toolkit docs explain the four-stage reporting pipeline and its bound
 test('homepage lists video toolkit once, before visual explainer, with accurate counts', () => {
   const index = readFileSync(join(DOCS, 'index.html'), 'utf8');
 
-  assert.match(index, />60 Skills \/\/ 12 Plugins \/\/ 17 Hooks</u);
-  assert.match(index, /id="finder-count">60 skills, 12 plugins</u);
+  assert.match(index, />61 Skills \/\/ 12 Plugins \/\/ 17 Hooks</u);
+  assert.match(index, /id="finder-count">61 skills, 12 plugins</u);
   assert.match(index, />12 Plugins<\/span>/u);
   assert.equal((index.match(/href="video-toolkit\/"/gu) || []).length, 1);
 


### PR DESCRIPTION
Publishes `context-engineering-fundamentals` into `dev-toolkit`, the first of the group-4 tools-repo standouts tracked in #115 / #220.

## What it adds

A skill that explains how Claude's attention budget works and when context degrades: the lost-in-middle effect, five degradation patterns (poisoning, distraction, confusion, clash) with mitigations, practical size thresholds, and write / select / compress / isolate strategies. No catalog duplicate: autocontext persists lessons across sessions (a different mechanism), and nothing else covers attention mechanics.

## Why this one first, and a correction to #220

#220 lists three group-4 skills as "publishable now, none carry brand constants," on the basis that a grep for `jamditis|houseofjawn|officejawn|centerforcooperativemedia|njpbs|/home/` returned nothing. That grep was case-sensitive and lowercase, so it missed the "Amditis" surname. On a full read of the three:

- `context-engineering-fundamentals` (this PR) carried a "Working with this project / For the Amditis Resource Kit specifically" section, a dangling "Related skills" list, and a December 2025 footer. Removed all three; the rest is general and ports clean.
- `frontend-authenticity` also carries a project-bound "Amditis theme" section (acid-green #c8ff00, clip-notch) and has no YAML frontmatter at all, so it is neither ready-as-is nor catalog-valid without edits.
- `template-factory` is content-clean but overlaps the published `project-templates-toolkit` (LESSONS + CLAUDE.md writers). That is a dedup or fold decision, not a mechanical port. It also carries a `context: fork` frontmatter field the skill-frontmatter test rejects.

Per-skill detail for the other two is on #220 for a follow-up.

## Edits to the source before publishing

- Removed the "Amditis Resource Kit" project section.
- Removed the "Related skills" references (`state-management-debugger`, `project-memory-generator`, `development-workflow`); none exist in this catalog.
- Removed the dated version footer.
- Replaced one em dash in the body with a sentence break, to match house style.
- Otherwise the source prose is preserved verbatim.

## Surface

- `dev-toolkit/skills/context-engineering-fundamentals/SKILL.md` (new)
- `dev-toolkit` bumped 1.1.1 to 1.2.0 (plugin manifest + marketplace listing), description "Eleven" to "Twelve"
- README table row added; CHANGELOG entry under [Unreleased]
- Top-level marketplace version stays 2.4.0 (pinned by the version-alignment test; a release PR bumps it)

## Validation

- agentskills `skills-ref validate` on the new directory: `Valid skill`
- `node --test scripts/skill-frontmatter.test.mjs`: 2/2 pass (frontmatter contract + version alignment)
- `node --test scripts/skill-security.test.mjs`: 4/4 pass

wake-20260814T1205-01521b
