### PR TITLE
Release v2.7.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-skills-journalism",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Agent skills and Claude Code plugins for journalism, research, and media organizations",
   "owner": {
     "name": "Joe Amditis",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.1] - 2026-08-21
+
+### Fixed
+
+- Preserved YAML parser diagnostics for malformed skill frontmatter and duplicate
+  unrelated keys. The Claude-only boolean error now applies only to invalid
+  `disable-model-invocation` values.
+
 ## [2.7.0] - 2026-08-21
 
 This release adds explicit multi-agent direction and guards against hidden
@@ -709,7 +717,8 @@ Initial commit with foundational skills.
 
 ---
 
-[Unreleased]: https://github.com/jamditis/claude-skills-journalism/compare/v2.7.0...HEAD
+[Unreleased]: https://github.com/jamditis/claude-skills-journalism/compare/v2.7.1...HEAD
+[2.7.1]: https://github.com/jamditis/claude-skills-journalism/compare/v2.7.0...v2.7.1
 [2.7.0]: https://github.com/jamditis/claude-skills-journalism/compare/v2.6.0...v2.7.0
 [2.6.0]: https://github.com/jamditis/claude-skills-journalism/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/jamditis/claude-skills-journalism/compare/v2.4.0...v2.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-skills-journalism",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-skills-journalism",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
         "playwright": "^1.57.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-skills-journalism",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Agent Skills for journalists, researchers, academics, media professionals, and communications practitioners.",
   "main": "index.js",
   "scripts": {

--- a/scripts/skill-frontmatter.test.mjs
+++ b/scripts/skill-frontmatter.test.mjs
@@ -123,7 +123,7 @@ test('published package versions stay aligned with the marketplace', () => {
   const marketplace = JSON.parse(
     readFileSync(join(ROOT, '.claude-plugin', 'marketplace.json'), 'utf8'),
   );
-  assert.equal(marketplace.version, '2.7.0', 'marketplace version');
+  assert.equal(marketplace.version, '2.7.1', 'marketplace version');
   const expected = new Map([
     ['autocontext', '1.1.2'],
     ['dev-toolkit', '1.4.0'],


### PR DESCRIPTION
Summary:
- Publish marketplace v2.7.1.
- Document corrected YAML parser diagnostics from PR #287.
- Keep package, lockfile, marketplace, and version tests aligned.

Validation:
- npm test: 223 passed, 1 existing TODO.
- npm run validate:catalog.
- npm run check:docs-css.
- Kimi low passed with no findings.

Deployment:
- After merge, publish v2.7.1 GitHub release and verify GitHub Pages.