### PR TITLE
Add dev-toolkit portability classifier and matrix

### DIFF
--- a/plans/codex-compatibility-matrix.md
+++ b/plans/codex-compatibility-matrix.md
@@ -550,3 +550,15 @@ more than one Codex installation path in the same profile, test:
 Record duplicate identity, precedence, activation, update, uninstall, recovery,
 and drift results here. Until then, documentation must recommend one Codex
 installation path per skill or package.
+
+## dev-toolkit per-skill portability
+
+The `dev-toolkit` row above is package-level. The per-skill breakdown lives in
+[dev-toolkit-portability-matrix.md](dev-toolkit-portability-matrix.md),
+generated from the repository by `scripts/dev-toolkit-portability.mjs` and
+guarded against drift by `scripts/dev-toolkit-portability.test.mjs`. It
+discovers 12 skills (not the stale 11 named above): 9 shared, 3
+adapter-required (`claude-md-updater`, `one-way-door`, `test-first-bugs`), 0
+Claude-only. `one-way-door` stays adapter-required for its automatic
+`AskUserQuestion` approval hooks, whose failure and approval semantics an
+adapter must reproduce, not drop.

--- a/plans/dev-toolkit-portability-matrix.md
+++ b/plans/dev-toolkit-portability-matrix.md
@@ -1,0 +1,29 @@
+# dev-toolkit per-skill portability
+
+How far each dev-toolkit skill is from running under Codex instead of
+Claude Code. Generated from the repository by the classifier; do not edit by
+hand. Regenerate with `node scripts/dev-toolkit-portability.mjs`.
+
+Classes: **shared** runs as written; **adapter-required** needs a documented
+Codex mapping (instruction file, tool vocabulary, or hook); **Claude-only**
+depends on a Claude runtime mechanic with no Codex equivalent.
+
+Inventory: 12 skills discovered from `dev-toolkit/skills` (9 shared, 3 adapter-required, 0 Claude-only).
+
+| Skill | Class | Auto-activation | Reason |
+| --- | --- | --- | --- |
+| `accessibility-compliance` | shared | no | No Claude-specific mechanic; runs under Codex as written. |
+| `claude-md-updater` | adapter-required | no | Targets CLAUDE.md; map the instruction file to AGENTS.md for Codex. |
+| `context-engineering-fundamentals` | shared | no | No Claude-specific mechanic; runs under Codex as written. |
+| `electron-dev` | shared | no | No Claude-specific mechanic; runs under Codex as written. |
+| `mobile-debugging` | shared | no | No Claude-specific mechanic; runs under Codex as written. |
+| `one-way-door` | adapter-required | yes (one-way-door-check.md) | Targets CLAUDE.md; map the instruction file to AGENTS.md for Codex; uses the AskUserQuestion tool; map to a Codex prompt or approval step; wires Claude PreToolUse/PostToolUse hooks; reproduce the failure and approval semantics before mapping, do not drop them. |
+| `python-pipeline` | shared | no | No Claude-specific mechanic; runs under Codex as written. |
+| `test-first-bugs` | adapter-required | yes (bug-report-detector.md) | Invokes the Task tool with subagent_type; map to a Codex multi-attempt run. |
+| `vibe-coding` | shared | no | No Claude-specific mechanic; runs under Codex as written. |
+| `web-scraping` | shared | no | No Claude-specific mechanic; runs under Codex as written. |
+| `web-ui-best-practices` | shared | no | No Claude-specific mechanic; runs under Codex as written. |
+| `zero-build-frontend` | shared | no | No Claude-specific mechanic; runs under Codex as written. |
+
+Adapter and Claude-only skills stay behind the one-installation-path rule in
+`plans/codex-compatibility-matrix.md` until each has a tested Codex mapping.

