### PR TITLE
Repair project-memory fixture verification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.11.3",
+        "markdown-it": "^15.0.0",
         "postcss": "8.5.26",
         "tailwindcss": "3.4.19",
         "yaml": "2.9.0"
@@ -149,6 +150,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argparse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-3.0.0.tgz",
+      "integrity": "sha512-BOp5NMrHqKxmq/OLr+clzzrRxgOKSLkcjmkWuChp7Irqwn4s74WjOBPIgWfA/HMcBnVkZ5XEuf9uUqzlpfCQ6A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "Python-2.0"
+    },
     "node_modules/axe-core": {
       "version": "4.11.4",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
@@ -269,6 +287,19 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
@@ -472,6 +503,61 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/linkify-it": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-6.1.0.tgz",
+      "integrity": "sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^3.0.0"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-15.0.0.tgz",
+      "integrity": "sha512-Lf8ajvVNdRpzSNB4VegxNy7gjs8gU35l4b4+ET49LrQC5PKYwLZ72u60LeJ9gv3qiaesuYjJWCyVeQmv/QWKQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^3.0.0",
+        "entities": "^8.0.0",
+        "linkify-it": "^6.0.0",
+        "mdurl": "^2.1.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^3.0.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
       "dev": true,
       "license": "MIT"
     },
@@ -800,6 +886,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -1075,6 +1171,13 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/uc.micro": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-3.0.0.tgz",
+      "integrity": "sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",
+    "markdown-it": "^15.0.0",
     "postcss": "8.5.26",
     "tailwindcss": "3.4.19",
     "yaml": "2.9.0"

--- a/scripts/project-memory-fixtures.mjs
+++ b/scripts/project-memory-fixtures.mjs
@@ -8,6 +8,7 @@ import {
   rmSync,
   writeFileSync,
 } from 'node:fs';
+import MarkdownIt from 'markdown-it';
 import {
   dirname,
   isAbsolute,
@@ -157,6 +158,8 @@ function requireRealAncestors(project, candidate, label) {
   }
 }
 
