### PR TITLE
Release v2.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-skills-journalism",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Agent skills and Claude Code plugins for journalism, research, and media organizations",
   "owner": {
     "name": "Joe Amditis",
@@ -21,7 +21,7 @@
     {
       "name": "dev-toolkit",
       "description": "Thirteen development skills for newsroom and research dev teams: accessibility, context management, directed multi-agent execution, Electron, mobile debugging, Python pipelines, test-first bug fixing, ethical scraping, no-build frontends, web UI craft, and CLAUDE.md maintenance.",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "author": {
         "name": "Joe Amditis",
         "email": "jamditis@gmail.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.0] - 2026-08-21
+
+This release adds explicit multi-agent direction and guards against hidden
+filesystem assumptions in portable skills.
+
 ### Added
 
 - **dev-toolkit director:** added an explicit-only director role that reads the
   applicable `CLAUDE.md` policy and directs work through the lower-tier agents
   and models configured for that environment. A standalone install invokes
   `/director`; the plugin form invokes `/dev-toolkit:director`.
+- **pdf-design path detector:** added a repository check that inventories
+  Claude installation paths and Snap confinement paths before portability work.
+
+### Changed
+
+- Parsed Claude-only frontmatter as YAML during Agent Skills projection, so
+  supported whitespace and inline comments do not cause false failures.
+- Updated the catalog, public documentation, and compatibility guidance for 63
+  skills. Bumped the marketplace to 2.7.0 and dev-toolkit to 1.4.0.
 
 ## [2.6.0] - 2026-08-21
 
@@ -695,7 +709,8 @@ Initial commit with foundational skills.
 
 ---
 
-[Unreleased]: https://github.com/jamditis/claude-skills-journalism/compare/v2.6.0...HEAD
+[Unreleased]: https://github.com/jamditis/claude-skills-journalism/compare/v2.7.0...HEAD
+[2.7.0]: https://github.com/jamditis/claude-skills-journalism/compare/v2.6.0...v2.7.0
 [2.6.0]: https://github.com/jamditis/claude-skills-journalism/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/jamditis/claude-skills-journalism/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/jamditis/claude-skills-journalism/compare/v2.3.3...v2.4.0

--- a/dev-toolkit/.claude-plugin/plugin.json
+++ b/dev-toolkit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-toolkit",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Thirteen development skills for newsroom and research dev teams: accessibility, context management, directed multi-agent execution, Electron, mobile debugging, Python pipelines, test-first bug fixing, ethical scraping, no-build frontends, web UI craft, and CLAUDE.md maintenance.",
   "author": {
     "name": "Joe Amditis",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-skills-journalism",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-skills-journalism",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "MIT",
       "dependencies": {
         "playwright": "^1.57.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-skills-journalism",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Agent Skills for journalists, researchers, academics, media professionals, and communications practitioners.",
   "main": "index.js",
   "scripts": {

--- a/plans/codex-compatibility-matrix.md
+++ b/plans/codex-compatibility-matrix.md
@@ -1,10 +1,10 @@
 # Codex compatibility matrix
 
 - Status: phase-two runtime pilots; journalism-core, visual-explainer, and portable okf-wiki scaffolding have scoped passes
-- Last evidence update: August 15, 2026
+- Last evidence update: August 21, 2026
 - Architecture: [Codex compatibility architecture decision](2026-07-21-codex-compatibility-architecture.md)
 
-> **Historical runtime results stay tied to their tested snapshots.** The v2.6.0
+> **Historical runtime results stay tied to their tested snapshots.** The v2.7.0
 > refresh updates current installation guidance without adding a native Codex
 > marketplace or plugin manifests. Every older version recorded below is the
 > version that was actually exercised. Those values are deliberately not bumped,
@@ -14,11 +14,11 @@
 >
 > The release catalog validation confirms the repository still follows the tested
 > legacy package and Agent Skills routes. It does not convert the older runtime
-> pilots into v2.6.0 runtime evidence.
+> pilots into v2.7.0 runtime evidence.
 
 ## August 2026 structure refresh
 
-- Marketplace 2.6.0 contains 12 Claude packages and 62 shared skills.
+- Marketplace 2.7.0 contains 12 Claude packages and 63 shared skills.
 - Codex can install the 15 nested journalism-core skills through the verified legacy-compatible package route.
 - The Agent Skills route supports root and nested skill layouts without converting Claude commands, agents, or hooks.
 - No native `.agents/plugins/marketplace.json` or `.codex-plugin/plugin.json` manifests are published.
@@ -50,7 +50,7 @@ Status labels:
 | Tool | Version or revision | Role |
 |---|---|---|
 | Codex structure refresh | 0.147.0 | Legacy package and Agent Skills route verification on August 15, 2026 |
-| Claude marketplace, current structure | 2.6.0 | Current catalog and version alignment; historical runtime results below remain snapshot-specific |
+| Claude marketplace, current structure | 2.7.0 | Current catalog and version alignment; historical runtime results below remain snapshot-specific |
 | Repository | `b0617649515d24ebfcd51f15bceb1d76b03db668` | Architecture commit used as the phase-one worktree base |
 | Repository release verification | [`9eef57629edbaa19bf47ec35296acebdd7b4ab1f`](https://github.com/jamditis/claude-skills-journalism/commit/9eef57629edbaa19bf47ec35296acebdd7b4ab1f) | July 23 post-merge `master` head used for the phase-one release evidence |
 | Repository visual-explainer pilot | [`f6a4b84dd2e9feafc6c2bf067f873e9301a083c2`](https://github.com/jamditis/claude-skills-journalism/commit/f6a4b84dd2e9feafc6c2bf067f873e9301a083c2) | July 23 `master` head installed for the V-ex-1 runtime evidence |

--- a/scripts/skill-frontmatter.test.mjs
+++ b/scripts/skill-frontmatter.test.mjs
@@ -123,10 +123,10 @@ test('published package versions stay aligned with the marketplace', () => {
   const marketplace = JSON.parse(
     readFileSync(join(ROOT, '.claude-plugin', 'marketplace.json'), 'utf8'),
   );
-  assert.equal(marketplace.version, '2.6.0', 'marketplace version');
+  assert.equal(marketplace.version, '2.7.0', 'marketplace version');
   const expected = new Map([
     ['autocontext', '1.1.2'],
-    ['dev-toolkit', '1.3.0'],
+    ['dev-toolkit', '1.4.0'],
     ['journalism-core', '1.5.0'],
     ['okf-wiki', '0.8.3'],
     ['pdf-design', '1.1.3'],


### PR DESCRIPTION
## Summary

- Publish marketplace v2.7.0 and dev-toolkit v1.4.0.
- Document Director and the pdf-design portability detector.
- Update current compatibility and public catalog guidance for 63 skills.

## Validation

- `npm test` (222 passed, 1 planned TODO)
- `npm run validate:catalog`
- `npm run check:docs-css`
- Kimi low-risk review passed with no findings.

## Deployment

After merge, publish the v2.7.0 GitHub release and verify GitHub Pages.