--- a/plans/dev-toolkit-portability-matrix.md
+++ b/plans/dev-toolkit-portability-matrix.md
@@ -19,7 +19,7 @@ Inventory: 12 skills discovered from `dev-toolkit/skills` (9 shared, 3 adapter-r
 | `mobile-debugging` | shared | no | No Claude-specific mechanic; runs under Codex as written. |
 | `one-way-door` | adapter-required | yes (one-way-door-check.md) | Targets CLAUDE.md; map the instruction file to AGENTS.md for Codex; uses the AskUserQuestion tool; map to a Codex prompt or approval step; wires Claude PreToolUse/PostToolUse hooks; reproduce the failure and approval semantics before mapping, do not drop them. |
 | `python-pipeline` | shared | no | No Claude-specific mechanic; runs under Codex as written. |
-| `test-first-bugs` | adapter-required | yes (bug-report-detector.md) | Invokes the Task tool with subagent_type; map to a Codex multi-attempt run. |
+| `test-first-bugs` | adapter-required | yes (bug-report-detector.md) | Invokes the Task tool with subagent_type; map to a Codex multi-attempt run; names Claude auto-activation hooks (bug-report-detector.md); reproduce their trigger and failure semantics before mapping. |
 | `vibe-coding` | shared | no | No Claude-specific mechanic; runs under Codex as written. |
 | `web-scraping` | shared | no | No Claude-specific mechanic; runs under Codex as written. |
 | `web-ui-best-practices` | shared | no | No Claude-specific mechanic; runs under Codex as written. |

--- a/scripts/dev-toolkit-portability.mjs
+++ b/scripts/dev-toolkit-portability.mjs
@@ -1,0 +1,228 @@
+// Classify every dev-toolkit skill by how much work it needs to run under Codex
+// instead of Claude Code. The inventory is read from the repository, not
+// hard-coded, so a skill added to dev-toolkit/skills is picked up on the next
+// run. Regenerate the committed matrix with:
+//   node scripts/dev-toolkit-portability.mjs
+// The drift test in scripts/dev-toolkit-portability.test.mjs fails if the
+// committed matrix and this classifier disagree.
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const ROOT = fileURLToPath(new URL('..', import.meta.url));
+export const SKILLS_SUBDIR = join('dev-toolkit', 'skills');
+export const HOOKS_SUBDIR = 'hooks';
+
+export const SHARED = 'shared';
+export const ADAPTER_REQUIRED = 'adapter-required';
+export const CLAUDE_ONLY = 'claude-only';
+export const CLASSES = [SHARED, ADAPTER_REQUIRED, CLAUDE_ONLY];
+
+// Discover skills from the repository. A skill is any directory under
+// dev-toolkit/skills that holds a SKILL.md. Returns records sorted by name.
+export function discoverSkills(root = ROOT) {
+  const dir = join(root, SKILLS_SUBDIR);
+  const skills = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const skillPath = join(dir, entry.name, 'SKILL.md');
+    if (!existsSync(skillPath)) continue;
+    skills.push({ name: entry.name, body: readFileSync(skillPath, 'utf8') });
+  }
+  return skills.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function frontmatterName(body) {
+  const match = body.match(/^---\n([\s\S]*?)\n---/u);
+  if (!match) return '';
+  const line = match[1].split('\n').find((l) => l.startsWith('name:'));
+  return line ? line.slice('name:'.length).trim() : '';
+}
+
+// Top-level hooks/*.md files are Claude auto-activation wiring (PreToolUse,
+// PostToolUse, UserPromptSubmit). A hook belongs to a skill when the skill's
+// own SKILL.md names it, which is the skill declaring its wiring
+// (test-first-bugs names bug-report-detector; one-way-door names
+// one-way-door-check). Keying on the skill's declaration, not on the hook
+// mentioning the skill, keeps a hook that only cites a skill as an example
+// (pre-commit-review) from being miscounted. Returns filename -> hook name,
+// repo-driven, no hand-kept table.
+export function autoActivationHooks(root = ROOT) {
+  const dir = join(root, HOOKS_SUBDIR);
+  if (!existsSync(dir)) return new Map();
+  const byFile = new Map();
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+    const body = readFileSync(join(dir, entry.name), 'utf8');
+    byFile.set(entry.name, frontmatterName(body) || entry.name.replace(/\.md$/u, ''));
+  }
+  return byFile;
+}
+
+function hasWord(body, word) {
+  return new RegExp(`\\b${word}\\b`, 'u').test(body);
+}
+
+// Signals are the concrete, verifiable reasons a skill is coupled to Claude.
+// Each carries a Codex mapping note or, for Claude-only, why none exists.
+// `mappable: false` forces the Claude-only class.
+export function detectSignals(body) {
+  const signals = [];
+  const namesClaudeMd = body.includes('CLAUDE.md');
+  const namesAgentsMd = body.includes('AGENTS.md');
+
+  // Instruction-file coupling. A skill that writes or targets CLAUDE.md is
+  // coupled unless it already treats AGENTS.md as the canonical instruction
+  // file (vibe-coding documents both, so it is not coupled).
+  if (namesClaudeMd && !namesAgentsMd) {
+    signals.push({
+      kind: 'instruction-file',
+      mappable: true,
+      detail: 'targets CLAUDE.md; map the instruction file to AGENTS.md for Codex',
+    });
+  }
+
+  // Claude tool vocabulary.
+  if (hasWord(body, 'AskUserQuestion')) {
+    signals.push({
+      kind: 'claude-tool',
+      mappable: true,
+      detail: 'uses the AskUserQuestion tool; map to a Codex prompt or approval step',
+    });
+  }
+  // The mechanic, not the noun: a bare mention of "subagents" as design advice
+  // is not coupling. Require the Task tool or its subagent_type parameter.
+  if (/\bTask tool\b/u.test(body) || /subagent_type/u.test(body)) {
+    signals.push({
+      kind: 'claude-tool',
+      mappable: true,
+      detail:
+        'invokes the Task tool with subagent_type; map to a Codex multi-attempt run',
+    });
+  }
+
+  // Claude hook auto-activation inside the skill body.
+  if (/\bPostToolUse\b|\bPreToolUse\b|"matcher"/u.test(body)) {
+    signals.push({
+      kind: 'claude-hook',
+      mappable: true,
+      detail:
+        'wires Claude PreToolUse/PostToolUse hooks; reproduce the failure and approval semantics before mapping, do not drop them',
+    });
+  }
+
+  // Claude-only runtime coupling. ${CLAUDE_SKILL_DIR} names the installed skill
+  // directory at Claude runtime and has no Codex equivalent; the package matrix
+  // already treats it as an unadapted Claude marker.
+  if (body.includes('CLAUDE_SKILL_DIR')) {
+    signals.push({
+      kind: 'claude-runtime',
+      mappable: false,
+      detail: 'depends on ${CLAUDE_SKILL_DIR}, a Claude runtime path with no Codex equivalent',
+    });
+  }
+
+  return signals;
+}
+
+export function classifySkill(skill, hooks = new Map()) {
+  const signals = detectSignals(skill.body);
+  const hookFiles = [];
+  for (const [hookFile, hookName] of hooks) {
+    if (skill.body.includes(hookName)) hookFiles.push(hookFile);
+  }
+  const automatic =
+    signals.some((s) => s.kind === 'claude-hook') || hookFiles.length > 0;
+
+  let cls;
+  if (signals.some((s) => s.mappable === false)) {
+    cls = CLAUDE_ONLY;
+  } else if (signals.length > 0) {
+    cls = ADAPTER_REQUIRED;
+  } else {
+    cls = SHARED;
+  }
+
+  const rawReason =
+    cls === SHARED
+      ? 'No Claude-specific mechanic; runs under Codex as written.'
+      : signals.map((s) => s.detail).join('; ') + '.';
+  const reason = rawReason.charAt(0).toUpperCase() + rawReason.slice(1);
+
+  return {
+    name: skill.name,
+    class: cls,
+    automatic,
+    hooks: hookFiles.sort(),
+    reason,
+  };
+}
+
+export function buildMatrix(root = ROOT) {
+  const hooks = autoActivationHooks(root);
+  return discoverSkills(root).map((skill) => classifySkill(skill, hooks));
+}
+
+function escapeCell(text) {
+  return text.replaceAll('|', '\\|');
+}
+
+// Render the committed matrix. No timestamps or environment data, so the drift
+// test can compare bytes. Ends with a trailing newline.
+export function renderMatrixMarkdown(rows) {
+  const counts = Object.fromEntries(CLASSES.map((c) => [c, 0]));
+  for (const row of rows) counts[row.class] += 1;
+
+  const lines = [];
+  lines.push('# dev-toolkit per-skill portability');
+  lines.push('');
+  lines.push(
+    'How far each dev-toolkit skill is from running under Codex instead of',
+  );
+  lines.push(
+    'Claude Code. Generated from the repository by the classifier; do not edit by',
+  );
+  lines.push('hand. Regenerate with `node scripts/dev-toolkit-portability.mjs`.');
+  lines.push('');
+  lines.push(
+    'Classes: **shared** runs as written; **adapter-required** needs a documented',
+  );
+  lines.push(
+    'Codex mapping (instruction file, tool vocabulary, or hook); **Claude-only**',
+  );
+  lines.push('depends on a Claude runtime mechanic with no Codex equivalent.');
+  lines.push('');
+  lines.push(
+    `Inventory: ${rows.length} skills discovered from \`dev-toolkit/skills\` ` +
+      `(${counts[SHARED]} shared, ${counts[ADAPTER_REQUIRED]} adapter-required, ` +
+      `${counts[CLAUDE_ONLY]} Claude-only).`,
+  );
+  lines.push('');
+  lines.push('| Skill | Class | Auto-activation | Reason |');
+  lines.push('| --- | --- | --- | --- |');
+  for (const row of rows) {
+    const auto = row.automatic
+      ? `yes${row.hooks.length ? ` (${row.hooks.join(', ')})` : ''}`
+      : 'no';
+    lines.push(
+      `| \`${row.name}\` | ${row.class} | ${auto} | ${escapeCell(row.reason)} |`,
+    );
+  }
+  lines.push('');
+  lines.push(
+    'Adapter and Claude-only skills stay behind the one-installation-path rule in',
+  );
+  lines.push(
+    '`plans/codex-compatibility-matrix.md` until each has a tested Codex mapping.',
+  );
+  lines.push('');
+  return lines.join('\n');
+}
+
+const MATRIX_PATH = join('plans', 'dev-toolkit-portability-matrix.md');
+export { MATRIX_PATH };
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  process.stdout.write(renderMatrixMarkdown(buildMatrix()));
+}

