### PR TITLE
Release v2.7.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-skills-journalism",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Agent skills and Claude Code plugins for journalism, research, and media organizations",
   "owner": {
     "name": "Joe Amditis",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.2] - 2026-08-21
+
+### Fixed
+
+- Aligned the compatibility matrix's current marketplace references with the
+  published release while keeping historical runtime evidence unchanged.
+- Added a regression check that derives the matrix's current marketplace version
+  from the marketplace manifest.
+
 ## [2.7.1] - 2026-08-21
 
 ### Fixed
@@ -717,7 +726,8 @@ Initial commit with foundational skills.
 
 ---
 
-[Unreleased]: https://github.com/jamditis/claude-skills-journalism/compare/v2.7.1...HEAD
+[Unreleased]: https://github.com/jamditis/claude-skills-journalism/compare/v2.7.2...HEAD
+[2.7.2]: https://github.com/jamditis/claude-skills-journalism/compare/v2.7.1...v2.7.2
 [2.7.1]: https://github.com/jamditis/claude-skills-journalism/compare/v2.7.0...v2.7.1
 [2.7.0]: https://github.com/jamditis/claude-skills-journalism/compare/v2.6.0...v2.7.0
 [2.6.0]: https://github.com/jamditis/claude-skills-journalism/compare/v2.5.0...v2.6.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-skills-journalism",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-skills-journalism",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "license": "MIT",
       "dependencies": {
         "playwright": "^1.57.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-skills-journalism",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Agent Skills for journalists, researchers, academics, media professionals, and communications practitioners.",
   "main": "index.js",
   "scripts": {

--- a/plans/codex-compatibility-matrix.md
+++ b/plans/codex-compatibility-matrix.md
@@ -18,7 +18,7 @@
 
 ## August 2026 structure refresh
 
-- Marketplace 2.7.0 contains 12 Claude packages and 63 shared skills.
+- Marketplace 2.7.2 contains 12 Claude packages and 63 shared skills.
 - Codex can install the 15 nested journalism-core skills through the verified legacy-compatible package route.
 - The Agent Skills route supports root and nested skill layouts without converting Claude commands, agents, or hooks.
 - No native `.agents/plugins/marketplace.json` or `.codex-plugin/plugin.json` manifests are published.
@@ -50,7 +50,7 @@ Status labels:
 | Tool | Version or revision | Role |
 |---|---|---|
 | Codex structure refresh | 0.147.0 | Legacy package and Agent Skills route verification on August 15, 2026 |
-| Claude marketplace, current structure | 2.7.0 | Current catalog and version alignment; historical runtime results below remain snapshot-specific |
+| Claude marketplace, current structure | 2.7.2 | Current catalog and version alignment; historical runtime results below remain snapshot-specific |
 | Repository | `b0617649515d24ebfcd51f15bceb1d76b03db668` | Architecture commit used as the phase-one worktree base |
 | Repository release verification | [`9eef57629edbaa19bf47ec35296acebdd7b4ab1f`](https://github.com/jamditis/claude-skills-journalism/commit/9eef57629edbaa19bf47ec35296acebdd7b4ab1f) | July 23 post-merge `master` head used for the phase-one release evidence |
 | Repository visual-explainer pilot | [`f6a4b84dd2e9feafc6c2bf067f873e9301a083c2`](https://github.com/jamditis/claude-skills-journalism/commit/f6a4b84dd2e9feafc6c2bf067f873e9301a083c2) | July 23 `master` head installed for the V-ex-1 runtime evidence |

--- a/scripts/codex-compatibility-docs.test.mjs
+++ b/scripts/codex-compatibility-docs.test.mjs
@@ -29,6 +29,9 @@ function findNativeCodexPluginManifests(directory = ROOT, manifests = []) {
 
 test('the compatibility matrix classifies every marketplace package', () => {
   const matrix = readFileSync(join(ROOT, 'plans', 'codex-compatibility-matrix.md'), 'utf8');
+  const marketplace = JSON.parse(
+    readFileSync(join(ROOT, '.claude-plugin', 'marketplace.json'), 'utf8'),
+  );
   const rows = [...matrix.matchAll(/^\| `([^`]+)` \|/gmu)].map((match) => match[1]);
 
   assert.deepEqual(rows, [
@@ -71,6 +74,10 @@ test('the compatibility matrix classifies every marketplace package', () => {
   assert.match(matrix, /scripts\/okf-wiki-runtime-pilot\.mjs/u);
   assert.match(matrix, /scripts\/visual-explainer-runtime-pilot\.mjs/u);
   assert.match(matrix, /2026-07-23-document-design-lock-migration\.md/u);
+  assert.match(
+    matrix,
+    new RegExp(`Claude marketplace, current structure \\| ${marketplace.version.replaceAll('.', '\\.')} \\|`, 'u'),
+  );
 
   const evidenceCells = matrix
     .split('\n')

--- a/scripts/codex-compatibility-docs.test.mjs
+++ b/scripts/codex-compatibility-docs.test.mjs
@@ -32,6 +32,7 @@ test('the compatibility matrix classifies every marketplace package', () => {
   const marketplace = JSON.parse(
     readFileSync(join(ROOT, '.claude-plugin', 'marketplace.json'), 'utf8'),
   );
+  const marketplaceVersionPattern = marketplace.version.replaceAll('.', '\\.');
   const rows = [...matrix.matchAll(/^\| `([^`]+)` \|/gmu)].map((match) => match[1]);
 
   assert.deepEqual(rows, [
@@ -76,7 +77,11 @@ test('the compatibility matrix classifies every marketplace package', () => {
   assert.match(matrix, /2026-07-23-document-design-lock-migration\.md/u);
   assert.match(
     matrix,
-    new RegExp(`Claude marketplace, current structure \\| ${marketplace.version.replaceAll('.', '\\.')} \\|`, 'u'),
+    new RegExp(`Claude marketplace, current structure \\| ${marketplaceVersionPattern} \\|`, 'u'),
+  );
+  assert.match(
+    matrix,
+    new RegExp(`Marketplace ${marketplaceVersionPattern} contains`, 'u'),
   );
 
   const evidenceCells = matrix

--- a/scripts/skill-frontmatter.test.mjs
+++ b/scripts/skill-frontmatter.test.mjs
@@ -123,7 +123,7 @@ test('published package versions stay aligned with the marketplace', () => {
   const marketplace = JSON.parse(
     readFileSync(join(ROOT, '.claude-plugin', 'marketplace.json'), 'utf8'),
   );
-  assert.equal(marketplace.version, '2.7.1', 'marketplace version');
+  assert.equal(marketplace.version, '2.7.2', 'marketplace version');
   const expected = new Map([
     ['autocontext', '1.1.2'],
     ['dev-toolkit', '1.4.0'],


### PR DESCRIPTION
Summary:
- Align current compatibility-matrix marketplace references with v2.7.2.
- Add a manifest-derived regression test.
- Preserve historical runtime evidence.

Validation:
- Target test: 8 passed.
- npm test: 223 passed with 1 existing TODO.
- npm run validate:catalog.
- npm run check:docs-css.
- Kimi low and high: zero findings.

Addresses late PR #288 finding: https://github.com/jamditis/claude-skills-journalism/pull/288#discussion_r3834103689

Deployment:
- After merge, publish v2.7.2 and verify Pages.