### PR TITLE
Release v2.7.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-skills-journalism",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "Agent skills and Claude Code plugins for journalism, research, and media organizations",
   "owner": {
     "name": "Joe Amditis",
@@ -76,7 +76,7 @@
     {
       "name": "project-templates-toolkit",
       "description": "Three skills for starting and closing out journalism projects: a CLAUDE.md project-memory writer, a LESSONS.md retrospective writer, and a template-selector decision tree for editorial tools, events, publications, research, pipelines, and archives.",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "author": {
         "name": "Joe Amditis",
         "email": "jamditis@gmail.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.3] - 2026-08-24
+
+### Fixed
+
+- Hardened the project-memory fixture verifier against inert Markdown, changed
+  section boundaries, duplicate required guidance, unexpected activation mutations,
+  special permission changes, and unknown filesystem entry types.
+
 ## [2.7.2] - 2026-08-21
 
 ### Fixed
@@ -726,7 +734,8 @@ Initial commit with foundational skills.
 
 ---
 
-[Unreleased]: https://github.com/jamditis/claude-skills-journalism/compare/v2.7.2...HEAD
+[Unreleased]: https://github.com/jamditis/claude-skills-journalism/compare/v2.7.3...HEAD
+[2.7.3]: https://github.com/jamditis/claude-skills-journalism/compare/v2.7.2...v2.7.3
 [2.7.2]: https://github.com/jamditis/claude-skills-journalism/compare/v2.7.1...v2.7.2
 [2.7.1]: https://github.com/jamditis/claude-skills-journalism/compare/v2.7.0...v2.7.1
 [2.7.0]: https://github.com/jamditis/claude-skills-journalism/compare/v2.6.0...v2.7.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-skills-journalism",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-skills-journalism",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "dependencies": {
         "playwright": "^1.57.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-skills-journalism",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "Agent Skills for journalists, researchers, academics, media professionals, and communications practitioners.",
   "main": "index.js",
   "scripts": {

--- a/plans/codex-compatibility-matrix.md
+++ b/plans/codex-compatibility-matrix.md
@@ -18,7 +18,7 @@
 
 ## August 2026 structure refresh
 
-- Marketplace 2.7.2 contains 12 Claude packages and 63 shared skills.
+- Marketplace 2.7.3 contains 12 Claude packages and 63 shared skills.
 - Codex can install the 15 nested journalism-core skills through the verified legacy-compatible package route.
 - The Agent Skills route supports root and nested skill layouts without converting Claude commands, agents, or hooks.
 - No native `.agents/plugins/marketplace.json` or `.codex-plugin/plugin.json` manifests are published.
@@ -50,7 +50,7 @@ Status labels:
 | Tool | Version or revision | Role |
 |---|---|---|
 | Codex structure refresh | 0.147.0 | Legacy package and Agent Skills route verification on August 15, 2026 |
-| Claude marketplace, current structure | 2.7.2 | Current catalog and version alignment; historical runtime results below remain snapshot-specific |
+| Claude marketplace, current structure | 2.7.3 | Current catalog and version alignment; historical runtime results below remain snapshot-specific |
 | Repository | `b0617649515d24ebfcd51f15bceb1d76b03db668` | Architecture commit used as the phase-one worktree base |
 | Repository release verification | [`9eef57629edbaa19bf47ec35296acebdd7b4ab1f`](https://github.com/jamditis/claude-skills-journalism/commit/9eef57629edbaa19bf47ec35296acebdd7b4ab1f) | July 23 post-merge `master` head used for the phase-one release evidence |
 | Repository visual-explainer pilot | [`f6a4b84dd2e9feafc6c2bf067f873e9301a083c2`](https://github.com/jamditis/claude-skills-journalism/commit/f6a4b84dd2e9feafc6c2bf067f873e9301a083c2) | July 23 `master` head installed for the V-ex-1 runtime evidence |

--- a/project-templates-toolkit/.claude-plugin/plugin.json
+++ b/project-templates-toolkit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-templates-toolkit",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Three skills for starting and closing out journalism projects: a CLAUDE.md project-memory writer, a LESSONS.md retrospective writer, and a template-selector decision tree for editorial tools, events, publications, research, pipelines, and archives.",
   "author": {
     "name": "Joe Amditis",

--- a/scripts/skill-frontmatter.test.mjs
+++ b/scripts/skill-frontmatter.test.mjs
@@ -123,7 +123,7 @@ test('published package versions stay aligned with the marketplace', () => {
   const marketplace = JSON.parse(
     readFileSync(join(ROOT, '.claude-plugin', 'marketplace.json'), 'utf8'),
   );
-  assert.equal(marketplace.version, '2.7.2', 'marketplace version');
+  assert.equal(marketplace.version, '2.7.3', 'marketplace version');
   const expected = new Map([
     ['autocontext', '1.1.2'],
     ['dev-toolkit', '1.4.0'],
@@ -131,7 +131,7 @@ test('published package versions stay aligned with the marketplace', () => {
     ['okf-wiki', '0.8.3'],
     ['pdf-design', '1.1.3'],
     ['pdf-playground', '1.3.5'],
-    ['project-templates-toolkit', '1.0.3'],
+    ['project-templates-toolkit', '1.0.4'],
     ['research-toolkit', '1.1.3'],
     ['security-toolkit', '1.2.3'],
     ['superjawn', '1.1.0'],


### PR DESCRIPTION
## Summary

- advance the marketplace from 2.7.2 to 2.7.3
- publish project-templates-toolkit 1.0.4 for the project-memory fixture hardening
- align the package files, changelog, current compatibility metadata, and version regression test

## Verification

- `node --test scripts/skill-frontmatter.test.mjs` — 2 passed
- `node --test scripts/codex-compatibility-docs.test.mjs` — 8 passed
- `npm test` — 242 passed, 0 failed, 1 todo
- `npm run validate:catalog` — passed
- `npm run validate:agent-skills` — 63 validated, 0 failed
- `npm run check:docs-css` — 52 stylesheets verified
- `git diff --check` — passed
- local Codex 5.5/low review — no findings

## Publication

This PR prepares the release only. It does not create a tag, GitHub Release, marketplace publication, or deployment.