### PR TITLE
Credit Reinaldo Chaves for the Brazilian records skill

### DIFF
--- a/docs/assets/tailwind/brazil-records-requests.css
+++ b/docs/assets/tailwind/brazil-records-requests.css
@@ -682,6 +682,9 @@ video {
 .pt-28 {
   padding-top: 7rem;
 }
+.pt-8 {
+  padding-top: 2rem;
+}
 .text-2xl {
   font-size: 1.5rem;
   line-height: 2rem;

--- a/docs/brazil-records-requests/index.html
+++ b/docs/brazil-records-requests/index.html
@@ -112,6 +112,11 @@
             <p class="text-sm text-clay mt-4">Read the <a class="content-link text-accentDark font-semibold" href="https://github.com/jamditis/claude-skills-journalism/tree/master/journalism-core/skills/brazil-records-requests" target="_blank" rel="noopener noreferrer">full skill on GitHub</a>.</p>
         </section>
 
+        <section class="mb-16 border-t border-clay/20 pt-8" aria-labelledby="contributor-heading">
+            <h2 id="contributor-heading" class="text-2xl font-bold mb-3">Contributor</h2>
+            <p class="max-w-3xl text-clay leading-relaxed">This skill was contributed by <a class="content-link text-accentDark font-semibold" href="https://github.com/reichaves" target="_blank" rel="noopener noreferrer">Reinaldo Chaves (@reichaves)</a>. <a class="content-link text-accentDark font-semibold" href="https://github.com/jamditis/claude-skills-journalism/pull/267" target="_blank" rel="noopener noreferrer">Read the original pull request.</a></p>
+        </section>
+
         <section class="bg-accentLight rounded-3xl p-8 md:p-10" aria-labelledby="related-heading">
             <h2 id="related-heading" class="text-2xl font-bold mb-5">Related skills</h2>
             <div class="flex flex-wrap gap-3">

--- a/journalism-core/skills/brazil-records-requests/SKILL.md
+++ b/journalism-core/skills/brazil-records-requests/SKILL.md
@@ -303,3 +303,8 @@ current CGU guidance for procedural changes to Fala.BR.
 Related Brazilian statutes that intersect: Lei 13.709/2018 (LGPD),
 Lei 13.460/2017 (users of public services), Lei 14.129/2021 (digital
 government).
+
+## Contributor credit
+
+Reinaldo Chaves ([@reichaves](https://github.com/reichaves)) contributed this
+skill in [PR #267](https://github.com/jamditis/claude-skills-journalism/pull/267).

--- a/scripts/brazil-records-requests-docs.test.mjs
+++ b/scripts/brazil-records-requests-docs.test.mjs
@@ -92,6 +92,18 @@ test('Brazil records requests page supplies the Open Graph image size', () => {
   assert.match(page, /<meta property="og:image:height" content="630">/u);
 });
 
+test('Brazil records requests credits its contributor', () => {
+  const page = readFileSync(PAGE, 'utf8');
+  const skill = readFileSync(SKILL, 'utf8');
+
+  assert.match(page, /Reinaldo Chaves/u);
+  assert.match(page, /https:\/\/github\.com\/reichaves/u);
+  assert.match(page, /https:\/\/github\.com\/jamditis\/claude-skills-journalism\/pull\/267/u);
+  assert.match(skill, /Reinaldo Chaves/u);
+  assert.match(skill, /https:\/\/github\.com\/reichaves/u);
+  assert.match(skill, /https:\/\/github\.com\/jamditis\/claude-skills-journalism\/pull\/267/u);
+});
+
 test('Codex guidance gives the current journalism-core skill count', () => {
   const readme = readFileSync(README, 'utf8');
 


### PR DESCRIPTION
## Summary

Credit Reinaldo Chaves (@reichaves) on the Brazilian public records requests page and in the skill source.

## Why

Reinaldo proposed and contributed the merged Brazilian records requests skill in #267.

## Checks

- `npm test`
- `npm run validate:agent-skills`
- `npm run check:docs-css`
- `npm run a11y`
- Local Codex review with `gpt-5.5` at low effort