--- a/scripts/dev-toolkit-portability.mjs
+++ b/scripts/dev-toolkit-portability.mjs
@@ -6,7 +6,7 @@
 // The drift test in scripts/dev-toolkit-portability.test.mjs fails if the
 // committed matrix and this classifier disagree.
 
-import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -19,16 +19,34 @@ export const ADAPTER_REQUIRED = 'adapter-required';
 export const CLAUDE_ONLY = 'claude-only';
 export const CLASSES = [SHARED, ADAPTER_REQUIRED, CLAUDE_ONLY];
 
+function readBundledText(dir) {
+  const bodies = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      bodies.push(readBundledText(path));
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    const bytes = readFileSync(path);
+    if (!bytes.includes(0)) bodies.push(bytes.toString('utf8'));
+  }
+  return bodies.filter(Boolean).join('\n');
+}
+
 // Discover skills from the repository. A skill is any directory under
-// dev-toolkit/skills that holds a SKILL.md. Returns records sorted by name.
+// dev-toolkit/skills that holds a SKILL.md. The classifier reads all bundled
+// text because scripts, references, and templates can carry runtime coupling
+// that SKILL.md does not repeat. Returns records sorted by name.
 export function discoverSkills(root = ROOT) {
   const dir = join(root, SKILLS_SUBDIR);
   const skills = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
-    const skillPath = join(dir, entry.name, 'SKILL.md');
+    const skillDir = join(dir, entry.name);
+    const skillPath = join(skillDir, 'SKILL.md');
     if (!existsSync(skillPath)) continue;
-    skills.push({ name: entry.name, body: readFileSync(skillPath, 'utf8') });
+    skills.push({ name: entry.name, body: readBundledText(skillDir) });
   }
   return skills.sort((a, b) => a.name.localeCompare(b.name));
 }
