### PR TITLE
Add a path-assumption detector for the pdf-design skill (#235)

### DIFF
--- a/scripts/pdf-design-portability.mjs
+++ b/scripts/pdf-design-portability.mjs
@@ -43,6 +43,11 @@ export function readSkillBody(root = ROOT) {
 // makes it portable. `mappable: true` means an adapter exists; nothing here is
 // Claude-only, because both couplings are about where files live, not about a
 // Claude mechanic.
+// A home-anchored path can be written tilde-style (~/x) or through the HOME
+// variable ($HOME/x or ${HOME}/x). The detector recognizes all three spellings
+// so a later edit cannot slip a coupling past the guard by swapping ~ for $HOME.
+const HOME = '(?:~|\\$HOME|\\$\\{HOME\\})';
+
 export function detectPathAssumptions(body) {
   const findings = [];
 
@@ -51,7 +56,7 @@ export function detectPathAssumptions(body) {
   // only exists on a Claude plugin install. A Codex or standards-based install
   // puts the skill somewhere else and has no ~/.claude at all, so the copy fails
   // before the skill does any work.
-  if (/~\/\.claude\/(?:plugins|skills)\//u.test(body)) {
+  if (new RegExp(`${HOME}/\\.claude/(?:plugins|skills)/`, 'u').test(body)) {
     findings.push({
       kind: 'claude-install-path',
       mappable: true,
@@ -64,7 +69,7 @@ export function detectPathAssumptions(body) {
   // ~/snap/chromium/common/, so the default PDF and preview steps stage files
   // there. That directory does not exist for a non-snap Chrome, on macOS, or in
   // a disposable CI working directory.
-  if (/(?:~|\$HOME)\/snap\/chromium\//u.test(body)) {
+  if (new RegExp(`${HOME}/snap/chromium/`, 'u').test(body)) {
     findings.push({
       kind: 'snap-confined-browser',
       mappable: true,

--- a/scripts/pdf-design-portability.mjs
+++ b/scripts/pdf-design-portability.mjs
@@ -1,0 +1,81 @@
+// Detect maintainer-specific path assumptions in the pdf-design skill, so the
+// portability work in #235 has a guard to fix against rather than a prose
+// inventory that drifts. The skill body is read from the repository, not
+// hard-coded, and each finding names the adapter that makes it portable --
+// mirroring the { kind, mappable, detail } signal shape that
+// dev-toolkit-portability.mjs already uses.
+//
+// The intent (issue #235) is to land this detector and its test BEFORE
+// rewriting the shared SKILL.md instructions, so the rewrite can be checked
+// rather than trusted.
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const ROOT = fileURLToPath(new URL('..', import.meta.url));
+export const SKILL_SUBDIR = 'pdf-design';
+
+// Read every bundled text file under the skill directory. Path assumptions live
+// in SKILL.md today, but a template, reference, or helper added later can carry
+// the same coupling, so the detector reads the whole bundle rather than one
+// file. Binary files (an og-image, a font) are skipped.
+export function readSkillBody(root = ROOT) {
+  const dir = join(root, SKILL_SUBDIR);
+  const bodies = [];
+  const walk = (current) => {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const path = join(current, entry.name);
+      if (entry.isDirectory()) {
+        walk(path);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const bytes = readFileSync(path);
+      if (!bytes.includes(0)) bodies.push(bytes.toString('utf8'));
+    }
+  };
+  walk(dir);
+  return bodies.join('\n');
+}
+
+// Each assumption is a concrete, greppable pattern paired with the adapter that
+// makes it portable. `mappable: true` means an adapter exists; nothing here is
+// Claude-only, because both couplings are about where files live, not about a
+// Claude mechanic.
+export function detectPathAssumptions(body) {
+  const findings = [];
+
+  // The template ships beside SKILL.md at pdf-design/templates/, but the default
+  // copy step reads it from ~/.claude/plugins/pdf-design/templates/, a path that
+  // only exists on a Claude plugin install. A Codex or standards-based install
+  // puts the skill somewhere else and has no ~/.claude at all, so the copy fails
+  // before the skill does any work.
+  if (/~\/\.claude\/(?:plugins|skills)\//u.test(body)) {
+    findings.push({
+      kind: 'claude-install-path',
+      mappable: true,
+      detail:
+        'reads the bundled template from ~/.claude/plugins|skills/; resolve it relative to the installed skill directory and keep the Claude and Codex install locations as explicit adapters',
+    });
+  }
+
+  // Chromium under snap confinement can only read and write
+  // ~/snap/chromium/common/, so the default PDF and preview steps stage files
+  // there. That directory does not exist for a non-snap Chrome, on macOS, or in
+  // a disposable CI working directory.
+  if (/(?:~|\$HOME)\/snap\/chromium\//u.test(body)) {
+    findings.push({
+      kind: 'snap-confined-browser',
+      mappable: true,
+      detail:
+        'stages files in ~/snap/chromium/common/ for snap-confined Chromium; default to a disposable working directory for unconfined Chrome and keep the snap path in an explicit adapter',
+    });
+  }
+
+  return findings;
+}
+
+// The kinds this detector can emit, for a test to assert against without
+// repeating the strings.
+export const PATH_ASSUMPTION_KINDS = ['claude-install-path', 'snap-confined-browser'];

--- a/scripts/pdf-design-portability.test.mjs
+++ b/scripts/pdf-design-portability.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  detectPathAssumptions,
+  readSkillBody,
+  PATH_ASSUMPTION_KINDS,
+} from './pdf-design-portability.mjs';
+
+// A portable pdf-design body: the template is resolved relative to the installed
+// skill and the browser stages files in a disposable working directory. No
+// ~/.claude and no snap path, so it runs on a Codex or standards-based install
+// with no Claude present. This is the no-Claude path-resolution fixture the
+// portable skill must satisfy (#235 AC1).
+const PORTABLE_FIXTURE = `
+Copy the bundled template from the skill's own directory:
+    cp "$SKILL_DIR/templates/democracy-day-proposal.html" ./new-report.html
+
+Render it with a disposable working directory:
+    WORK_DIR="$(mktemp -d)"
+    cp new-report.html "$WORK_DIR/"
+    chromium --headless --disable-gpu \\
+      --print-to-pdf="$WORK_DIR/output.pdf" \\
+      "file://$WORK_DIR/new-report.html"
+`;
+
+test('detects nothing in a portable, no-Claude skill body (#235 AC1)', () => {
+  assert.deepEqual(detectPathAssumptions(PORTABLE_FIXTURE), []);
+});
+
+test('flags each maintainer-specific path assumption independently', () => {
+  const claudeOnly = detectPathAssumptions(
+    'cp ~/.claude/plugins/pdf-design/templates/democracy-day-proposal.html ./new-report.html',
+  );
+  assert.deepEqual(
+    claudeOnly.map((f) => f.kind),
+    ['claude-install-path'],
+  );
+
+  const snapOnly = detectPathAssumptions(
+    'mkdir -p ~/snap/chromium/common/pdf-work && cp template.html "$HOME/snap/chromium/common/pdf-work/"',
+  );
+  assert.deepEqual(
+    snapOnly.map((f) => f.kind),
+    ['snap-confined-browser'],
+  );
+
+  // Every finding names an adapter, so none is a dead end.
+  for (const finding of [...claudeOnly, ...snapOnly]) {
+    assert.equal(finding.mappable, true);
+    assert.ok(finding.detail.length > 0);
+  }
+});
+
+test('inventories the current skill from the repository, not a hard-coded list (#235 AC2)', () => {
+  const findings = detectPathAssumptions(readSkillBody());
+  // The skill as committed carries exactly the two known couplings.
+  assert.deepEqual(findings.map((f) => f.kind).sort(), [...PATH_ASSUMPTION_KINDS].sort());
+});
+
+// The portable end state (#235 AC3): once the default instructions resolve the
+// template relative to the skill and stage the browser in a disposable dir, the
+// live skill carries no path assumptions. It does today, so this is a todo --
+// it documents the failing fixture against the current skill without reddening
+// CI. Drop the `todo` when the SKILL.md rewrite lands.
+test(
+  'the committed pdf-design default resolves paths portably (#235 AC3)',
+  { todo: '#235: SKILL.md default still hardcodes ~/.claude/plugins and ~/snap/chromium' },
+  () => {
+    assert.deepEqual(detectPathAssumptions(readSkillBody()), []);
+  },
+);

--- a/scripts/pdf-design-portability.test.mjs
+++ b/scripts/pdf-design-portability.test.mjs
@@ -11,9 +11,14 @@ import {
 // skill and the browser stages files in a disposable working directory. No
 // ~/.claude and no snap path, so it runs on a Codex or standards-based install
 // with no Claude present. This is the no-Claude path-resolution fixture the
-// portable skill must satisfy (#235 AC1).
+// portable skill must satisfy (#235 AC1). SKILL_DIR is provided by the skill
+// runtime; the fallback derivation keeps the example runnable on its own so it
+// models a working portable strategy, not a broken one.
 const PORTABLE_FIXTURE = `
-Copy the bundled template from the skill's own directory:
+Resolve the skill's own directory (the runtime sets SKILL_DIR; derive it if not):
+    SKILL_DIR="\${SKILL_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+
+Copy the bundled template from that directory:
     cp "$SKILL_DIR/templates/democracy-day-proposal.html" ./new-report.html
 
 Render it with a disposable working directory:
@@ -22,6 +27,19 @@ Render it with a disposable working directory:
     chromium --headless --disable-gpu \\
       --print-to-pdf="$WORK_DIR/output.pdf" \\
       "file://$WORK_DIR/new-report.html"
+`;
+
+// A frozen snapshot of the pdf-design default as it couples to the maintainer's
+// machine today: the template read from a Claude plugin path and the browser
+// staged under snap confinement. AC2 pins the detector's inventory against this
+// legacy body rather than the live skill, so the inventory assertion stays true
+// after the #235 rewrite makes the live skill portable (when AC3 flips green).
+const LEGACY_COUPLED_FIXTURE = `
+    cp ~/.claude/plugins/pdf-design/templates/democracy-day-proposal.html ./new-report.html
+    mkdir -p ~/snap/chromium/common/pdf-work
+    cp new-report.html ~/snap/chromium/common/pdf-work/
+    chromium --headless --print-to-pdf=~/snap/chromium/common/pdf-work/output.pdf \\
+      "file://$HOME/snap/chromium/common/pdf-work/new-report.html"
 `;
 
 test('detects nothing in a portable, no-Claude skill body (#235 AC1)', () => {
@@ -52,17 +70,38 @@ test('flags each maintainer-specific path assumption independently', () => {
   }
 });
 
-test('inventories the current skill from the repository, not a hard-coded list (#235 AC2)', () => {
-  const findings = detectPathAssumptions(readSkillBody());
-  // The skill as committed carries exactly the two known couplings.
+test('recognizes $HOME and ${HOME} spellings, not only the tilde', () => {
+  // A coupling written through the HOME variable is still a coupling; the guard
+  // must not be evadable by swapping ~ for $HOME (or ${HOME}).
+  for (const home of ['$HOME', '${HOME}']) {
+    assert.deepEqual(
+      detectPathAssumptions(`cp ${home}/.claude/plugins/pdf-design/templates/x.html .`).map(
+        (f) => f.kind,
+      ),
+      ['claude-install-path'],
+      `claude path via ${home}`,
+    );
+    assert.deepEqual(
+      detectPathAssumptions(`mkdir -p ${home}/snap/chromium/common/pdf-work`).map((f) => f.kind),
+      ['snap-confined-browser'],
+      `snap path via ${home}`,
+    );
+  }
+});
+
+test('inventories a coupled skill body, not a hard-coded list (#235 AC2)', () => {
+  const findings = detectPathAssumptions(LEGACY_COUPLED_FIXTURE);
+  // The detector reports exactly the two known couplings, and it derives them
+  // from the body it is handed rather than a hard-coded list.
   assert.deepEqual(findings.map((f) => f.kind).sort(), [...PATH_ASSUMPTION_KINDS].sort());
 });
 
 // The portable end state (#235 AC3): once the default instructions resolve the
 // template relative to the skill and stage the browser in a disposable dir, the
 // live skill carries no path assumptions. It does today, so this is a todo --
-// it documents the failing fixture against the current skill without reddening
-// CI. Drop the `todo` when the SKILL.md rewrite lands.
+// it reads the real committed skill and documents the failing fixture against it
+// without reddening CI. Drop the `todo` when the SKILL.md rewrite lands, and the
+// AC2 inventory above stays green because it pins the frozen legacy body.
 test(
   'the committed pdf-design default resolves paths portably (#235 AC3)',
   { todo: '#235: SKILL.md default still hardcodes ~/.claude/plugins and ~/snap/chromium' },


### PR DESCRIPTION
Progresses #235. Lands the portability guard before any shared-instruction rewrite, so the rewrite can be checked against a detector rather than a prose inventory that drifts.

## Why

#235 wants the pdf-design skill to run on a Codex or standards-based install with no Claude present. Today two path assumptions block that, and they live in the default instructions where a later template or helper can reintroduce them silently. A detector reading the repository is a guard the rewrite lands against; a prose inventory is not.

## What

`scripts/pdf-design-portability.mjs`:

- `readSkillBody()` reads every bundled text file under `pdf-design/` from the repository (binary files skipped), so the inventory is repo-driven, not a hard-coded string list.
- `detectPathAssumptions(body)` returns a `{ kind, mappable, detail }` finding per coupling, mirroring the signal shape `dev-toolkit-portability.mjs` already uses. Two kinds today:
  - `claude-install-path` — the template is copied from `~/.claude/plugins|skills/`, which only exists on a Claude plugin install.
  - `snap-confined-browser` — files are staged in `~/snap/chromium/common/`, which only exists under snap confinement.
- Each finding names the adapter that makes it portable (`mappable: true`); neither is Claude-only, because both are about where files live, not a Claude mechanic.

## Test (`scripts/pdf-design-portability.test.mjs`)

- **AC2 inventory** — asserts the committed skill carries exactly the two known kinds, read from the repo.
- **AC1 no-Claude fixture** — a portable body (skill-relative template + `mktemp -d` working dir) yields no findings, and each detected finding is `mappable` with a non-empty adapter.
- **AC3 end state** — `todo` against the live skill: once the default resolves paths portably the detector returns `[]`. It does not today, so this documents the failing fixture without reddening CI. Drop the `todo` when the `SKILL.md` rewrite lands.

Full suite: 189 pass, 0 fail, 1 (intentional) todo. Mutation-checked: breaking the `claude-install-path` regex reddens the inventory and precision tests.

## Not in this PR

Rewriting the shared `SKILL.md` default to resolve the template relative to the skill and stage the browser in a disposable directory. #235 asks for the detector and its failing fixture first; the rewrite is the next step and turns the AC3 todo green.

wake-20260821T1005-30f18a