+const markdown = new MarkdownIt('commonmark', { html: true });
+
 function commentStateAfter(line, commentOpen) {
   let cursor = 0;
   while (true) {
@@ -173,47 +176,57 @@ function commentStateAfter(line, commentOpen) {
   }
 }
 
-function activeMarkdownLines(body) {
-  const active = [];
-  let fence;
-  let commentOpen = false;
-
-  for (const line of body.split(/\r?\n/u)) {
-    if (commentOpen || line.includes('<!--')) {
-      active.push(null);
-      commentOpen = commentStateAfter(line, commentOpen);
+function activeMarkdownEntries(body) {
+  const lines = body.split(/\r?\n/u);
+  const active = [...lines];
+  const headings = new Map();
+  const code = new Set();
+  const comments = new Set();
+  for (const token of markdown.parse(body, {})) {
+    if (!token.map) continue;
+    const [start, end] = token.map;
+    if (token.type === 'heading_open') {
+      headings.set(start, {
+        level: Number(token.tag.slice(1)),
+        containerLevel: token.level,
+      });
       continue;
     }
-    if (fence) {
-      active.push(null);
-      const closingFence = new RegExp(
-        `^ {0,3}${fence.character}{${fence.length},}[ \\t]*$`,
-        'u',
-      );
-      if (closingFence.test(line)) fence = undefined;
-      continue;
+    if (!['code_block', 'fence', 'html_block'].includes(token.type)) continue;
+    const commentBlock = token.type === 'html_block'
+      && token.content.trimStart().startsWith('<!--');
+    for (let index = start; index < end; index += 1) {
+      active[index] = null;
+      if (token.type !== 'html_block') code.add(index);
+      if (commentBlock) comments.add(index);
     }
-    const openingFence = /^ {0,3}(`{3,}|~{3,})/u.exec(line);
-    if (openingFence) {
-      active.push(null);
-      fence = {
-        character: openingFence[1][0],
-        length: openingFence[1].length,
-      };
-      continue;
-    }
-    active.push(line);
   }
-
-  return active;
+  let commentOpen = false;
+  for (let index = 0; index < active.length; index += 1) {
+    if (code.has(index) || (active[index] === null && !comments.has(index))) continue;
+    if (!commentOpen && !lines[index].includes('<!--')) continue;
+    active[index] = null;
+    commentOpen = commentStateAfter(lines[index], commentOpen);
+  }
+  return active
+    .map((line, index) => {
+      if (line === null) return null;
+      const heading = headings.get(index);
+      return {
+        line,
+        headingLevel: heading?.level,
+        containerLevel: heading?.containerLevel,
+      };
+    })
+    .filter((entry) => entry !== null);
 }
 
 function verifyPreservedGuidance(body, existing, label) {
-  const outputLines = activeMarkdownLines(body).filter((line) => line !== null);
+  const outputLines = activeMarkdownEntries(body);
   const expectedLines = existing.split(/\r?\n/u).filter(Boolean);
   for (const line of new Set(expectedLines)) {
     const expectedCount = expectedLines.filter((candidate) => candidate === line).length;
-    const actualCount = outputLines.filter((candidate) => candidate === line).length;
+    const actualCount = outputLines.filter((candidate) => candidate.line === line).length;
     if (actualCount !== expectedCount) {
       throw new Error(
         `Project-memory did not preserve the existing ${label} guidance exactly once`,
@@ -221,10 +234,28 @@ function verifyPreservedGuidance(body, existing, label) {
     }
   }
   let previousIndex = -1;
+  let previousContainerLevel = 0;
   for (const line of expectedLines) {
-    const index = outputLines.indexOf(line, previousIndex + 1);
+    const index = outputLines.findIndex(
+      (candidate, candidateIndex) => candidateIndex > previousIndex && candidate.line === line,
+    );
     if (index < 0) {
       throw new Error(`Project-memory changed the order of existing ${label} guidance`);
+    }
+    const insertedHeadingLevels = outputLines
+      .slice(previousIndex + 1, index)
+      .filter((candidate) => candidate.containerLevel === previousContainerLevel)
+      .map((candidate) => candidate.headingLevel)
+      .filter((level) => level !== undefined);
+    const existingHeadingLevel = outputLines[index].headingLevel;
+    const changesStructure = insertedHeadingLevels.some(
+      (level) => existingHeadingLevel === undefined || level < existingHeadingLevel,
+    );
+    if (changesStructure) {
+      throw new Error(`Project-memory changed the structure of existing ${label} guidance`);
+    }
+    if (outputLines[index].containerLevel !== undefined) {
+      previousContainerLevel = outputLines[index].containerLevel;
     }
     previousIndex = index;
   }
@@ -232,20 +263,29 @@ function verifyPreservedGuidance(body, existing, label) {
 
 function verifyRequiredSection(body, requiredText, label) {
   const [heading, ...guidance] = requiredText;
-  const lines = activeMarkdownLines(body);
-  const headingIndex = lines.indexOf(heading);
+  const lines = activeMarkdownEntries(body);
+  const headingIndex = lines.findIndex((entry) => entry.line === heading);
   const headingMatch = /^(#{1,6})\s/u.exec(heading);
   if (headingIndex < 0 || !headingMatch) {
     throw new Error(
       `Project-memory ${label} required heading must be an exact Markdown line`,
     );
   }
+  for (const text of requiredText) {
+    const count = lines.filter((entry) => entry.line === text).length;
+    if (count !== 1) {
+      throw new Error(`Project-memory ${label} required text must appear exactly once`);
+    }
+  }
 
-  const headingLevel = headingMatch[1].length;
+  const requiredHeadingLevel = headingMatch[1].length;
+  const requiredContainerLevel = lines[headingIndex].containerLevel;
   let sectionEnd = lines.length;
   for (let index = headingIndex + 1; index < lines.length; index += 1) {
-    const nextHeading = /^(#{1,6})\s/u.exec(lines[index]);
-    if (nextHeading && nextHeading[1].length <= headingLevel) {
+    if (
+      lines[index].containerLevel === requiredContainerLevel
+      && lines[index].headingLevel <= requiredHeadingLevel
+    ) {
       sectionEnd = index;
       break;
     }
@@ -253,10 +293,21 @@ function verifyRequiredSection(body, requiredText, label) {
 
   let previousIndex = headingIndex;
   for (const text of guidance) {
-    const index = lines.indexOf(text, previousIndex + 1);
+    const index = lines.findIndex(
+      (entry, entryIndex) => entryIndex > previousIndex && entry.line === text,
+    );
     if (index < 0 || index >= sectionEnd) {
       throw new Error(
         `Project-memory ${label} output does not keep required guidance under its heading`,
+      );
+    }
+    const changesStructure = lines
+      .slice(previousIndex + 1, index)
+      .some((entry) => entry.containerLevel === requiredContainerLevel
+        && entry.headingLevel !== undefined);
+    if (changesStructure) {
+      throw new Error(
+        `Project-memory ${label} output changes the required guidance structure`,
       );
     }
     previousIndex = index;
@@ -278,7 +329,7 @@ function snapshotProjectTree(project) {
       const path = prefix ? `${prefix}/${entry.name}` : entry.name;
       const absolutePath = containedPath(project, path, 'Snapshot path');
       const stat = lstatSync(absolutePath);
-      const mode = stat.mode & 0o777;
+      const mode = stat.mode & 0o7777;
       if (stat.isDirectory()) {
         snapshot[path] = { kind: 'directory', mode };
         walk(absolutePath, path);

--- a/scripts/project-memory-fixtures.test.mjs
+++ b/scripts/project-memory-fixtures.test.mjs
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import { syncBuiltinESMExports } from 'node:module';
 import {
   chmodSync,
+  lstatSync,
   mkdtempSync,
   mkdirSync,
   readFileSync,
@@ -244,6 +245,286 @@ test('output verifier rejects guidance inside fenced code blocks and comments', 
   );
 });
 
+test('output verifier rejects required guidance inside raw HTML blocks', () => {
+  const { project } = newProject('claude');
+  const fixture = PROJECT_MEMORY_FIXTURES.claude;
+  writeAcceptedOutput(project, fixture);
+  writeFileSync(
+    join(project, fixture.output.root.path),
+    `${fixture.existing.root}<pre>\n${fixture.output.root.requiredText.join('\n')}\n</pre>\n`,
+  );
+
+  assert.throws(
+    () => verifyOutput(project, 'claude'),
+    /required heading must be an exact Markdown line/iu,
+  );
+});
+
+test('output verifier keeps type-one blocks open through invalid closing tags', () => {
+  const { project } = newProject('claude');
+  const fixture = PROJECT_MEMORY_FIXTURES.claude;
+  writeAcceptedOutput(project, fixture);
+  writeFileSync(
+    join(project, fixture.output.root.path),
+    `${fixture.existing.root}<pre>\n</pre >\n${fixture.output.root.requiredText.join('\n')}\n</pre>\n`,
+  );
+
+  assert.throws(
+    () => verifyOutput(project, 'claude'),
+    /required heading must be an exact Markdown line/iu,
+  );
+});
+
+test('output verifier rejects required guidance inside other raw HTML blocks', () => {
+  const { project } = newProject('claude');
+  const fixture = PROJECT_MEMORY_FIXTURES.claude;
+  writeAcceptedOutput(project, fixture);
+  writeFileSync(
+    join(project, fixture.output.root.path),
+    `${fixture.existing.root}<div>\n${fixture.output.root.requiredText.join('\n')}\n</div>\n`,
+  );
+
+  assert.throws(
+    () => verifyOutput(project, 'claude'),
+    /required heading must be an exact Markdown line/iu,
+  );
+});
+
+test('output verifier rejects required guidance after closing type-six HTML tags', () => {
+  const { project } = newProject('claude');
+  const fixture = PROJECT_MEMORY_FIXTURES.claude;
+  writeAcceptedOutput(project, fixture);
+  writeFileSync(
+    join(project, fixture.output.root.path),
+    `${fixture.existing.root}</div> trailing text\n${fixture.output.root.requiredText.join('\n')}\n\n`,
+  );
+
+  assert.throws(
+    () => verifyOutput(project, 'claude'),
+    /required heading must be an exact Markdown line/iu,
+  );
+});
+
+test('output verifier rejects required guidance after all type-six HTML tags', () => {
+  const { project } = newProject('claude');
+  const fixture = PROJECT_MEMORY_FIXTURES.claude;
+  writeAcceptedOutput(project, fixture);
+  writeFileSync(
+    join(project, fixture.output.root.path),
+    `${fixture.existing.root}Visible context\n<menuitem>\n`
+      + `${fixture.output.root.requiredText.join('\n')}\n\n`,
+  );
+
+  assert.throws(
+    () => verifyOutput(project, 'claude'),
+    /required heading must be an exact Markdown line/iu,
+  );
+});
+
+test('output verifier rejects required guidance inside every raw HTML block form', () => {
+  const fixture = PROJECT_MEMORY_FIXTURES.claude;
+  const cases = [
+    ['processing instruction', '<?project-memory', '?>'],
+    ['CDATA section', '<![CDATA[', ']]>'],
+    ['HTML declaration', '<!DOCTYPE html', '>'],
+    ['type-six HTML block', '<div>', '</div>'],
+    ['type-seven HTML block', '<project-memory>', ''],
+  ];
+
+  for (const [name, opening, closing] of cases) {
+    const { project } = newProject('claude');
+    writeAcceptedOutput(project, fixture);
+    writeFileSync(
+      join(project, fixture.output.root.path),
+      `${fixture.existing.root}${opening}\n${fixture.output.root.requiredText.join('\n')}\n${closing}\n`,
+    );
+
+    assert.throws(
+      () => verifyOutput(project, 'claude'),
+      /required heading must be an exact Markdown line/iu,
+      name,
+    );
+  }
+});
+
+test('output verifier accepts type-seven tags inside paragraphs', () => {
+  const { project } = newProject('claude');
+  const fixture = PROJECT_MEMORY_FIXTURES.claude;
+  writeAcceptedOutput(project, fixture);
+  writeFileSync(
+    join(project, fixture.output.root.path),
+    `${fixture.existing.root}Visible context\n<project-memory>\n`
+      + `${fixture.output.root.requiredText.join('\n')}\n`,
+  );
+
+  assert.doesNotThrow(() => verifyOutput(project, 'claude'));
+});
+
+test('output verifier accepts inline type-one and type-seven HTML', () => {
+  const fixture = PROJECT_MEMORY_FIXTURES.claude;
+  const visibleCases = [
+    'Visible context\n<pre/>',
+    '> Visible context\n<project-memory>',
+  ];
+
+  for (const prefix of visibleCases) {
+    const { project } = newProject('claude');
+    writeAcceptedOutput(project, fixture);
+    writeFileSync(
+      join(project, fixture.output.root.path),
+      `${fixture.existing.root}${prefix}\n${fixture.output.root.requiredText.join('\n')}\n`,
+    );
+
+    assert.doesNotThrow(() => verifyOutput(project, 'claude'));
+  }
+});
+
+test('output verifier ignores raw tags inside existing HTML comments', () => {
+  const { project } = newProject('claude');
+  const fixture = PROJECT_MEMORY_FIXTURES.claude;
+  writeAcceptedOutput(project, fixture);
+  writeFileSync(
+    join(project, fixture.output.root.path),
+    `${fixture.existing.root}<!--\n<pre>\n-->\n${fixture.output.root.requiredText.join('\n')}\n`,
+  );
+
+  assert.doesNotThrow(() => verifyOutput(project, 'claude'));
+});
+
+test('output verifier accepts guidance after an inert HTML comment marker', () => {
+  const { project } = newProject('claude');
+  const fixture = PROJECT_MEMORY_FIXTURES.claude;
+  writeAcceptedOutput(project, fixture);
+  writeFileSync(
+    join(project, fixture.output.root.path),
+    `${fixture.existing.root}<script>\nconst marker = '<!--';\n</script>\n`
+      + `${fixture.output.root.requiredText.join('\n')}\n`,
+  );
+
+  assert.doesNotThrow(() => verifyOutput(project, 'claude'));
+});
+
+test('output verifier preserves existing Markdown section boundaries', () => {
+  const { project } = newProject('codex');
+  const fixture = PROJECT_MEMORY_FIXTURES.codex;
+  const changedExisting = fixture.existing.root.replace(
+    '## Release safety\n- Keep',
+    '## Release safety\n### Release exception\n- Keep',
+  );
+  writeAcceptedOutput(project, fixture);
+  writeFileSync(
+    join(project, fixture.output.root.path),
+    `${changedExisting}${fixture.output.root.requiredText.join('\n')}\n`,
+  );
+
+  assert.throws(
+    () => verifyOutput(project, 'codex'),
+    /changed the structure of existing root guidance/iu,
+  );
+});
+
+test('output verifier rejects headings that reparent existing sections', () => {
+  const { project } = newProject('codex');
+  const fixture = PROJECT_MEMORY_FIXTURES.codex;
+  const changedExisting = fixture.existing.root.replace(
+    '## Release safety',
+    '# Different project\n## Release safety',
+  );
+  writeAcceptedOutput(project, fixture);
+  writeFileSync(
+    join(project, fixture.output.root.path),
+    `${changedExisting}${fixture.output.root.requiredText.join('\n')}\n`,
+  );
+
+  assert.throws(
+    () => verifyOutput(project, 'codex'),
+    /changed the structure of existing root guidance/iu,
+  );
+});
+
+test('output verifier rejects indented headings that reparent existing sections', () => {
+  const { project } = newProject('codex');
+  const fixture = PROJECT_MEMORY_FIXTURES.codex;
+  const changedExisting = fixture.existing.root.replace(
+    '## Release safety',
+    ' # Different project\n## Release safety',
+  );
+  writeAcceptedOutput(project, fixture);
+  writeFileSync(
+    join(project, fixture.output.root.path),
+    `${changedExisting}${fixture.output.root.requiredText.join('\n')}\n`,
+  );
+
+  assert.throws(
+    () => verifyOutput(project, 'codex'),
+    /changed the structure of existing root guidance/iu,
+  );
+});
+
+test('output verifier rejects setext headings that change existing sections', () => {
+  const { project } = newProject('codex');
+  const fixture = PROJECT_MEMORY_FIXTURES.codex;
+  const changedExisting = fixture.existing.root.replace(
+    '- Keep',
+    'Different project\n=================\n- Keep',
+  );
+  writeAcceptedOutput(project, fixture);
+  writeFileSync(
+    join(project, fixture.output.root.path),
+    `${changedExisting}${fixture.output.root.requiredText.join('\n')}\n`,
+  );
+
+  assert.throws(
+    () => verifyOutput(project, 'codex'),
+    /changed the structure of existing root guidance/iu,
+  );
+});
+
+test('output verifier rejects duplicated required guidance', () => {
+  const { project } = newProject('codex');
+  const fixture = PROJECT_MEMORY_FIXTURES.codex;
+  writeAcceptedOutput(project, fixture);
+  writeFileSync(
+    join(project, fixture.output.root.path),
+    `${fixture.existing.root}${fixture.output.root.requiredText.join('\n')}\n`
+      + `${fixture.output.root.requiredText[1]}\n`,
+  );
+
+  assert.throws(
+    () => verifyOutput(project, 'codex'),
+    /required text must appear exactly once/iu,
+  );
+});
+
+test('output verifier rejects required guidance in a nested subsection', () => {
+  const { project } = newProject('claude');
+  const fixture = PROJECT_MEMORY_FIXTURES.claude;
+  writeAcceptedOutput(project, fixture);
+  writeFileSync(
+    join(project, fixture.output.root.path),
+    `${fixture.existing.root}${fixture.output.root.requiredText[0]}\n### Different scope\n`
+      + `${fixture.output.root.requiredText[1]}\n`,
+  );
+
+  assert.throws(
+    () => verifyOutput(project, 'claude'),
+    /changes the required guidance structure/iu,
+  );
+});
+
+test('output verifier accepts quoted headings in a required section', () => {
+  const { project } = newProject('claude');
+  const fixture = PROJECT_MEMORY_FIXTURES.claude;
+  writeAcceptedOutput(project, fixture);
+  writeFileSync(
+    join(project, fixture.output.root.path),
+    `${fixture.existing.root}${fixture.output.root.requiredText[0]}\n> ## Note\n`
+      + `${fixture.output.root.requiredText[1]}\n`,
+  );
+
+  assert.doesNotThrow(() => verifyOutput(project, 'claude'));
+});
+
 test('output verifier requires the prepared snapshot before accepting mutations', () => {
   const fixture = newProject('codex');
   writeAcceptedOutput(fixture.project, PROJECT_MEMORY_FIXTURES.codex);
@@ -391,6 +672,28 @@ test('non-trigger check detects any instruction-file mutation', () => {
       changedMode.prepared.snapshot,
     ),
     /non-trigger changed AGENTS\.md/u,
+  );
+});
+
+test('non-trigger check detects special permission mutations', {
+  skip: process.platform === 'win32',
+}, (context) => {
+  const fixture = newProject('codex');
+  const path = join(fixture.project, 'AGENTS.md');
+  const permissionBits = lstatSync(path).mode & 0o777;
+  chmodSync(path, permissionBits | 0o4000);
+  if ((lstatSync(path).mode & 0o4000) === 0) {
+    context.skip('The filesystem does not preserve the setuid bit');
+    return;
+  }
+
+  assert.throws(
+    () => verifyProjectMemoryNonTrigger(
+      fixture.project,
+      'codex',
+      fixture.prepared.snapshot,
+    ),
+    /non-trigger changed AGENTS\.md/iu,
   );
 });
 


### PR DESCRIPTION
## Summary

- Parse fixture Markdown with CommonMark tokens.
- Preserve existing guidance section boundaries.
- Record special permission bits in fixture snapshots.
- Require each required line exactly once.

Addresses the post-merge connector findings from #290:

- `PRRT_kwDOQu79aM6b0Kl7`
- `PRRT_kwDOQu79aM6b0KmB`
- `PRRT_kwDOQu79aM6b0KmF`
- `PRRT_kwDOQu79aM6b0KmJ`

## Verification

- `node --test scripts/project-memory-fixtures.test.mjs`
- `npm test`
- `npm run validate:catalog`
- `npm run validate:agent-skills`
- `npm run check:docs-css`
- `npm audit --omit=dev --audit-level=high`