### PR TITLE
fix: preserve YAML parser errors in skill validation

### DIFF
--- a/scripts/agent-skills-validation.test.mjs
+++ b/scripts/agent-skills-validation.test.mjs
@@ -179,3 +179,36 @@ test('Claude explicit-only frontmatter must be one boolean field', (t) => {
   assert.equal(results[0].status, 1);
   assert.match(results[0].stderr, /must be one top-level boolean field/u);
 });
+
+test('YAML parser errors preserve their details when the Claude-only field is absent', (t) => {
+  const fixtures = [
+    {
+      name: 'malformed YAML',
+      frontmatter: 'name: director\ndescription: [unterminated\n',
+      error: /Flow sequence .* end with a \]/u,
+    },
+    {
+      name: 'duplicate unrelated key',
+      frontmatter: 'name: director\ndescription: Direct work\ndescription: Duplicate\n',
+      error: /Map keys must be unique/u,
+    },
+  ];
+
+  for (const fixture of fixtures) {
+    const root = mkdtempSync(join(tmpdir(), 'agent-skills-validation-'));
+    t.after(() => rmSync(root, { recursive: true, force: true }));
+    const skill = join(root, fixture.name.replaceAll(' ', '-'));
+    mkdirSync(skill);
+    writeFileSync(join(skill, 'SKILL.md'), `---\n${fixture.frontmatter}---\n`);
+
+    const results = validateSkillDirectories([skill], {
+      run() {
+        assert.fail('standards validator must not run for invalid YAML frontmatter');
+      },
+    });
+
+    assert.equal(results[0].status, 1, fixture.name);
+    assert.match(results[0].stderr, fixture.error, fixture.name);
+    assert.doesNotMatch(results[0].stderr, /must be one top-level boolean field/u, fixture.name);
+  }
+});

--- a/scripts/validate-agent-skills.mjs
+++ b/scripts/validate-agent-skills.mjs
@@ -56,7 +56,16 @@ export function validateSkillDirectories(
       const document = frontmatter ? parseDocument(frontmatter[1], { uniqueKeys: true }) : null;
       const explicitValue = document?.get(CLAUDE_EXPLICIT_FIELD);
 
-      if (document?.errors.length || (explicitValue !== undefined && typeof explicitValue !== 'boolean')) {
+      if (document?.errors.length) {
+        return {
+          directory,
+          status: 1,
+          stdout: '',
+          stderr: document.errors.map((error) => error.toString()).join('\n'),
+        };
+      }
+
+      if (explicitValue !== undefined && typeof explicitValue !== 'boolean') {
         return {
           directory,
           status: 1,


### PR DESCRIPTION
Summary:
- Preserve YAML parser diagnostics for malformed frontmatter and duplicate unrelated keys.
- Keep the Claude-only boolean message limited to invalid disable-model-invocation values.

Tests:
- Targeted validation tests: 9 passed.
- npm test: 223 passed and 1 existing TODO.

Addresses the late connector finding from #284: https://github.com/jamditis/claude-skills-journalism/pull/284#discussion_r3833327591