@@ -132,6 +150,15 @@ export function classifySkill(skill, hooks = new Map()) {
   for (const [hookFile, hookName] of hooks) {
     if (skill.body.includes(hookName)) hookFiles.push(hookFile);
   }
+  if (hookFiles.length > 0 && !signals.some((s) => s.kind === 'claude-hook')) {
+    signals.push({
+      kind: 'claude-hook',
+      mappable: true,
+      detail:
+        `names Claude auto-activation hooks (${hookFiles.sort().join(', ')}); ` +
+        'reproduce their trigger and failure semantics before mapping',
+    });
+  }
   const automatic =
     signals.some((s) => s.kind === 'claude-hook') || hookFiles.length > 0;
 
@@ -223,6 +250,12 @@ export function renderMatrixMarkdown(rows) {
 const MATRIX_PATH = join('plans', 'dev-toolkit-portability-matrix.md');
 export { MATRIX_PATH };
 
+export function writeMatrix(root = ROOT) {
+  const path = join(root, MATRIX_PATH);
+  writeFileSync(path, renderMatrixMarkdown(buildMatrix(root)), 'utf8');
+  return path;
+}
+
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  process.stdout.write(renderMatrixMarkdown(buildMatrix()));
+  writeMatrix();
 }

--- a/scripts/dev-toolkit-portability.test.mjs
+++ b/scripts/dev-toolkit-portability.test.mjs
@@ -1,5 +1,14 @@
 import assert from 'node:assert/strict';
-import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import test from 'node:test';
@@ -16,6 +25,7 @@ import {
   classifySkill,
   buildMatrix,
   renderMatrixMarkdown,
+  writeMatrix,
 } from './dev-toolkit-portability.mjs';
 
 function skillDirsOnDisk() {
@@ -61,8 +71,67 @@ test('tool coupling is the mechanic, not the noun', () => {
   // record its auto-activation as "no".
   assert.equal(rows['test-first-bugs'].automatic, true);
   assert.ok(rows['test-first-bugs'].hooks.includes('bug-report-detector.md'));
+  assert.match(rows['test-first-bugs'].reason, /hook/u);
   // Mentions "subagents" only as design advice -> portable.
   assert.equal(rows['context-engineering-fundamentals'].class, SHARED);
+});
+
+test('a named top-level hook is an adapter-required signal', () => {
+  const hooks = new Map([['prompt-check.md', 'prompt-check']]);
+  const row = classifySkill(
+    { name: 'hook-only', body: 'Activated by the prompt-check hook.' },
+    hooks,
+  );
+
+  assert.equal(row.class, ADAPTER_REQUIRED);
+  assert.equal(row.automatic, true);
+  assert.deepEqual(row.hooks, ['prompt-check.md']);
+  assert.match(row.reason, /hook/u);
+  assert.doesNotMatch(row.reason, /No Claude-specific mechanic/u);
+});
+
+test('classification scans bundled text files, not only SKILL.md', () => {
+  const root = mkdtempSync(join(tmpdir(), 'dev-toolkit-portability-'));
+  try {
+    const skillDir = join(root, SKILLS_SUBDIR, 'bundled-hook');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: bundled-hook\n---\n\n# Portable-looking instructions\n',
+    );
+    writeFileSync(
+      join(skillDir, 'runtime.ps1'),
+      '# Runtime wiring uses PreToolUse and $HOME/.claude state.\n',
+    );
+
+    const row = buildMatrix(root)[0];
+    assert.equal(row.class, ADAPTER_REQUIRED);
+    assert.match(row.reason, /hook/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('the regeneration helper writes the matrix it generates', () => {
+  const root = mkdtempSync(join(tmpdir(), 'dev-toolkit-portability-'));
+  try {
+    const skillDir = join(root, SKILLS_SUBDIR, 'portable');
+    mkdirSync(skillDir, { recursive: true });
+    mkdirSync(join(root, 'plans'), { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: portable\n---\n\n# Portable instructions\n',
+    );
+
+    writeMatrix(root);
+
+    assert.equal(
+      readFileSync(join(root, MATRIX_PATH), 'utf8'),
+      renderMatrixMarkdown(buildMatrix(root)),
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test('one-way-door is adapter-required and automatic with approval semantics (AC6)', () => {

--- a/scripts/dev-toolkit-portability.test.mjs
+++ b/scripts/dev-toolkit-portability.test.mjs
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+import {
+  ROOT,
+  SKILLS_SUBDIR,
+  MATRIX_PATH,
+  SHARED,
+  ADAPTER_REQUIRED,
+  CLAUDE_ONLY,
+  CLASSES,
+  discoverSkills,
+  classifySkill,
+  buildMatrix,
+  renderMatrixMarkdown,
+} from './dev-toolkit-portability.mjs';
+
+function skillDirsOnDisk() {
+  const dir = join(ROOT, SKILLS_SUBDIR);
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && existsSync(join(dir, e.name, 'SKILL.md')))
+    .map((e) => e.name)
+    .sort();
+}
+
+test('inventory is discovered from the repository, not hard-coded (AC1)', () => {
+  const discovered = discoverSkills().map((s) => s.name);
+  assert.deepEqual(discovered, skillDirsOnDisk());
+  // The module source must not carry a hard-coded skill list or count.
+  const source = readFileSync(join(ROOT, 'scripts', 'dev-toolkit-portability.mjs'), 'utf8');
+  assert.doesNotMatch(source, /accessibility-compliance/u);
+  assert.doesNotMatch(source, /\b12 skills\b/u);
+});
+
+test('every skill classifies into a known class with a reason (AC2)', () => {
+  for (const row of buildMatrix()) {
+    assert.ok(CLASSES.includes(row.class), `${row.name} has class ${row.class}`);
+    assert.ok(row.reason.trim().length > 0, `${row.name} has a reason`);
+    assert.equal(typeof row.automatic, 'boolean');
+  }
+});
+
+test('instruction-file coupling: CLAUDE.md target vs AGENTS.md-aware', () => {
+  const rows = Object.fromEntries(buildMatrix().map((r) => [r.name, r]));
+  // Targets CLAUDE.md, no AGENTS.md mapping -> needs an adapter.
+  assert.equal(rows['claude-md-updater'].class, ADAPTER_REQUIRED);
+  assert.match(rows['claude-md-updater'].reason, /CLAUDE\.md/u);
+  // Mentions CLAUDE.md but documents AGENTS.md as canonical -> portable.
+  assert.equal(rows['vibe-coding'].class, SHARED);
+});
+
+test('tool coupling is the mechanic, not the noun', () => {
+  const rows = Object.fromEntries(buildMatrix().map((r) => [r.name, r]));
+  // Invokes the Task tool with subagent_type -> needs an adapter.
+  assert.equal(rows['test-first-bugs'].class, ADAPTER_REQUIRED);
+  assert.match(rows['test-first-bugs'].reason, /subagent_type/u);
+  // It also auto-activates through a hook it names, so the matrix must not
+  // record its auto-activation as "no".
+  assert.equal(rows['test-first-bugs'].automatic, true);
+  assert.ok(rows['test-first-bugs'].hooks.includes('bug-report-detector.md'));
+  // Mentions "subagents" only as design advice -> portable.
+  assert.equal(rows['context-engineering-fundamentals'].class, SHARED);
+});
+
+test('one-way-door is adapter-required and automatic with approval semantics (AC6)', () => {
+  const row = buildMatrix().find((r) => r.name === 'one-way-door');
+  assert.equal(row.class, ADAPTER_REQUIRED);
+  assert.equal(row.automatic, true);
+  assert.ok(row.hooks.includes('one-way-door-check.md'));
+  assert.match(row.reason, /AskUserQuestion/u);
+  assert.match(row.reason, /approval/u);
+});
+
+test('a portable skill stays shared', () => {
+  const row = buildMatrix().find((r) => r.name === 'accessibility-compliance');
+  assert.equal(row.class, SHARED);
+  assert.equal(row.automatic, false);
+});
+
+test('the classifier reaches all three classes (trigger and non-trigger)', () => {
+  const shared = classifySkill({ name: 'x', body: '# just guidance, no tools' });
+  assert.equal(shared.class, SHARED);
+
+  const adapter = classifySkill({ name: 'x', body: 'ask with AskUserQuestion here' });
+  assert.equal(adapter.class, ADAPTER_REQUIRED);
+
+  // ${CLAUDE_SKILL_DIR} is a Claude runtime path with no Codex equivalent.
+  const claudeOnly = classifySkill({ name: 'x', body: 'reads ${CLAUDE_SKILL_DIR}/data' });
+  assert.equal(claudeOnly.class, CLAUDE_ONLY);
+
+  // Auto-activation comes from the skill naming its hook. A hook the skill does
+  // not name (only cited as an example) is not attributed.
+  const hooks = new Map([
+    ['x-check.md', 'x-check'],
+    ['other.md', 'other-hook'],
+  ]);
+  const auto = classifySkill({ name: 'x', body: 'activated by the x-check hook' }, hooks);
+  assert.equal(auto.automatic, true);
+  assert.deepEqual(auto.hooks, ['x-check.md']);
+});
+
+test('committed matrix matches the classifier output (drift guard, AC8)', () => {
+  const committed = readFileSync(join(ROOT, MATRIX_PATH), 'utf8');
+  assert.equal(
+    committed,
+    renderMatrixMarkdown(buildMatrix()),
+    'plans/dev-toolkit-portability-matrix.md is stale; regenerate with `node scripts/dev-toolkit-portability.mjs`',
+  );
+});


### PR DESCRIPTION
## What

Classify every `dev-toolkit` skill by how much work it needs to run under Codex
instead of Claude Code, and guard the result against drift.

- `scripts/dev-toolkit-portability.mjs` discovers skills from the repository
  (not a hard-coded count) and classifies each as shared, adapter-required, or
  Claude-only from concrete signals: an instruction file it targets (`CLAUDE.md`
  with no `AGENTS.md` mapping), Claude tool vocabulary (`AskUserQuestion`, the
  Task tool with `subagent_type`), Claude hooks it wires, and a top-level hook it
  names. `${CLAUDE_SKILL_DIR}` marks Claude-only.
- `plans/dev-toolkit-portability-matrix.md` is generated from the classifier: 12
  skills, 9 shared, 3 adapter-required (`claude-md-updater`, `one-way-door`,
  `test-first-bugs`), 0 Claude-only.
- `scripts/dev-toolkit-portability.test.mjs` pins the repo-driven inventory, the
  class-and-reason coverage, the mechanic-not-mention distinctions (`vibe-coding`
  and `context-engineering-fundamentals` stay shared), the one-way-door
  approval-semantics caveat, and a byte-equal drift guard.
- `plans/codex-compatibility-matrix.md` gains a per-skill cross-reference and the
  corrected count (12, not the stale 11).

## Why

Issue #232 asks to evaluate each skill apart from Claude hook, subagent,
tool-name, and `CLAUDE.md` assumptions, and to not map automatic behavior
(one-way-door) without its approval semantics.

## Verification

`node --test scripts/dev-toolkit-portability.test.mjs` (8 pass) and
`node --test scripts/codex-compatibility-docs.test.mjs` (8 pass, unchanged).

Partial progress on #232; remaining acceptance criteria are tracked in the issue
comment.

wake-20260819T1705-d9b4b0
