### PR TITLE
Add web design picker skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-skills-journalism",
-  "version": "2.7.3",
+  "version": "2.8.0",
   "description": "Agent skills and Claude Code plugins for journalism, research, and media organizations",
   "owner": {
     "name": "Joe Amditis",
@@ -127,6 +127,17 @@
       },
       "source": "./video-toolkit",
       "category": "Journalism"
+    },
+    {
+      "name": "web-design-picker",
+      "description": "Build distinct website directions, a client review picker, asset catalog, previews, and Cloudflare-ready handoff packages.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Joe Amditis",
+        "email": "jamditis@gmail.com"
+      },
+      "source": "./web-design-picker",
+      "category": "Design"
     },
     {
       "name": "visual-explainer",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.0] - 2026-09-01
+
+### Added
+
+- Added the `web-design-picker` plugin for producing distinct website concepts,
+  a switchable client review site, downloadable design assets, preview images,
+  static-site QA, and separate deployment and handoff packages.
+
+### Changed
+
+- Added `web-design-picker` to the shared skill catalog, Claude marketplace,
+  Codex display metadata, repository documentation, and public skill browser.
+
 ## [2.7.3] - 2026-08-24
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,15 @@ claude-skills-journalism/
 │       ├── video-frames/        # Frame extraction and vision analysis
 │       └── video-transcribe/    # Reproducible Whisper transcription
 │
+├── # Plugin: web-design-picker (1 skill, v1.0.0), registered in marketplace.json
+├── web-design-picker/           # Website directions, review picker, asset handoff
+│   ├── .claude-plugin/plugin.json
+│   ├── agents/openai.yaml
+│   ├── assets/                  # Picker, catalog, concept, schema, and favicon sources
+│   ├── references/              # Design, accessibility, QA, and delivery guidance
+│   ├── scripts/                 # Scaffold, build, preview, validate, and package tools
+│   └── SKILL.md
+│
 ├── # Plugin: visual-explainer (1 skill), registered in marketplace.json
 ├── visual-explainer/            # HTML diagrams, data tables, architecture views
 │   ├── references/              # CSS patterns, library guides, nav patterns
@@ -260,11 +269,11 @@ This repo distributes shared skills as Claude and Codex packages and as standard
 /plugin install journalism-core@claude-skills-journalism
 ```
 
-Available plugins: `autocontext`, `dev-toolkit`, `journalism-core`, `okf-wiki`, `pdf-design`, `pdf-playground`, `project-templates-toolkit`, `research-toolkit`, `security-toolkit`, `superjawn`, `video-toolkit`, `visual-explainer`. See `.claude-plugin/marketplace.json` for the full list.
+Available plugins: `autocontext`, `dev-toolkit`, `journalism-core`, `okf-wiki`, `pdf-design`, `pdf-playground`, `project-templates-toolkit`, `research-toolkit`, `security-toolkit`, `superjawn`, `video-toolkit`, `web-design-picker`, `visual-explainer`. See `.claude-plugin/marketplace.json` for the full list.
 
 ### Alternate: copy a single skill into `~/.claude/skills/`
 
-Most skills live inside a package's `skills/` directory. The `okf-wiki`, `pdf-design`, and `visual-explainer` packages keep `SKILL.md` at the package root. Clone the repo and copy the directory that directly contains the required `SKILL.md`. Claude Code discovers skills at `~/.claude/skills/<skill-name>/SKILL.md`, one level deep:
+Most skills live inside a package's `skills/` directory. The `okf-wiki`, `pdf-design`, `web-design-picker`, and `visual-explainer` packages keep `SKILL.md` at the package root. Clone the repo and copy the directory that directly contains the required `SKILL.md`. Claude Code discovers skills at `~/.claude/skills/<skill-name>/SKILL.md`, one level deep:
 
 ```bash
 git clone https://github.com/jamditis/claude-skills-journalism.git ~/projects/claude-skills-journalism
@@ -278,6 +287,7 @@ cp -r dev-toolkit/skills/web-scraping ~/.claude/skills/
 cp -r security-toolkit/skills/secure-auth ~/.claude/skills/
 cp -r project-templates-toolkit/skills/project-memory ~/.claude/skills/
 cp -r okf-wiki ~/.claude/skills/
+cp -r web-design-picker ~/.claude/skills/
 
 # Or symlink so git pull updates them in place (ln -sfn replaces an existing link):
 ln -sfn "$PWD/research-toolkit/skills/free-apis-catalog" ~/.claude/skills/free-apis-catalog

--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ Then restart Claude Code (close and reopen). See the [PDF Playground README](./p
 | [security-toolkit](./security-toolkit/) | Four defensive security skills covering OWASP Top 10 fundamentals and supply-chain hardening: pre-deployment audit checklists (auth, input validation, secrets management), secure authentication patterns (password hashing, session management, JWT, OAuth, passkeys), API hardening (rate limiting, CORS, request throttling, defense-in-depth for Express, FastAPI, and serverless), and npm/bun supply-chain hardening with install-time cooldown plus a sandboxed pre-install scan for the bypass case (defends against Mini Shai-Hulud-class worms) | `/security-toolkit:hotpatch` | Aug 21, 2026 |
 | [superjawn](./superjawn/) | Research-augmented fork of obra/superpowers. Default-on research phase fires before brainstorming, systematic-debugging, and writing-skills. Includes all 14 skills with no soft dependencies on the upstream `superpowers` plugin | invoked indirectly via skills (e.g. `superjawn:brainstorming`, `superjawn:systematic-debugging`, `superjawn:writing-plans`) | Aug 21, 2026 |
 | [video-toolkit](./video-toolkit/) | Four composable skills for social-video accountability reporting: downloading public video from Twitter/X, TikTok, YouTube, Instagram, and Facebook; transcribing it with a provenance sidecar and a CPU path any evaluator can re-run; extracting and vision-analyzing frames; and aggregating the result into an interactive dashboard | n/a, skills only | Aug 21, 2026 |
+| [web-design-picker](./web-design-picker/) | Build two to five distinct website directions, a switchable client review site, downloadable design assets, preview images, static QA reports, and separate Cloudflare Drop and design-handoff packages | n/a, skill only | Sep 1, 2026 |
 | [visual-explainer](./visual-explainer/) | HTML diagrams, data tables, architecture views, slide decks, and KPI dashboards adapted from nicobailon/visual-explainer with journalism, newsroom, and academic design sensibilities | `/visual-explainer:project-recap` | Aug 21, 2026 |
 
 #### Skills (manual installation)
 
-Most skills live inside a plugin's `skills/` directory. The `okf-wiki/SKILL.md`, `pdf-design/SKILL.md`, and `visual-explainer/SKILL.md` root-skill packages keep the skill at the package root. To install one skill without taking a whole plugin, clone the repo and copy or symlink the directory that directly contains its `SKILL.md`. Claude Code discovers skills at `~/.claude/skills/<skill-name>/SKILL.md`, one level deep:
+Most skills live inside a plugin's `skills/` directory. The `okf-wiki/SKILL.md`, `pdf-design/SKILL.md`, `visual-explainer/SKILL.md`, and `web-design-picker/SKILL.md` root-skill packages keep the skill at the package root. To install one skill without taking a whole plugin, clone the repo and copy or symlink the directory that directly contains its `SKILL.md`. Claude Code discovers skills at `~/.claude/skills/<skill-name>/SKILL.md`, one level deep:
 
 ```
 git clone https://github.com/jamditis/claude-skills-journalism.git ~/projects/claude-skills-journalism
@@ -88,10 +89,12 @@ cp -r project-templates-toolkit/skills/project-memory ~/.claude/skills/
 
 # A root-skill package is already the directory to copy:
 cp -r okf-wiki ~/.claude/skills/
+cp -r web-design-picker ~/.claude/skills/
 
 # Or symlink so git pull updates them in place (ln -sfn replaces an existing link):
 ln -sfn "$PWD/research-toolkit/skills/free-apis-catalog" ~/.claude/skills/free-apis-catalog
 ln -sfn "$PWD/dev-toolkit/skills/director" ~/.claude/skills/director
+ln -sfn "$PWD/web-design-picker" ~/.claude/skills/web-design-picker
 ln -sfn "$PWD/visual-explainer" ~/.claude/skills/visual-explainer
 ```
 
@@ -190,6 +193,7 @@ These six skills ship together as the [research-toolkit](./research-toolkit/) pl
 | Skill | Description | Updated |
 |-------|-------------|--------|
 | [pdf-design](./pdf-design/) | Professional PDF reports and proposals with brand system, budget tables, and multi-page layouts. For the full interactive experience, use [pdf-playground](./pdf-playground/) instead | Aug 21, 2026 |
+| [web-design-picker](./web-design-picker/) | Produce distinct responsive website directions, a client review picker, downloadable design assets, preview images, static QA reports, and deployment and handoff packages | Sep 1, 2026 |
 | [visual-explainer](./visual-explainer/) | Turn complex data into styled HTML pages, architecture diagrams, data tables, flowcharts, timelines, source maps, and dashboards with dark/light theme support. Now registered as a plugin (`/plugin install visual-explainer@claude-skills-journalism`) | Aug 21, 2026 |
 
 ### PDF Playground skill

--- a/docs/academic-writing/index.html
+++ b/docs/academic-writing/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Academic writing</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="academic-writing">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Research methodology, scholarly communication, and academic writing workflows for papers, literature reviews, and grant proposals.
             </p>

--- a/docs/accessibility-compliance/index.html
+++ b/docs/accessibility-compliance/index.html
@@ -148,6 +148,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-bold mb-6 tracking-tight">Accessibility compliance</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="accessibility-compliance">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl leading-relaxed">
                 Web accessibility patterns for news sites, journalism tools, and academic platforms. Ensure your content reaches all readers.
             </p>

--- a/docs/ai-writing-detox/index.html
+++ b/docs/ai-writing-detox/index.html
@@ -155,6 +155,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-bold mb-6 tracking-tight">AI writing detox</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="ai-writing-detox">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl leading-relaxed">
                 Eliminate AI-generated writing patterns that erode reader trust. Essential for journalists using AI assistance who need human-sounding output.
             </p>

--- a/docs/api-hardening/index.html
+++ b/docs/api-hardening/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">API hardening</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="api-hardening">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Defense-in-depth patterns for protecting APIs from abuse, injection attacks, and data leakage. Oriented around the OWASP API Security Top 10:2023, with practical implementations for Express, FastAPI, and serverless.
             </p>

--- a/docs/assets/tailwind/index.css
+++ b/docs/assets/tailwind/index.css
@@ -810,6 +810,9 @@ video {
 .bg-\[\#b45309\]\/10 {
   background-color: rgb(180 83 9 / 0.1);
 }
+.bg-\[\#e85d04\]\/10 {
+  background-color: rgb(232 93 4 / 0.1);
+}
 .bg-accent {
   --tw-bg-opacity: 1;
   background-color: rgb(61 75 64 / var(--tw-bg-opacity, 1));
@@ -1085,6 +1088,10 @@ video {
   --tw-text-opacity: 1;
   color: rgb(124 58 237 / var(--tw-text-opacity, 1));
 }
+.text-\[\#9a3c00\] {
+  --tw-text-opacity: 1;
+  color: rgb(154 60 0 / var(--tw-text-opacity, 1));
+}
 .text-\[\#CA3553\] {
   --tw-text-opacity: 1;
   color: rgb(202 53 83 / var(--tw-text-opacity, 1));
@@ -1096,6 +1103,10 @@ video {
 .text-\[\#d97706\] {
   --tw-text-opacity: 1;
   color: rgb(217 119 6 / var(--tw-text-opacity, 1));
+}
+.text-\[\#e85d04\] {
+  --tw-text-opacity: 1;
+  color: rgb(232 93 4 / var(--tw-text-opacity, 1));
 }
 .text-accent {
   --tw-text-opacity: 1;
@@ -1291,6 +1302,10 @@ video {
 .group:hover .group-hover\:text-\[\#b45309\] {
   --tw-text-opacity: 1;
   color: rgb(180 83 9 / var(--tw-text-opacity, 1));
+}
+.group:hover .group-hover\:text-\[\#b94700\] {
+  --tw-text-opacity: 1;
+  color: rgb(185 71 0 / var(--tw-text-opacity, 1));
 }
 .group:hover .group-hover\:text-\[\#d97706\] {
   --tw-text-opacity: 1;

--- a/docs/autocontext/index.html
+++ b/docs/autocontext/index.html
@@ -159,6 +159,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <div class="inline-block px-3 py-1 bg-white/10 rounded-full text-xs font-semibold tracking-wide uppercase mb-6">Claude Code Plugin</div>
             <h1 class="font-display text-5xl md:text-7xl font-black leading-[0.9] mb-6">AutoContext</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T15:53:55-04:00" data-updated-slug="autocontext">Updated <time datetime="2026-08-21T15:53:55-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl md:text-2xl text-white/90 max-w-2xl mb-4 font-light">A Claude Code plugin that gives your AI assistant a memory for each project.</p>
             <p class="text-base md:text-lg text-white/70 max-w-2xl mb-10">Every time you correct Claude, "no, use the other API", "you forgot to clear the cache", autocontext saves that as a lesson. Next session, it loads those lessons before Claude starts working, so the same mistakes don't happen twice.</p>
             <div class="flex flex-wrap gap-4">

--- a/docs/brazil-records-requests/index.html
+++ b/docs/brazil-records-requests/index.html
@@ -45,6 +45,7 @@
             <p class="inline-flex items-center rounded-full bg-accentLight text-accentDark px-3 py-1 text-sm font-semibold mb-6">journalism-core skill</p>
             <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">Brazilian public records requests</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="brazil-records-requests">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl md:text-2xl text-clay leading-relaxed max-w-3xl">Use the Lei de Acesso à Informação to find the right public body, request the record, track the deadline, and take the correct appeal path.</p>
         </div>
     </header>

--- a/docs/claude-md-updater/index.html
+++ b/docs/claude-md-updater/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">CLAUDE.md updater</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="claude-md-updater">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Turn the lessons of a working session into a scoped CLAUDE.md edit, shown as a diff you approve before anything is written.
             </p>

--- a/docs/content-access/index.html
+++ b/docs/content-access/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Content access</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="content-access">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Ethical and legal approaches for accessing paywalled and geo-blocked content for journalism and research.
             </p>

--- a/docs/context-engineering-fundamentals/index.html
+++ b/docs/context-engineering-fundamentals/index.html
@@ -56,6 +56,7 @@
             <p class="text-sm font-semibold mb-4">Development skill</p>
             <h1 class="text-4xl md:text-5xl font-bold">Context engineering fundamentals</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="context-engineering-fundamentals">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl mt-5">Keep instructions, evidence, and task state usable during long AI-agent sessions.</p>
         </div>
     </header>

--- a/docs/crisis-communications/index.html
+++ b/docs/crisis-communications/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Crisis communications</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="crisis-communications">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Frameworks for accurate, rapid communication during breaking news and high-pressure situations.
             </p>

--- a/docs/data-journalism/index.html
+++ b/docs/data-journalism/index.html
@@ -136,6 +136,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <div class="inline-block px-3 py-1 bg-white/10 rounded-full text-xs font-semibold tracking-wide uppercase mb-6">Core Journalism Skill</div>
             <h1 class="font-display text-5xl md:text-7xl font-black leading-[0.9] mb-6">Data<br>Journalism</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T15:00:39-04:00" data-updated-slug="data-journalism">Updated <time datetime="2026-08-21T15:00:39-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl md:text-2xl text-white/90 max-w-2xl mb-10 font-light">
                 Find, analyze, and present data to tell compelling stories. From acquisition to publication-ready visualizations.
             </p>

--- a/docs/digital-archive/index.html
+++ b/docs/digital-archive/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Digital archive</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="digital-archive">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Build production-quality digital archives with AI-powered categorization, entity extraction, and knowledge graph construction.
             </p>

--- a/docs/director/index.html
+++ b/docs/director/index.html
@@ -56,6 +56,7 @@
             <p class="text-sm font-semibold mb-4">Development skill</p>
             <h1 class="text-4xl md:text-5xl font-bold">Director</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T16:01:04-04:00" data-updated-slug="director">Updated <time datetime="2026-08-21T16:01:04-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl mt-5">Direct, decide, delegate, and review without taking over implementation work.</p>
         </div>
     </header>

--- a/docs/editorial-workflow/index.html
+++ b/docs/editorial-workflow/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Editorial workflow</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="editorial-workflow">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Manage editorial workflows for newsrooms and publications with story tracking, deadline management, and handoff protocols.
             </p>

--- a/docs/electron-dev/index.html
+++ b/docs/electron-dev/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Electron dev</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="electron-dev">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Build production-quality Electron desktop applications with React, TypeScript, and Vite.
             </p>

--- a/docs/fact-check-workflow/index.html
+++ b/docs/fact-check-workflow/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Fact-check workflow</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="fact-check-workflow">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Structured workflow for claim verification, evidence gathering, rating scales, and correction protocols.
             </p>

--- a/docs/foia-requests/index.html
+++ b/docs/foia-requests/index.html
@@ -187,6 +187,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 FOIA<br>Requests
             </h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="foia-requests">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl md:text-2xl text-white/90 max-w-2xl mb-10 font-light">
                 Freedom of Information Act and public records request workflows for investigative journalists, researchers, and transparency advocates.
             </p>

--- a/docs/free-apis-catalog/index.html
+++ b/docs/free-apis-catalog/index.html
@@ -139,6 +139,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <div class="inline-block px-3 py-1 bg-white/10 rounded-full text-xs font-semibold tracking-wide uppercase mb-6">Developer reference</div>
             <h1 class="font-display text-5xl md:text-7xl font-black leading-[0.9] mb-6">Free APIs<br>catalog</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="free-apis-catalog">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl md:text-2xl text-white/90 max-w-2xl mb-10 font-light">
                 Curated free-API catalog for journalism use-cases &mdash; government data, news, social media, AI/ML, business, geocoding. Currency notes for major API sunsets (IEX Cloud, CrowdTangle, ProPublica Congress, X, Reddit) and an evaluation rubric for picking APIs.
             </p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -612,7 +612,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                             <span class="text-[8px] bg-[#e85d04]/10 text-[#9a3c00] px-2 py-1 rounded font-semibold">Review</span>
                             <span class="text-[8px] bg-[#e85d04]/10 text-[#9a3c00] px-2 py-1 rounded font-semibold">Handoff</span>
                         </div>
-                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T21:57:48-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:57:48-04:00">Sep 1, 2026</time></p>
+                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T22:01:12-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T22:01:12-04:00">Sep 1, 2026</time></p>
                     </a>
 
                     <a href="visual-explainer/" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
@@ -809,7 +809,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         </div>
                         <h3 class="font-display text-lg font-bold mb-2 group-hover:text-[#b94700] transition-colors">web-design-picker</h3>
                         <p class="text-sm text-mist leading-relaxed">Build separate design theses, compare them in one review site, and package deployable files and editable assets.</p>
-                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T21:57:48-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:57:48-04:00">Sep 1, 2026</time></p>
+                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T22:01:12-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T22:01:12-04:00">Sep 1, 2026</time></p>
                     </a>
 
                     <a href="visual-explainer/" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">

--- a/docs/index.html
+++ b/docs/index.html
@@ -612,7 +612,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                             <span class="text-[8px] bg-[#e85d04]/10 text-[#9a3c00] px-2 py-1 rounded font-semibold">Review</span>
                             <span class="text-[8px] bg-[#e85d04]/10 text-[#9a3c00] px-2 py-1 rounded font-semibold">Handoff</span>
                         </div>
-                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T21:33:24-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:33:24-04:00">Sep 1, 2026</time></p>
+                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T21:37:43-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:37:43-04:00">Sep 1, 2026</time></p>
                     </a>
 
                     <a href="visual-explainer/" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
@@ -809,7 +809,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         </div>
                         <h3 class="font-display text-lg font-bold mb-2 group-hover:text-[#b94700] transition-colors">web-design-picker</h3>
                         <p class="text-sm text-mist leading-relaxed">Build separate design theses, compare them in one review site, and package deployable files and editable assets.</p>
-                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T21:33:24-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:33:24-04:00">Sep 1, 2026</time></p>
+                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T21:37:43-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:37:43-04:00">Sep 1, 2026</time></p>
                     </a>
 
                     <a href="visual-explainer/" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">

--- a/docs/index.html
+++ b/docs/index.html
@@ -612,7 +612,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                             <span class="text-[8px] bg-[#e85d04]/10 text-[#9a3c00] px-2 py-1 rounded font-semibold">Review</span>
                             <span class="text-[8px] bg-[#e85d04]/10 text-[#9a3c00] px-2 py-1 rounded font-semibold">Handoff</span>
                         </div>
-                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T21:33:06-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:33:06-04:00">Sep 1, 2026</time></p>
+                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T21:33:24-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:33:24-04:00">Sep 1, 2026</time></p>
                     </a>
 
                     <a href="visual-explainer/" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
@@ -809,7 +809,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         </div>
                         <h3 class="font-display text-lg font-bold mb-2 group-hover:text-[#b94700] transition-colors">web-design-picker</h3>
                         <p class="text-sm text-mist leading-relaxed">Build separate design theses, compare them in one review site, and package deployable files and editable assets.</p>
-                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T21:33:06-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:33:06-04:00">Sep 1, 2026</time></p>
+                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T21:33:24-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:33:24-04:00">Sep 1, 2026</time></p>
                     </a>
 
                     <a href="visual-explainer/" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">

--- a/docs/index.html
+++ b/docs/index.html
@@ -612,7 +612,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                             <span class="text-[8px] bg-[#e85d04]/10 text-[#9a3c00] px-2 py-1 rounded font-semibold">Review</span>
                             <span class="text-[8px] bg-[#e85d04]/10 text-[#9a3c00] px-2 py-1 rounded font-semibold">Handoff</span>
                         </div>
-                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T21:37:43-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:37:43-04:00">Sep 1, 2026</time></p>
+                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T21:48:47-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:48:47-04:00">Sep 1, 2026</time></p>
                     </a>
 
                     <a href="visual-explainer/" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
@@ -809,7 +809,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         </div>
                         <h3 class="font-display text-lg font-bold mb-2 group-hover:text-[#b94700] transition-colors">web-design-picker</h3>
                         <p class="text-sm text-mist leading-relaxed">Build separate design theses, compare them in one review site, and package deployable files and editable assets.</p>
-                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T21:37:43-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:37:43-04:00">Sep 1, 2026</time></p>
+                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T21:48:47-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:48:47-04:00">Sep 1, 2026</time></p>
                     </a>
 
                     <a href="visual-explainer/" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">

--- a/docs/index.html
+++ b/docs/index.html
@@ -414,7 +414,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <div class="deckle-card-solid p-6 md:p-8">
                     <div class="flex flex-col md:flex-row md:items-center justify-between gap-3 mb-4">
                         <h2 class="font-display text-2xl font-light italic">Find a skill</h2>
-                    <span class="section-label" id="finder-count">64 skills, 13 plugins</span>
+                        <span class="section-label" id="finder-count">64 skills, 13 plugins</span>
                     </div>
                     <div class="relative">
                         <i data-lucide="search" class="w-5 h-5 text-mist absolute left-4 top-1/2 -translate-y-1/2 pointer-events-none"></i>

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,7 +13,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Agent skills for journalism | Joe Amditis</title>
-    <meta name="description" content="63 agent skills, 12 plugins, and 17 hooks for journalists, researchers, academics, and media professionals. Supports Claude Code and Codex.">
+    <meta name="description" content="64 agent skills, 13 plugins, and 17 hooks for journalists, researchers, academics, and media professionals. Supports Claude Code and Codex.">
 
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
@@ -227,7 +227,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
 
     <!-- Open Graph -->
     <meta property="og:title" content="Agent skills for journalism">
-    <meta property="og:description" content="63 skills, 12 plugins, and 17 hooks for journalists, researchers, academics, and media professionals. Supports Claude Code and Codex.">
+    <meta property="og:description" content="64 skills, 13 plugins, and 17 hooks for journalists, researchers, academics, and media professionals. Supports Claude Code and Codex.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://skills.amditis.tech/">
     <meta property="og:image" content="https://skills.amditis.tech/og-image.png">
@@ -237,7 +237,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Agent skills for journalism">
-    <meta name="twitter:description" content="63 skills, 12 plugins, and 17 hooks for journalists, researchers, academics, and media professionals. Supports Claude Code and Codex.">
+    <meta name="twitter:description" content="64 skills, 13 plugins, and 17 hooks for journalists, researchers, academics, and media professionals. Supports Claude Code and Codex.">
     <meta name="twitter:image" content="https://skills.amditis.tech/og-image.png">
 <script src="ask-ai.js" defer></script>
 
@@ -247,7 +247,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
   "@context": "https://schema.org",
   "@type": "SoftwareSourceCode",
   "name": "Agent skills for journalism",
-  "description": "63 agent skills, 12 plugins, and 17 workflow hooks for verification, FOIA, data journalism, academic writing, and more. Built for journalists, researchers, and media professionals.",
+  "description": "64 agent skills, 13 plugins, and 17 workflow hooks for verification, FOIA, data journalism, academic writing, and more. Built for journalists, researchers, and media professionals.",
   "url": "https://skills.amditis.tech",
   "codeRepository": "https://github.com/jamditis/claude-skills-journalism",
   "programmingLanguage": "Markdown",
@@ -303,7 +303,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <!-- Hero -->
             <header class="mb-32 md:mb-44 animate-page-in">
                 <div class="inline-block px-4 py-1 border border-ink/10 mb-6">
-                    <span class="text-[9px] font-bold tracking-[0.4em] uppercase opacity-50">63 Skills // 12 Plugins // 17 Hooks</span>
+                    <span class="text-[9px] font-bold tracking-[0.4em] uppercase opacity-50">64 Skills // 13 Plugins // 17 Hooks</span>
                 </div>
                 <h1 class="font-display fluid-title text-[11vw] md:text-[8.5vw] font-light leading-[0.85] tracking-tight mb-12 text-ink">
                     Skills for <br> <span class="italic font-black">journalism.</span>
@@ -414,7 +414,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 <div class="deckle-card-solid p-6 md:p-8">
                     <div class="flex flex-col md:flex-row md:items-center justify-between gap-3 mb-4">
                         <h2 class="font-display text-2xl font-light italic">Find a skill</h2>
-                        <span class="section-label" id="finder-count">63 skills, 12 plugins</span>
+                    <span class="section-label" id="finder-count">64 skills, 13 plugins</span>
                     </div>
                     <div class="relative">
                         <i data-lucide="search" class="w-5 h-5 text-mist absolute left-4 top-1/2 -translate-y-1/2 pointer-events-none"></i>
@@ -431,7 +431,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <section id="skills" class="reveal-section mb-32">
                 <div class="section-header flex flex-col md:flex-row md:items-end justify-between gap-4" style="border-bottom: 2px solid rgba(61, 75, 64, 0.2); background: linear-gradient(90deg, rgba(61, 75, 64, 0.04) 0%, transparent 100%); padding: 1rem; margin-bottom: 2rem;">
                     <h2 class="font-display text-4xl font-light italic">01 / Plugins</h2>
-                    <span class="section-label">12 Plugins</span>
+                    <span class="section-label">13 Plugins</span>
                 </div>
 
                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
@@ -598,6 +598,21 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                             <span class="text-[8px] bg-[#4f46e5]/10 text-[#4f46e5] px-2 py-1 rounded font-semibold">Dashboards</span>
                         </div>
                         <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-08-21T15:53:55-04:00" data-updated-slug="video-toolkit">Updated <time datetime="2026-08-21T15:53:55-04:00">Aug 21, 2026</time></p>
+                    </a>
+
+                    <a href="web-design-picker/" class="skill-card skill-card-featured p-6 transition-all duration-300 block group" data-keywords="web design concepts directions client review picker assets cloudflare drop static site">
+                        <div class="flex items-start justify-between mb-3">
+                            <i data-lucide="panels-top-left" class="w-5 h-5 text-[#e85d04]"></i>
+                            <span class="featured-badge" style="background: #12355b;">New plugin</span>
+                        </div>
+                        <h3 class="font-display text-lg font-bold mb-2 group-hover:text-[#b94700] transition-colors">web-design-picker</h3>
+                        <p class="text-sm text-mist leading-relaxed">Distinct website directions, a switchable client review site, downloadable assets, preview images, QA reports, and delivery packages.</p>
+                        <div class="flex flex-wrap gap-2 mt-3">
+                            <span class="text-[8px] bg-[#e85d04]/10 text-[#9a3c00] px-2 py-1 rounded font-semibold">Directions</span>
+                            <span class="text-[8px] bg-[#e85d04]/10 text-[#9a3c00] px-2 py-1 rounded font-semibold">Review</span>
+                            <span class="text-[8px] bg-[#e85d04]/10 text-[#9a3c00] px-2 py-1 rounded font-semibold">Handoff</span>
+                        </div>
+                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T21:33:06-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:33:06-04:00">Sep 1, 2026</time></p>
                     </a>
 
                     <a href="visual-explainer/" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
@@ -783,10 +798,20 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             <section class="reveal-section mb-32">
                 <div class="section-header flex flex-col md:flex-row md:items-end justify-between gap-4">
                     <h2 class="font-display text-4xl font-light italic">04 / Design &amp; production</h2>
-                    <span class="section-label">1 Skill</span>
+                    <span class="section-label">2 Skills</span>
                 </div>
 
                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    <a href="web-design-picker/" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
+                        <div class="flex items-start justify-between mb-3">
+                            <i data-lucide="panels-top-left" class="w-5 h-5 text-[#e85d04]"></i>
+                            <span class="featured-badge" style="background: #12355b;">New</span>
+                        </div>
+                        <h3 class="font-display text-lg font-bold mb-2 group-hover:text-[#b94700] transition-colors">web-design-picker</h3>
+                        <p class="text-sm text-mist leading-relaxed">Build separate design theses, compare them in one review site, and package deployable files and editable assets.</p>
+                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T21:33:06-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:33:06-04:00">Sep 1, 2026</time></p>
+                    </a>
+
                     <a href="visual-explainer/" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
                         <div class="flex items-start justify-between mb-3">
                             <i data-lucide="layout-dashboard" class="w-5 h-5 text-[#2a9a90]"></i>
@@ -1467,7 +1492,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             const defaultCount = countEl ? countEl.textContent : '';
             // Searchable text = visible card text + any data-keywords. The keywords
             // let a parent plugin card (e.g. superjawn, pdf-playground) match the
-                // sub-skills it bundles but doesn't render as their own card, so all 63
+                // sub-skills it bundles but doesn't render as their own card, so all 64
             // advertised skills are findable, not just the cards on the page.
             // The last-updated tape is excluded: it would otherwise make every
             // card match "updated", and any card match the month it changed.

--- a/docs/index.html
+++ b/docs/index.html
@@ -612,7 +612,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                             <span class="text-[8px] bg-[#e85d04]/10 text-[#9a3c00] px-2 py-1 rounded font-semibold">Review</span>
                             <span class="text-[8px] bg-[#e85d04]/10 text-[#9a3c00] px-2 py-1 rounded font-semibold">Handoff</span>
                         </div>
-                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T21:48:47-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:48:47-04:00">Sep 1, 2026</time></p>
+                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T21:57:48-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:57:48-04:00">Sep 1, 2026</time></p>
                     </a>
 
                     <a href="visual-explainer/" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
@@ -809,7 +809,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         </div>
                         <h3 class="font-display text-lg font-bold mb-2 group-hover:text-[#b94700] transition-colors">web-design-picker</h3>
                         <p class="text-sm text-mist leading-relaxed">Build separate design theses, compare them in one review site, and package deployable files and editable assets.</p>
-                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T21:48:47-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:48:47-04:00">Sep 1, 2026</time></p>
+                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T21:57:48-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:57:48-04:00">Sep 1, 2026</time></p>
                     </a>
 
                     <a href="visual-explainer/" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">

--- a/docs/index.html
+++ b/docs/index.html
@@ -612,7 +612,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                             <span class="text-[8px] bg-[#e85d04]/10 text-[#9a3c00] px-2 py-1 rounded font-semibold">Review</span>
                             <span class="text-[8px] bg-[#e85d04]/10 text-[#9a3c00] px-2 py-1 rounded font-semibold">Handoff</span>
                         </div>
-                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T23:18:14-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T23:18:14-04:00">Sep 1, 2026</time></p>
+                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T23:47:14-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T23:47:14-04:00">Sep 1, 2026</time></p>
                     </a>
 
                     <a href="visual-explainer/" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
@@ -809,7 +809,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         </div>
                         <h3 class="font-display text-lg font-bold mb-2 group-hover:text-[#b94700] transition-colors">web-design-picker</h3>
                         <p class="text-sm text-mist leading-relaxed">Build separate design theses, compare them in one review site, and package deployable files and editable assets.</p>
-                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T23:18:14-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T23:18:14-04:00">Sep 1, 2026</time></p>
+                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T23:47:14-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T23:47:14-04:00">Sep 1, 2026</time></p>
                     </a>
 
                     <a href="visual-explainer/" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">

--- a/docs/index.html
+++ b/docs/index.html
@@ -612,7 +612,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                             <span class="text-[8px] bg-[#e85d04]/10 text-[#9a3c00] px-2 py-1 rounded font-semibold">Review</span>
                             <span class="text-[8px] bg-[#e85d04]/10 text-[#9a3c00] px-2 py-1 rounded font-semibold">Handoff</span>
                         </div>
-                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T22:01:12-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T22:01:12-04:00">Sep 1, 2026</time></p>
+                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T23:18:14-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T23:18:14-04:00">Sep 1, 2026</time></p>
                     </a>
 
                     <a href="visual-explainer/" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">
@@ -809,7 +809,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                         </div>
                         <h3 class="font-display text-lg font-bold mb-2 group-hover:text-[#b94700] transition-colors">web-design-picker</h3>
                         <p class="text-sm text-mist leading-relaxed">Build separate design theses, compare them in one review site, and package deployable files and editable assets.</p>
-                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T22:01:12-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T22:01:12-04:00">Sep 1, 2026</time></p>
+                        <p class="updated-tape updated-tape-card mt-4" data-updated-at="2026-09-01T23:18:14-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T23:18:14-04:00">Sep 1, 2026</time></p>
                     </a>
 
                     <a href="visual-explainer/" class="skill-card skill-card-featured p-6 transition-all duration-300 block group">

--- a/docs/interview-prep/index.html
+++ b/docs/interview-prep/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Interview prep</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="interview-prep">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Prepare for journalism interviews with research checklists, question frameworks, and attribution guidelines.
             </p>

--- a/docs/interview-transcription/index.html
+++ b/docs/interview-transcription/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Interview transcription</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="interview-transcription">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Interview management, transcription workflows, and source note-taking from preparation through publication.
             </p>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -12,7 +12,7 @@ Source: https://github.com/jamditis/claude-skills-journalism
 Joe Amditis, associate director of operations, Center for Cooperative Media, Montclair State University.
 Personal site: https://jamditis.com
 
-## Skills (63 total)
+## Skills (64 total)
 
 ### Journalism and verification
 - source-verification, SIFT method, verification trails, source credibility, deepfakes/C2PA
@@ -72,6 +72,7 @@ Personal site: https://jamditis.com
 ### Documents and explainers
 - pdf-design, design and edit professional PDF reports and proposals
 - pdf-playground, document design (proposals, reports)
+- web-design-picker, create distinct website directions, a client review picker, asset catalog, previews, QA reports, and delivery packages
 - visual-explainer, generate self-contained HTML pages that visually explain systems
 - okf-wiki, scaffold an Open Knowledge Format knowledge base (one-concept-per-file markdown, validator, session-start orientation hooks)
 
@@ -148,7 +149,7 @@ codex plugin add journalism-core@claude-skills-journalism
 
 This repository does not ship native Codex manifests. The route does not convert Claude-specific commands, agents, hooks, or root-level skills into Codex components.
 
-Plugins (12): `journalism-core` (15 skills), `research-toolkit` (6), `dev-toolkit` (13), `security-toolkit` (4 skills + /hotpatch command), `project-templates-toolkit` (3), `pdf-design` (1), `pdf-playground` (1), `visual-explainer` (1), `video-toolkit` (4), `okf-wiki` (1), `superjawn` (14), `autocontext` (cross-session knowledge persistence, hooks, commands, and agents rather than skills).
+Plugins (13): `journalism-core` (15 skills), `research-toolkit` (6), `dev-toolkit` (13), `security-toolkit` (4 skills + /hotpatch command), `project-templates-toolkit` (3), `pdf-design` (1), `pdf-playground` (1), `web-design-picker` (1), `visual-explainer` (1), `video-toolkit` (4), `okf-wiki` (1), `superjawn` (14), `autocontext` (cross-session knowledge persistence, hooks, commands, and agents rather than skills).
 
 ## Alternate installation
 

--- a/docs/mobile-debugging/index.html
+++ b/docs/mobile-debugging/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Mobile debugging</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="mobile-debugging">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Remote JavaScript console access and debugging on mobile devices without desktop DevTools.
             </p>

--- a/docs/newsletter-publishing/index.html
+++ b/docs/newsletter-publishing/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Newsletter publishing</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="newsletter-publishing">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Email newsletter workflows for journalists and researchers building direct audience relationships.
             </p>

--- a/docs/newsroom-style/index.html
+++ b/docs/newsroom-style/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Newsroom style</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="newsroom-style">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Enforce AP Style and newsroom conventions for professional journalism writing.
             </p>

--- a/docs/okf-wiki/index.html
+++ b/docs/okf-wiki/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">okf-wiki</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T16:01:04-04:00" data-updated-slug="okf-wiki">Updated <time datetime="2026-08-21T16:01:04-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 One command scaffolds a knowledge base that Claude and your team can both read: small markdown files, one concept each, every fact carrying its own provenance. You get the spec, a validator that fails on a broken or stale concept, and session hooks that point Claude at the bundle before it touches anything.
             </p>

--- a/docs/one-way-door/index.html
+++ b/docs/one-way-door/index.html
@@ -134,6 +134,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">One-way door check</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="one-way-door">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Flag irreversible architectural decisions before you commit to them. The most expensive mistakes aren't bugs, they're decisions that can't be undone.
             </p>

--- a/docs/page-monitoring/index.html
+++ b/docs/page-monitoring/index.html
@@ -161,6 +161,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Page monitoring</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="page-monitoring">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Track web page changes, detect content removal, and preserve important pages before they disappear.
             </p>

--- a/docs/pdf-design/index.html
+++ b/docs/pdf-design/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">PDF design</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T15:53:55-04:00" data-updated-slug="pdf-design">Updated <time datetime="2026-08-21T15:53:55-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Create professional PDF reports and funding proposals with live preview and iterative design.
             </p>

--- a/docs/pdf-playground/index.html
+++ b/docs/pdf-playground/index.html
@@ -197,6 +197,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 PDF<br>Playground
             </h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T15:53:55-04:00" data-updated-slug="pdf-playground">Updated <time datetime="2026-08-21T15:53:55-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl md:text-2xl text-white/90 max-w-2xl mb-10 font-light">
                 Create professional, print-ready documents with your own branding. Perfect for newsrooms, nonprofits, and organizations.
             </p>

--- a/docs/photo-metadata/index.html
+++ b/docs/photo-metadata/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Photo metadata</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="photo-metadata">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Embed caption, credit, alt text, and license inside the image file so the metadata travels wherever the photo goes.
             </p>

--- a/docs/project-memory/index.html
+++ b/docs/project-memory/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Project memory</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="project-memory">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Generate CLAUDE.md project memory files that transfer institutional knowledge, not obvious information.
             </p>

--- a/docs/project-retrospective/index.html
+++ b/docs/project-retrospective/index.html
@@ -147,6 +147,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-bold mb-6 tracking-tight">Project retrospective</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="project-retrospective">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl leading-relaxed">
                 Generate LESSONS.md files that capture institutional knowledge, especially failures. Think like a journalist writing about your own project.
             </p>

--- a/docs/python-pipeline/index.html
+++ b/docs/python-pipeline/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Python pipeline</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="python-pipeline">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Python data processing pipelines with modular architecture for content processing workflows, dispatcher patterns, and batch processing systems.
             </p>

--- a/docs/secure-auth/index.html
+++ b/docs/secure-auth/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Secure auth</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="secure-auth">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Production-ready authentication patterns aligned with NIST SP 800-63B-4, OWASP 2026 cheat sheets, OAuth 2.1, and WebAuthn L3, with breach-driven lessons.
             </p>

--- a/docs/security-checklist/index.html
+++ b/docs/security-checklist/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Security checklist</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="security-checklist">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Pre-deployment security audit organized around the OWASP Top 10:2025 categories. The baseline that prevents obvious disasters, not a substitute for a real penetration test.
             </p>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -277,6 +277,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://skills.amditis.tech/web-design-picker/</loc>
+    <lastmod>2026-09-01</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://skills.amditis.tech/web-scraping/</loc>
     <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>

--- a/docs/social-media-intelligence/index.html
+++ b/docs/social-media-intelligence/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Social media intelligence</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="social-media-intelligence">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Systematic approaches for monitoring, analyzing, and investigating social media for journalism and OSINT.
             </p>

--- a/docs/source-verification/index.html
+++ b/docs/source-verification/index.html
@@ -146,6 +146,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 Source<br>Verification
             </h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T15:00:39-04:00" data-updated-slug="source-verification">Updated <time datetime="2026-08-21T15:00:39-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl md:text-2xl text-white/90 max-w-2xl mb-10 font-light">
                 Systematic approaches for verifying sources, claims, and digital content. Essential for reporters, fact-checkers, and researchers.
             </p>

--- a/docs/story-pitch/index.html
+++ b/docs/story-pitch/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Story pitch</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="story-pitch">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Craft effective story pitches for different publication types and formats. Good stories die in bad pitches.
             </p>

--- a/docs/superjawn/index.html
+++ b/docs/superjawn/index.html
@@ -165,6 +165,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-5xl md:text-7xl font-black leading-[0.9] mb-6">superjawn</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T15:53:55-04:00" data-updated-slug="superjawn">Updated <time datetime="2026-08-21T15:53:55-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl md:text-2xl text-white/90 max-w-2xl mb-4 font-light">Skills that research before they act.</p>
             <p class="text-base md:text-lg text-white/70 max-w-2xl mb-10">A fork of obra/superpowers. Each entry-point skill runs research by default, before brainstorming, before debugging, before writing skills. Stale-artifact consumers get a narrow freshness check. Everything else ports clean.</p>
             <div class="flex flex-wrap gap-4">

--- a/docs/superpowers/plans/2026-09-01-web-design-picker-integration.md
+++ b/docs/superpowers/plans/2026-09-01-web-design-picker-integration.md
@@ -1,0 +1,77 @@
+# Web design picker integration implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superjawn:subagent-driven-development (recommended) or superjawn:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the supplied `web-design-picker` package as an installable, cataloged, and documented standalone plugin.
+
+**Architecture:** Keep the package as a root-skill plugin, matching `visual-explainer` and `okf-wiki`. Import the functional skill files unchanged, then add only the repository metadata and public documentation required by current validators.
+
+**Tech stack:** Agent Skills Markdown, Claude plugin JSON, Codex UI YAML, Python 3.10+, static HTML, Node.js repository validators.
+
+---
+
+## Execution note
+
+Joe approved the design and then directed the primary session to implement locally after delegated workers stalled without changing files. Work proceeds on `feat/web-design-picker`; nothing is pushed or deployed.
+
+### Task 1: Import the approved package
+
+**Files:**
+- Create: `web-design-picker/SKILL.md`
+- Create: `web-design-picker/README.md`
+- Create: `web-design-picker/requirements-optional.txt`
+- Create: `web-design-picker/assets/*`
+- Create: `web-design-picker/examples/*`
+- Create: `web-design-picker/references/*`
+- Create: `web-design-picker/scripts/*`
+
+- [ ] Inspect the ZIP for duplicate, absolute, or parent-traversal paths.
+- [ ] Extract it to a disposable directory and scan the text files for credentials and generated dependency trees.
+- [ ] Copy only the approved functional files. Omit the package-level `CHANGELOG.md`, `LICENSE`, `VERIFICATION.md`, and `manifest.txt`.
+- [ ] Compile all imported Python scripts and run `python web-design-picker/scripts/web_design_picker.py self-test`.
+- [ ] Inspect the imported tree and checkpoint the result.
+
+### Task 2: Register the plugin and skill
+
+**Files:**
+- Create: `web-design-picker/.claude-plugin/plugin.json`
+- Create: `web-design-picker/agents/openai.yaml`
+- Modify: `.claude-plugin/marketplace.json`
+- Modify: `skills-catalog.yaml`
+
+- [ ] Add plugin metadata at version `1.0.0` using the existing author and design-category conventions.
+- [ ] Add stable model-invoked Codex UI metadata with only `display_name` and `short_description`.
+- [ ] Register the package and skill in the marketplace and repository catalog.
+- [ ] Run `npm run validate:catalog` and `npm run validate:agent-skills`.
+
+### Task 3: Add repository and public documentation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `CLAUDE.md`
+- Modify: `CHANGELOG.md`
+- Modify: `docs/index.html`
+- Create: `docs/web-design-picker/index.html`
+
+- [ ] Add the plugin to the installation table, manual-install examples, and design-and-production skill table.
+- [ ] Add the package to the repository map and available-plugin list.
+- [ ] Add one concise Unreleased changelog entry without changing the repository release version.
+- [ ] Add a docs index card and a focused detail page using the existing site design, favicon, accessibility, and updated-stamp hooks.
+- [ ] Run the docs accessibility and updated-stamp checks, then checkpoint the integration diff.
+
+### Task 4: Verify the complete change
+
+- [ ] Run the package self-test again in a disposable directory.
+- [ ] Run Python compilation for all imported scripts.
+- [ ] Run `npm run validate:catalog`, `npm run validate:agent-skills`, `npm test`, `npm run a11y`, and `node scripts/updated-stamp.mjs --check`.
+- [ ] Run `claude plugin validate --strict ./web-design-picker` when the installed CLI supports that command; record an unavailable command as a tooling limitation, not a pass.
+- [ ] Inspect `git diff --check`, the complete diff, paths, line endings, and credential-like strings.
+- [ ] Commit the implementation locally with the configured Joe Amditis noreply identity.
+
+### Task 5: Run the local review gate
+
+- [ ] Run Kimi K3 at low reasoning against the committed local diff and address every finding.
+- [ ] Run Kimi K3 at high reasoning against the post-fix diff and address every finding.
+- [ ] Use Qwen, then Claude Opus 4.8, only if Kimi is unavailable or quota-blocked.
+- [ ] Re-run affected verification after review fixes and leave the branch unpushed for Joe.
+

--- a/docs/superpowers/specs/2026-09-01-web-design-picker-integration-design.md
+++ b/docs/superpowers/specs/2026-09-01-web-design-picker-integration-design.md
@@ -1,0 +1,102 @@
+# Web design picker integration design
+
+## Decision
+
+Add `web-design-picker` as a standalone, top-level Claude Code plugin with one
+root `SKILL.md`. It will use the existing root-skill pattern rather than a
+`skills/web-design-picker/` wrapper.
+
+```text
+web-design-picker/
+├── .claude-plugin/plugin.json
+├── SKILL.md
+├── agents/openai.yaml
+├── assets/
+├── examples/
+├── references/
+├── scripts/
+├── README.md
+└── requirements-optional.txt
+```
+
+The plugin manifest and marketplace entry will both declare version `1.0.0`.
+The repository release-version decision is deferred to implementation, after
+the current release policy is inspected.
+
+## Package contents
+
+Copy from the reviewed ZIP: `SKILL.md`, `assets/`, `examples/`, `references/`,
+`scripts/`, and `requirements-optional.txt`. Keep `assets/manifest.webmanifest`
+because it is a functional static-site asset.
+
+Add a repository-specific `README.md` that documents marketplace installation,
+copy-installation, optional Python dependencies, Playwright, and ffmpeg. Do
+not retain the ZIP instruction to upload the archive directly to an unspecified
+skill host.
+
+Do not copy `CHANGELOG.md`, `VERIFICATION.md`, or `manifest.txt`. The root
+changelog records repository releases; the verification record is specific to
+the source build environment; and the static file inventory would drift.
+Omit the ZIP-local `LICENSE` to match current plugin layout. The repository
+license and `license: MIT` frontmatter remain the license record.
+
+## Repository surfaces
+
+Implementation will add:
+
+- `.claude-plugin/plugin.json` for the new plugin;
+- a `web-design-picker` entry in `.claude-plugin/marketplace.json`, with
+  `source: "./web-design-picker"` and the Design category;
+- package and stable skill entries in `skills-catalog.yaml`;
+- `agents/openai.yaml` with the catalog-required `interface.display_name` and
+  `interface.short_description` fields;
+- a root README plugin-table entry and design-and-production skill-table entry;
+- the plugin in `CLAUDE.md`'s directory map and available-plugin list; and
+- a documentation card plus `docs/web-design-picker/index.html` so the
+  updated-stamp surfaces remain complete.
+
+## Validation
+
+Before release, run:
+
+```text
+npm run validate:catalog
+npm run validate:agent-skills
+node scripts/updated-stamp.mjs --check
+claude plugin validate --strict ./web-design-picker
+claude --plugin-dir ./web-design-picker
+```
+
+Review the imported Python scripts before execution. If their self-test is
+used, run it in a disposable project directory. Browser QA starts a local
+server and needs a Chromium environment that permits local navigation.
+
+No deployment, marketplace publication, or push is part of this work.
+
+## Research notes
+
+- The [Agent Skills specification](https://agentskills.io/specification)
+  requires a directory with `SKILL.md`, YAML frontmatter, a lowercase
+  hyphenated name that matches its directory, and permits `scripts/`,
+  `references/`, and `assets/`.
+- The [Claude Code plugin guide](https://code.claude.com/docs/en/plugins)
+  permits a one-skill plugin to keep `SKILL.md` at the plugin root. It places
+  only `plugin.json` inside `.claude-plugin/`.
+- The [Claude Code marketplace guide](https://code.claude.com/docs/en/plugin-marketplaces)
+  requires marketplace plugin entries to provide a kebab-case name and source.
+- The [Claude Code plugin reference](https://code.claude.com/docs/en/plugins-reference)
+  defines explicit manifest versioning and recommends semantic versioning for
+  published plugins.
+- Closest local examples are `visual-explainer/`, `pdf-design/`, and
+  `okf-wiki/`: each is a top-level plugin with root `SKILL.md`, a plugin
+  manifest, and `agents/openai.yaml`.
+- `scripts/repository-catalog.mjs` requires every marketplace package and
+  `SKILL.md` to appear in `skills-catalog.yaml`; stable skills need
+  `agents/openai.yaml`. `scripts/updated-stamp.mjs` requires matching README
+  and documentation surfaces.
+
+## Scope boundary
+
+This document records the approved design only. It does not add the plugin,
+copy archive files, change catalog or documentation surfaces, run imported
+scripts, publish a marketplace release, deploy, or push.

--- a/docs/supply-chain-hardening/index.html
+++ b/docs/supply-chain-hardening/index.html
@@ -159,6 +159,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Supply-chain hardening</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="supply-chain-hardening">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Install-time cooldowns for npm and bun, plus a sandboxed pre-install scan when the cooldown has to be bypassed. Layered defense against the npm/bun maintainer-compromise pattern that powered Mini Shai-Hulud.
             </p>

--- a/docs/template-selector/index.html
+++ b/docs/template-selector/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Template selector</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="template-selector">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Choose the correct CLAUDE.md or LESSONS.md template for journalism projects. Don't guess - use the decision tree.
             </p>

--- a/docs/test-first-bugs/index.html
+++ b/docs/test-first-bugs/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Test-first bugs</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="test-first-bugs">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Enforce a disciplined bug-fixing workflow that prevents regression and parallelizes fix attempts.
             </p>

--- a/docs/vibe-coding/index.html
+++ b/docs/vibe-coding/index.html
@@ -187,6 +187,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
                 Vibe<br>Coding
             </h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="vibe-coding">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl md:text-2xl text-white/90 max-w-2xl mb-10 font-light">
                 Practical strategies for building software effectively with AI coding assistants like Claude Code, Cursor, and Windsurf.
             </p>

--- a/docs/video-toolkit/index.html
+++ b/docs/video-toolkit/index.html
@@ -70,6 +70,7 @@
             </div>
             <h1 class="font-display text-5xl md:text-7xl font-bold tracking-tight mb-5">Video toolkit</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T15:53:55-04:00" data-updated-slug="video-toolkit">Updated <time datetime="2026-08-21T15:53:55-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl md:text-2xl text-clay leading-relaxed max-w-3xl">
                 Turn public social video into a traceable reporting record: collect clips, transcribe the audio, inspect what appears on screen, and read the whole set through one dashboard.
             </p>

--- a/docs/visual-explainer/index.html
+++ b/docs/visual-explainer/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Visual explainer</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T15:53:55-04:00" data-updated-slug="visual-explainer">Updated <time datetime="2026-08-21T15:53:55-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Generate self-contained HTML pages that visually explain systems, data stories, investigations, editorial workflows, and code changes. Adapted from nicobailon/visual-explainer with journalism design sensibilities.
             </p>

--- a/docs/web-archiving/index.html
+++ b/docs/web-archiving/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Web archiving</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="web-archiving">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Access inaccessible web pages and preserve web content for journalism, research, and legal purposes.
             </p>

--- a/docs/web-design-picker/index.html
+++ b/docs/web-design-picker/index.html
@@ -155,7 +155,7 @@
         <div class="wrap hero-grid">
             <div class="hero-copy">
                 <h1>Three ways in.</h1>
-                <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-09-01T22:01:12-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T22:01:12-04:00">Sep 1, 2026</time></p>
+                <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-09-01T23:18:14-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T23:18:14-04:00">Sep 1, 2026</time></p>
                 <div class="hero-meta">
                     <span class="utility">Web design picker</span>
                 </div>

--- a/docs/web-design-picker/index.html
+++ b/docs/web-design-picker/index.html
@@ -155,7 +155,7 @@
         <div class="wrap hero-grid">
             <div class="hero-copy">
                 <h1>Three ways in.</h1>
-                <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-09-01T21:33:06-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:33:06-04:00">Sep 1, 2026</time></p>
+                <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-09-01T21:33:24-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:33:24-04:00">Sep 1, 2026</time></p>
                 <div class="hero-meta">
                     <span class="utility">Web design picker</span>
                 </div>

--- a/docs/web-design-picker/index.html
+++ b/docs/web-design-picker/index.html
@@ -155,7 +155,7 @@
         <div class="wrap hero-grid">
             <div class="hero-copy">
                 <h1>Three ways in.</h1>
-                <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-09-01T21:57:48-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:57:48-04:00">Sep 1, 2026</time></p>
+                <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-09-01T22:01:12-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T22:01:12-04:00">Sep 1, 2026</time></p>
                 <div class="hero-meta">
                     <span class="utility">Web design picker</span>
                 </div>

--- a/docs/web-design-picker/index.html
+++ b/docs/web-design-picker/index.html
@@ -155,7 +155,7 @@
         <div class="wrap hero-grid">
             <div class="hero-copy">
                 <h1>Three ways in.</h1>
-                <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-09-01T23:18:14-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T23:18:14-04:00">Sep 1, 2026</time></p>
+                <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-09-01T23:47:14-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T23:47:14-04:00">Sep 1, 2026</time></p>
                 <div class="hero-meta">
                     <span class="utility">Web design picker</span>
                 </div>

--- a/docs/web-design-picker/index.html
+++ b/docs/web-design-picker/index.html
@@ -155,7 +155,7 @@
         <div class="wrap hero-grid">
             <div class="hero-copy">
                 <h1>Three ways in.</h1>
-                <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-09-01T21:37:43-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:37:43-04:00">Sep 1, 2026</time></p>
+                <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-09-01T21:48:47-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:48:47-04:00">Sep 1, 2026</time></p>
                 <div class="hero-meta">
                     <span class="utility">Web design picker</span>
                 </div>

--- a/docs/web-design-picker/index.html
+++ b/docs/web-design-picker/index.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Create distinct website directions, compare them in one client review site, and package deployment files and editable design assets.">
+    <title>Web design picker - Agent skills for journalism</title>
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='18' fill='navy'/><text x='50' y='.74em' text-anchor='middle' fill='white' font-size='72' font-family='serif'>W</text></svg>">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=IBM+Plex+Mono:wght@400;500;600&family=Newsreader:opsz,wght@6..72,400;6..72,600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../updated.css">
+    <script src="../ask-ai.js" defer></script>
+    <script src="../updated.js" defer></script>
+    <style>
+        :root {
+            --paper: #f2efe7;
+            --ink: #102238;
+            --navy: #12355b;
+            --orange: #e85d04;
+            --teal: #1b7f79;
+            --blue: #d6e7f5;
+            --line: #9babb8;
+            --white: #fffdf7;
+        }
+
+        * { box-sizing: border-box; }
+        html { scroll-behavior: smooth; }
+        body {
+            margin: 0;
+            color: var(--ink);
+            background:
+                linear-gradient(rgba(18, 53, 91, 0.055) 1px, transparent 1px),
+                linear-gradient(90deg, rgba(18, 53, 91, 0.055) 1px, transparent 1px),
+                var(--paper);
+            background-size: 32px 32px;
+            font-family: "Newsreader", Georgia, serif;
+            font-size: 18px;
+            line-height: 1.6;
+        }
+        a { color: inherit; }
+        a:focus-visible, button:focus-visible { outline: 3px solid var(--orange); outline-offset: 4px; }
+        .skip-link { position: absolute; left: -9999px; top: 0; z-index: 20; }
+        .skip-link:focus { left: 1rem; top: 1rem; padding: 0.7rem 1rem; color: white; background: var(--ink); }
+        .wrap { width: min(1120px, calc(100% - 40px)); margin: 0 auto; }
+        .utility { font: 600 0.76rem/1.3 "IBM Plex Mono", monospace; letter-spacing: 0.08em; text-transform: uppercase; }
+
+        nav {
+            border-bottom: 1px solid var(--line);
+            background: rgba(242, 239, 231, 0.94);
+            backdrop-filter: blur(12px);
+        }
+        nav .wrap { display: flex; align-items: center; justify-content: space-between; min-height: 62px; gap: 1rem; }
+        nav a { text-decoration-thickness: 1px; text-underline-offset: 0.22em; }
+        .install-link { color: var(--white); background: var(--navy); padding: 0.55rem 0.8rem; text-decoration: none; }
+
+        header { padding: clamp(3.5rem, 8vw, 7.5rem) 0 3.5rem; overflow: hidden; }
+        .hero-grid { display: grid; grid-template-columns: minmax(0, 1.05fr) minmax(360px, 0.95fr); gap: clamp(2rem, 6vw, 5rem); align-items: center; }
+        h1, h2, h3 { margin: 0; text-wrap: balance; }
+        h1 {
+            max-width: 760px;
+            font-family: "Archivo Black", sans-serif;
+            font-size: clamp(3.2rem, 8.5vw, 7.4rem);
+            font-weight: 400;
+            letter-spacing: -0.065em;
+            line-height: 0.87;
+        }
+        .hero-copy > p:not(.updated-tape) { max-width: 650px; margin: 2rem 0 0; font-size: clamp(1.18rem, 2vw, 1.55rem); }
+        .hero-meta { display: flex; align-items: center; gap: 1rem; margin-top: 1.35rem; }
+        .updated-tape { margin: 0; }
+
+        .triptych { position: relative; min-height: 500px; }
+        .sheet {
+            position: absolute;
+            width: 76%;
+            aspect-ratio: 0.72;
+            border: 2px solid var(--ink);
+            box-shadow: 10px 12px 0 rgba(16, 34, 56, 0.18);
+            overflow: hidden;
+            opacity: 0;
+            animation: place-sheet 0.75s cubic-bezier(.2,.8,.2,1) forwards;
+        }
+        .sheet::before { content: ""; display: block; height: 9%; border-bottom: 2px solid currentColor; }
+        .sheet::after { content: attr(data-label); position: absolute; left: 1rem; bottom: 0.8rem; font: 600 0.68rem/1 "IBM Plex Mono", monospace; letter-spacing: 0.12em; text-transform: uppercase; }
+        .sheet-a { left: 0; top: 8%; color: var(--white); background: var(--navy); transform: rotate(-8deg); animation-delay: 0.1s; }
+        .sheet-b { right: 0; top: 0; color: var(--ink); background: var(--blue); transform: rotate(7deg); animation-delay: 0.25s; }
+        .sheet-c { left: 13%; top: 21%; color: #23140c; background: #f9a03f; transform: rotate(-1deg); animation-delay: 0.4s; }
+        .sheet-lines { padding: 15% 12%; }
+        .sheet-lines span { display: block; height: 10px; margin-bottom: 15px; background: currentColor; opacity: 0.82; }
+        .sheet-lines span:nth-child(2) { width: 62%; }
+        .sheet-lines span:nth-child(3) { width: 84%; height: 64px; opacity: 0.18; }
+        @keyframes place-sheet { from { opacity: 0; translate: 0 45px; } to { opacity: 1; translate: 0 0; } }
+
+        main { padding-bottom: 7rem; }
+        section { padding: clamp(3rem, 7vw, 6rem) 0; border-top: 1px solid var(--line); }
+        .section-grid { display: grid; grid-template-columns: minmax(180px, 0.33fr) minmax(0, 0.67fr); gap: clamp(2rem, 7vw, 7rem); }
+        .section-grid > * { min-width: 0; }
+        h2 { font-family: "Archivo Black", sans-serif; font-size: clamp(2rem, 4vw, 3.6rem); font-weight: 400; letter-spacing: -0.045em; line-height: 1; }
+        h3 { font-family: "IBM Plex Mono", monospace; font-size: 0.9rem; letter-spacing: 0.06em; text-transform: uppercase; }
+        p { margin: 0 0 1.2rem; }
+        .lede { font-size: clamp(1.35rem, 2.8vw, 2.05rem); line-height: 1.35; }
+        .output-list { list-style: none; margin: 2.5rem 0 0; padding: 0; border-top: 2px solid var(--ink); }
+        .output-list li { display: grid; grid-template-columns: 4.5rem 1fr; gap: 1rem; padding: 1rem 0; border-bottom: 1px solid var(--line); }
+        .output-list b { font-family: "IBM Plex Mono", monospace; color: var(--orange); }
+
+        .directions { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0; border: 2px solid var(--ink); }
+        .direction { min-height: 280px; padding: 1.5rem; border-right: 2px solid var(--ink); }
+        .direction:last-child { border-right: 0; }
+        .direction:nth-child(1) { color: white; background: var(--navy); }
+        .direction:nth-child(2) { background: var(--blue); }
+        .direction:nth-child(3) { background: #f9a03f; }
+        .direction p { margin-top: 6rem; font-size: 1.05rem; }
+
+        pre { margin: 1.5rem 0; padding: 1.35rem; overflow-x: auto; color: #e9f1f7; background: var(--ink); border-left: 7px solid var(--orange); font: 0.82rem/1.65 "IBM Plex Mono", monospace; }
+        code { font-family: "IBM Plex Mono", monospace; }
+        .note { padding: 1.3rem 1.5rem; background: var(--white); border: 1px solid var(--line); }
+        .actions { display: flex; flex-wrap: wrap; gap: 0.8rem; margin-top: 2rem; }
+        .button { padding: 0.78rem 1rem; font: 600 0.82rem/1 "IBM Plex Mono", monospace; text-decoration: none; border: 2px solid var(--ink); }
+        .button-primary { color: white; background: var(--navy); }
+        .button-secondary { background: transparent; }
+        footer { padding: 2rem 0; color: var(--white); background: var(--ink); font: 0.78rem/1.5 "IBM Plex Mono", monospace; }
+
+        @media (max-width: 820px) {
+            .hero-grid, .section-grid { grid-template-columns: minmax(0, 1fr); }
+            .triptych { min-height: 390px; width: min(470px, 100%); }
+            .directions { grid-template-columns: 1fr; }
+            .direction { min-height: auto; border-right: 0; border-bottom: 2px solid var(--ink); }
+            .direction:last-child { border-bottom: 0; }
+            .direction p { margin-top: 2rem; }
+        }
+        @media (max-width: 520px) {
+            .wrap { width: min(100% - 24px, 1120px); }
+            nav .utility { display: none; }
+            h1 { font-size: clamp(3rem, 18vw, 4.8rem); }
+            .triptych { min-height: 320px; }
+            .output-list li { grid-template-columns: 3.5rem 1fr; }
+        }
+        @media (prefers-reduced-motion: reduce) {
+            html { scroll-behavior: auto; }
+            .sheet { opacity: 1; animation: none; }
+        }
+    </style>
+</head>
+<body>
+    <a class="skip-link" href="#main">Skip to main content</a>
+    <nav aria-label="Primary">
+        <div class="wrap">
+            <a href="../">All skills</a>
+            <span class="utility">Design and production / v1.0.0</span>
+            <a class="install-link utility" href="#install">Install</a>
+        </div>
+    </nav>
+
+    <header>
+        <div class="wrap hero-grid">
+            <div class="hero-copy">
+                <h1>Three ways in.</h1>
+                <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-09-01T21:33:06-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:33:06-04:00">Sep 1, 2026</time></p>
+                <div class="hero-meta">
+                    <span class="utility">Web design picker</span>
+                </div>
+                <p>Build separate website design theses, compare them in one client review site, and deliver the selected direction with its assets and deployment package.</p>
+            </div>
+            <div class="triptych" aria-hidden="true">
+                <div class="sheet sheet-a" data-label="Evidence-led"><div class="sheet-lines"><span></span><span></span><span></span></div></div>
+                <div class="sheet sheet-b" data-label="Editorial"><div class="sheet-lines"><span></span><span></span><span></span></div></div>
+                <div class="sheet sheet-c" data-label="Product-first"><div class="sheet-lines"><span></span><span></span><span></span></div></div>
+            </div>
+        </div>
+    </header>
+
+    <main id="main">
+        <section>
+            <div class="wrap section-grid">
+                <h2>What it makes</h2>
+                <div>
+                    <p class="lede">A review package that lets people judge different design arguments in context, then hand off the useful source files without mixing them into the deployment archive.</p>
+                    <ul class="output-list">
+                        <li><b>01</b><span>Two to five standalone responsive concepts, three by default.</span></li>
+                        <li><b>02</b><span>A fullscreen picker with keyboard navigation, URL state, and isolated concept styles.</span></li>
+                        <li><b>03</b><span>A searchable asset catalog with individual, family, and download-all controls.</span></li>
+                        <li><b>04</b><span>Static QA reports, desktop and mobile previews, and separate deployment and handoff ZIPs.</span></li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section>
+            <div class="wrap section-grid">
+                <h2>Distinct by design</h2>
+                <div>
+                    <p class="lede">Each direction changes the information architecture, type, space, geometry, media, interaction, and emotional register. A palette swap does not count.</p>
+                    <div class="directions">
+                        <article class="direction"><h3>Evidence-led</h3><p>Proof, process, and outcomes lead the page.</p></article>
+                        <article class="direction"><h3>Editorial</h3><p>Reading rhythm and narrative sequence carry the argument.</p></article>
+                        <article class="direction"><h3>Product-first</h3><p>The interface and its working parts become the evidence.</p></article>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="install">
+            <div class="wrap section-grid">
+                <h2>Install and run</h2>
+                <div>
+                    <h3>Claude Code marketplace</h3>
+                    <pre><code>/plugin marketplace add jamditis/claude-skills-journalism
+/plugin install web-design-picker@claude-skills-journalism</code></pre>
+                    <h3>Start a project</h3>
+                    <pre><code>python scripts/web_design_picker.py init ./client-site --name "Client name"
+python scripts/web_design_picker.py run ./client-site --strict --test-downloads</code></pre>
+                    <p class="note">Scaffolding and favicon exports require Pillow and resvg-cli. Browser previews require Playwright and Chromium. Video exports require ffmpeg. Generated sites are framework-free static files.</p>
+                    <div class="actions">
+                        <a class="button button-primary" href="https://github.com/jamditis/claude-skills-journalism/tree/master/web-design-picker">View source</a>
+                        <a class="button button-secondary" href="https://github.com/jamditis/claude-skills-journalism/blob/master/web-design-picker/SKILL.md">Read the skill</a>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section>
+            <div class="wrap section-grid">
+                <h2>Release boundary</h2>
+                <div>
+                    <p class="lede">The Cloudflare Drop ZIP starts with <code>index.html</code> and contains only deployable static files. The design-assets ZIP holds editable artwork, tokens, notes, and source derivatives.</p>
+                    <p>Prototype forms must state that they are not connected or download a structured brief. Production submission needs a real endpoint. The QA report records what ran and does not label browser previews complete when Chromium could not open the local test server.</p>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <div class="wrap">Agent skills for journalism · MIT license · Joe Amditis</div>
+    </footer>
+</body>
+</html>

--- a/docs/web-design-picker/index.html
+++ b/docs/web-design-picker/index.html
@@ -155,7 +155,7 @@
         <div class="wrap hero-grid">
             <div class="hero-copy">
                 <h1>Three ways in.</h1>
-                <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-09-01T21:33:24-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:33:24-04:00">Sep 1, 2026</time></p>
+                <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-09-01T21:37:43-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:37:43-04:00">Sep 1, 2026</time></p>
                 <div class="hero-meta">
                     <span class="utility">Web design picker</span>
                 </div>

--- a/docs/web-design-picker/index.html
+++ b/docs/web-design-picker/index.html
@@ -155,7 +155,7 @@
         <div class="wrap hero-grid">
             <div class="hero-copy">
                 <h1>Three ways in.</h1>
-                <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-09-01T21:48:47-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:48:47-04:00">Sep 1, 2026</time></p>
+                <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-09-01T21:57:48-04:00" data-updated-slug="web-design-picker">Updated <time datetime="2026-09-01T21:57:48-04:00">Sep 1, 2026</time></p>
                 <div class="hero-meta">
                     <span class="utility">Web design picker</span>
                 </div>

--- a/docs/web-scraping/index.html
+++ b/docs/web-scraping/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Web scraping</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="web-scraping">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Reliable, ethical web scraping with fallback strategies, access-failure handling, and social media extraction.
             </p>

--- a/docs/web-ui-best-practices/index.html
+++ b/docs/web-ui-best-practices/index.html
@@ -139,6 +139,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Web UI best practices</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T14:21:06-04:00" data-updated-slug="web-ui-best-practices">Updated <time datetime="2026-08-21T14:21:06-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Signs of taste in web UI. The small details that separate polished products from rough ones, speed, restraint, honesty, and respect for the user's time.
             </p>

--- a/docs/zero-build-frontend/index.html
+++ b/docs/zero-build-frontend/index.html
@@ -160,6 +160,7 @@ strong[class~="text-accentDark"], em[class~="text-accentDark"] { color: #1e293b 
             </div>
             <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Zero-build frontend</h1>
             <p class="updated-tape updated-tape-hero mt-5" data-updated-at="2026-08-21T15:00:39-04:00" data-updated-slug="zero-build-frontend">Updated <time datetime="2026-08-21T15:00:39-04:00">Aug 21, 2026</time></p>
+
             <p class="text-xl text-white/90 max-w-2xl">
                 Build production-quality web applications without build tools, bundlers, or complex toolchains.
             </p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-skills-journalism",
-  "version": "2.7.3",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-skills-journalism",
-      "version": "2.7.3",
+      "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
         "playwright": "^1.57.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-skills-journalism",
-  "version": "2.7.3",
+  "version": "2.8.0",
   "description": "Agent Skills for journalists, researchers, academics, media professionals, and communications practitioners.",
   "main": "index.js",
   "scripts": {

--- a/plans/codex-compatibility-matrix.md
+++ b/plans/codex-compatibility-matrix.md
@@ -1,10 +1,10 @@
 # Codex compatibility matrix
 
 - Status: phase-two runtime pilots; journalism-core, visual-explainer, and portable okf-wiki scaffolding have scoped passes
-- Last evidence update: August 28, 2026
+- Last evidence update: September 1, 2026
 - Architecture: [Codex compatibility architecture decision](2026-07-21-codex-compatibility-architecture.md)
 
-> **Historical runtime results stay tied to their tested snapshots.** The v2.7.0
+> **Historical runtime results stay tied to their tested snapshots.** The v2.8.0
 > refresh updates current installation guidance without adding a native Codex
 > marketplace or plugin manifests. Every older version recorded below is the
 > version that was actually exercised. Those values are deliberately not bumped,
@@ -14,11 +14,11 @@
 >
 > The release catalog validation confirms the repository still follows the tested
 > legacy package and Agent Skills routes. It does not convert the older runtime
-> pilots into v2.7.0 runtime evidence.
+> pilots into v2.8.0 runtime evidence.
 
-## August 2026 structure refresh
+## September 2026 structure refresh
 
-- Marketplace 2.7.3 contains 12 Claude packages and 63 shared skills.
+- Marketplace 2.8.0 contains 13 Claude packages and 64 shared skills.
 - Codex can install the 15 nested journalism-core skills through the verified legacy-compatible package route.
 - The Agent Skills route supports root and nested skill layouts without converting Claude commands, agents, or hooks.
 - No native `.agents/plugins/marketplace.json` or `.codex-plugin/plugin.json` manifests are published.
@@ -50,7 +50,7 @@ Status labels:
 | Tool | Version or revision | Role |
 |---|---|---|
 | Codex structure refresh | 0.147.0 | Legacy package and Agent Skills route verification on August 15, 2026 |
-| Claude marketplace, current structure | 2.7.3 | Current catalog and version alignment; historical runtime results below remain snapshot-specific |
+| Claude marketplace, current structure | 2.8.0 | Current catalog and version alignment; historical runtime results below remain snapshot-specific |
 | Repository | `b0617649515d24ebfcd51f15bceb1d76b03db668` | Architecture commit used as the phase-one worktree base |
 | Repository release verification | [`9eef57629edbaa19bf47ec35296acebdd7b4ab1f`](https://github.com/jamditis/claude-skills-journalism/commit/9eef57629edbaa19bf47ec35296acebdd7b4ab1f) | July 23 post-merge `master` head used for the phase-one release evidence |
 | Repository visual-explainer pilot | [`f6a4b84dd2e9feafc6c2bf067f873e9301a083c2`](https://github.com/jamditis/claude-skills-journalism/commit/f6a4b84dd2e9feafc6c2bf067f873e9301a083c2) | July 23 `master` head installed for the V-ex-1 runtime evidence |
@@ -417,6 +417,20 @@ installed directory, frontmatter, and content hash matched. The second update
 left the lock and installed-tree digests unchanged. This is local lock
 migration evidence, not public catalog history or a mixed-install claim.
 
+### Wdp-structure-1: web-design-picker repository preflight
+
+Environment: Windows 11 on Legion with Python 3.13, Node.js 22.17.0, Claude
+Code 2.1.251, and a disposable Python virtual environment on September 1,
+2026.
+
+Result: the root skill passed the pinned Agent Skills validator, the repository
+catalog validator, strict Claude plugin validation, and its own scaffold,
+build, static validation, distinctness, anti-slop, packaging, and browser QA
+self-test. The self-test used Pillow, resvg-cli, Playwright, and Chromium. No Codex
+activation, non-activation, resource-read, runtime, or no-Claude-environment
+fixture ran, so this is repository structure evidence rather than a Codex
+support claim.
+
 ## Package matrix
 
 | Package | Version and components | Current classification | Included and excluded scope | Evidence | Next proof |
@@ -432,6 +446,7 @@ migration evidence, not public catalog history or a mixed-install claim.
 | `security-toolkit` | 1.2.0; four nested skills; one command | Candidate plus Claude-only surface | The four shared skills are candidates. `/security-toolkit:hotpatch` and its sandbox lifecycle remain Claude-only. | [V-phase-1](#v-phase-1-repaired-standards-baseline) covers structure; [R-phase-1](#r-phase-1-phase-one-repository-checks) covers security tests | Test skill activation separately; do not map `hotpatch` without authority and failure-semantics tests. |
 | `superjawn` | 1.0.0; 14 nested skills | Not assessed | No package-wide claim. Each skill needs review for Claude tool names, namespacing, agent dispatch, and parallel-agent assumptions. | [V-phase-1](#v-phase-1-repaired-standards-baseline) covers structure only | Evaluate one skill at a time with client-specific tool traces. Do not bulk-port. |
 | `video-toolkit` | 1.0.6; four nested skills; external media runtimes | Observed manual Codex preflight; durable harness and media execution pending | Include explicit activation, dependency refusal, CPU and no-GPU selection, unrelated non-trigger behavior, and the tested untrusted-transcript boundary as manual observations only. Exclude a repeatable runtime claim, real media, output paths, browser fallback, hosted APIs, and media-parser sandboxing. | [V-tool-preflight-1](#v-tool-preflight-1-video-toolkit-codex-preflight), [V-phase-1](#v-phase-1-repaired-standards-baseline), and [F-phase-1](#f-phase-1-affected-claude-package-regression) | Add a repeatable harness with sanitized raw results, then run pinned local media through transcript, frame, provenance, dashboard, browser, sandbox, resource-cap, and cleanup fixtures. |
+| `web-design-picker` | 1.0.0; one root skill; 16 Python scripts; optional browser and media runtimes | Not assessed for Codex | Include no Codex runtime claim. Repository structure, plugin metadata, deterministic scaffold, build, validation, and packaging are locally checked; Codex activation and runtime behavior remain untested. | [Wdp-structure-1](#wdp-structure-1-web-design-picker-repository-preflight) | Run paired activation, non-activation, installed-resource, disposable-project, and no-Claude-environment fixtures before making a Codex support claim. |
 | `visual-explainer` | 0.7.1; one root skill; eight source commands | Runtime pilot passed on the Codex project-standards path; command surfaces unclaimed | Include the root skill and its relative resources only through `.agents/skills`. The legacy route omits root-skill registration. Its three client-generated command wrappers and all eight source commands remain outside this claim. | [V-ex-release-1](#v-ex-release-1-visual-explainer-root-skill-runtime-pilot), [V-phase-1](#v-phase-1-repaired-standards-baseline), and [Cv-base-1](#cv-base-1-codex-creator-helper-comparison) | Add a no-Claude-environment gate and scheduled runtime regression before a broader package claim; test command wrappers only in a separately scoped issue. |
 
 ## Pilot fixtures

--- a/scripts/codex-compatibility-docs.test.mjs
+++ b/scripts/codex-compatibility-docs.test.mjs
@@ -47,6 +47,7 @@ test('the compatibility matrix classifies every marketplace package', () => {
     'security-toolkit',
     'superjawn',
     'video-toolkit',
+    'web-design-picker',
     'visual-explainer',
   ]);
   assert.match(matrix, /`pdf-playground` \| 1\.3\.2/u);
@@ -89,7 +90,7 @@ test('the compatibility matrix classifies every marketplace package', () => {
     .split('\n')
     .filter((line) => /^\| `[^`]+` \|/u.test(line))
     .map((line) => line.split('|')[5].trim());
-  assert.equal(evidenceCells.length, 12);
+  assert.equal(evidenceCells.length, 13);
   for (const evidence of evidenceCells) {
     assert.match(evidence, /\[[^\]]+\]\(#[^)]+\)/u);
   }
@@ -246,7 +247,7 @@ test('video-toolkit evidence stays limited to the tested preflight', () => {
     matrix,
     /Observed manual Codex preflight; durable harness and media execution pending/u,
   );
-  assert.match(matrix, /Last evidence update: August 28, 2026/u);
+  assert.match(matrix, /Last evidence update: September 1, 2026/u);
   assert.match(matrix, /Codex video-toolkit preflight \| 0\.149\.1/u);
   assert.match(
     matrix,

--- a/scripts/skill-frontmatter.test.mjs
+++ b/scripts/skill-frontmatter.test.mjs
@@ -123,7 +123,7 @@ test('published package versions stay aligned with the marketplace', () => {
   const marketplace = JSON.parse(
     readFileSync(join(ROOT, '.claude-plugin', 'marketplace.json'), 'utf8'),
   );
-  assert.equal(marketplace.version, '2.7.3', 'marketplace version');
+  assert.equal(marketplace.version, '2.8.0', 'marketplace version');
   const expected = new Map([
     ['autocontext', '1.1.2'],
     ['dev-toolkit', '1.4.0'],
@@ -136,6 +136,7 @@ test('published package versions stay aligned with the marketplace', () => {
     ['security-toolkit', '1.2.3'],
     ['superjawn', '1.1.0'],
     ['video-toolkit', '1.0.6'],
+    ['web-design-picker', '1.0.0'],
     ['visual-explainer', '0.7.4'],
   ]);
 

--- a/scripts/video-toolkit-docs.test.mjs
+++ b/scripts/video-toolkit-docs.test.mjs
@@ -40,9 +40,9 @@ test('homepage lists video toolkit once, before visual explainer, with accurate 
   const index = readFileSync(join(DOCS, 'index.html'), 'utf8');
   const skillCount = findSkillFiles().length;
 
-  assert.match(index, new RegExp(`>${skillCount} Skills // 12 Plugins // 17 Hooks`, 'u'));
-  assert.match(index, new RegExp(`id="finder-count">${skillCount} skills, 12 plugins`, 'u'));
-  assert.match(index, />12 Plugins<\/span>/u);
+  assert.match(index, new RegExp(`>${skillCount} Skills // 13 Plugins // 17 Hooks`, 'u'));
+  assert.match(index, new RegExp(`id="finder-count">${skillCount} skills, 13 plugins`, 'u'));
+  assert.match(index, />13 Plugins<\/span>/u);
   assert.equal((index.match(/href="video-toolkit\/"/gu) || []).length, 1);
 
   const pluginsStart = index.indexOf('<!-- Plugins -->');

--- a/skills-catalog.yaml
+++ b/skills-catalog.yaml
@@ -26,6 +26,8 @@ packages:
     source: ./superjawn
   - name: video-toolkit
     source: ./video-toolkit
+  - name: web-design-picker
+    source: ./web-design-picker
   - name: visual-explainer
     source: ./visual-explainer
 skills:
@@ -216,6 +218,9 @@ skills:
   - name: video-transcribe
     package: video-toolkit
     path: video-toolkit/skills/video-transcribe
+  - name: web-design-picker
+    package: web-design-picker
+    path: web-design-picker
   - name: visual-explainer
     package: visual-explainer
     path: visual-explainer

--- a/web-design-picker/.claude-plugin/plugin.json
+++ b/web-design-picker/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "web-design-picker",
+  "description": "Build distinct website directions, a client review picker, asset catalog, previews, and Cloudflare-ready handoff packages.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Joe Amditis",
+    "email": "jamditis@gmail.com"
+  }
+}

--- a/web-design-picker/README.md
+++ b/web-design-picker/README.md
@@ -50,6 +50,7 @@ python scripts/web_design_picker.py validate PROJECT_DIR --strict
 python scripts/web_design_picker.py preview PROJECT_DIR --test-downloads
 python scripts/web_design_picker.py package PROJECT_DIR
 python scripts/web_design_picker.py run PROJECT_DIR --strict --test-downloads
+python scripts/web_design_picker.py run PROJECT_DIR --allow-external  # permit intentional external http(s) references
 ```
 
 The `preview` command requires Playwright and a Chromium environment permitted to open a local HTTP server. Static validation and packaging do not require browser automation.

--- a/web-design-picker/README.md
+++ b/web-design-picker/README.md
@@ -1,0 +1,76 @@
+# web-design-picker
+
+A reusable Agent Skill and static-site factory for presenting two to five genuinely distinct website directions, three by default, in one switchable review site.
+
+The package creates:
+
+- standalone responsive concept pages;
+- a neutral iframe-based direction picker;
+- hash-addressable toggles and keyboard navigation;
+- class-based and browser full-screen presentation modes;
+- a searchable asset catalog;
+- individual asset downloads;
+- browser-generated per-family and all-assets ZIPs;
+- complete favicon families;
+- media, palette, and raster/vector export helpers;
+- static validation, anti-slop review, distinctness scoring, browser QA, screenshots, and deterministic delivery ZIPs;
+- a Cloudflare Drop archive with `index.html` at its root and no nested ZIP.
+
+## Install as a skill
+
+Install the plugin from this repository's Claude Code marketplace:
+
+```text
+/plugin marketplace add jamditis/claude-skills-journalism
+/plugin install web-design-picker@claude-skills-journalism
+```
+
+For a standalone Agent Skills install, copy or link this directory into the agent's skills directory. The root `SKILL.md` contains the operating instructions.
+
+## Command-line use
+
+```bash
+python scripts/web_design_picker.py init ./my-project --name "Client name" --directions 3
+```
+
+Complete the brief and build the actual concepts, then run:
+
+```bash
+python scripts/web_design_picker.py run ./my-project --test-downloads
+```
+
+The Cloudflare-ready file appears in `my-project/deliverables/`.
+
+## Unified command map
+
+```bash
+python scripts/web_design_picker.py init PROJECT_DIR --name "Client name"
+python scripts/web_design_picker.py build PROJECT_DIR
+python scripts/web_design_picker.py validate PROJECT_DIR --strict
+python scripts/web_design_picker.py preview PROJECT_DIR --test-downloads
+python scripts/web_design_picker.py package PROJECT_DIR
+python scripts/web_design_picker.py run PROJECT_DIR --strict --test-downloads
+```
+
+The `preview` command requires Playwright and a Chromium environment permitted to open a local HTTP server. Static validation and packaging do not require browser automation.
+
+## Tool dependencies
+
+Project scaffolding and favicon exports require Pillow and resvg-cli. Browser previews require Playwright and Chromium. Install the declared tools in an isolated environment:
+
+```bash
+python -m pip install -r requirements-optional.txt
+playwright install chromium
+```
+
+Install `ffmpeg` and `ffprobe` through the operating system when video optimization is needed. Existing projects can use the build, static validation, and packaging commands without these media and browser tools.
+
+## Self-test
+
+Install Pillow and resvg-cli before running the default self-test because it scaffolds a fresh project and exports its favicon families.
+
+```bash
+python scripts/web_design_picker.py self-test
+```
+
+Add `--browser` where local Chromium navigation is permitted.

--- a/web-design-picker/SKILL.md
+++ b/web-design-picker/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 # Web design picker
 
-Build a complete website-concept review package rather than isolated mockups. The default deliverable is three materially different, responsive website directions; a review shell that switches among them without losing the presentation context; a full-screen presentation mode; a searchable asset catalog with per-format, per-family, and download-all controls; and two clean release archives.
+Build a complete website-concept review package rather than isolated mockups. The default deliverable is three materially different, responsive website directions; a review shell that switches among them without losing the presentation context; a full-screen presentation mode; a searchable asset catalog with per-format, per-family, and download-all controls; two primary release archives; and supporting review, source, and full-handoff archives.
 
 When invoked for an actual website project, perform the work. Do not stop at a strategy document unless the user asks only for strategy.
 
@@ -171,7 +171,7 @@ python scripts/web_design_picker.py preview PROJECT_DIR --test-downloads
 
 Treat missing files, missing root `index.html`, broken local references, missing favicons, unlabeled controls, unsafe archive paths, nested archives, and oversized deployment assets as release blockers. Treat heuristic slop findings as design-review prompts, not automatic proof of a defect.
 
-### 9. Package two archives
+### 9. Package the release and handoff archives
 
 Run:
 
@@ -183,6 +183,9 @@ Produce:
 
 - `PROJECT_SLUG-cloudflare-drop.zip`: only deployable static files, with `index.html` at the archive root and no enclosing folder or nested ZIP.
 - `PROJECT_SLUG-design-assets.zip`: the full editable/raster asset handoff, manifest, tokens, notes, and source derivatives.
+- `PROJECT_SLUG-review-site.zip`: the review site with its downloadable assets.
+- `PROJECT_SLUG-source-project.zip`: the editable source project and configuration.
+- `PROJECT_SLUG-website-design-handoff.zip`: the full review, source, QA, and delivery bundle.
 
 Follow [the QA and Cloudflare Drop checklist](references/qa-and-cloudflare-drop.md). Never tell the user a site has been deployed when only a ZIP was created.
 

--- a/web-design-picker/SKILL.md
+++ b/web-design-picker/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: web-design-picker
+description: Use when creating distinct website directions, a client review picker, asset catalog, previews, and Cloudflare-ready handoffs.
+license: MIT
+compatibility: Python 3.10+. Build, validation, and packaging use the standard library. Scaffolding and favicon exports require Pillow and resvg-cli; screenshots require Playwright plus Chromium; video exports require ffmpeg. Generated sites are framework-free static files.
+metadata:
+  author: Joe Amditis
+  version: "1.0.0"
+  category: web-design
+---
+
+# Web design picker
+
+Build a complete website-concept review package rather than isolated mockups. The default deliverable is three materially different, responsive website directions; a review shell that switches among them without losing the presentation context; a full-screen presentation mode; a searchable asset catalog with per-format, per-family, and download-all controls; and two clean release archives.
+
+When invoked for an actual website project, perform the work. Do not stop at a strategy document unless the user asks only for strategy.
+
+## Default output contract
+
+Create:
+
+1. Three standalone direction source pages in `src/concepts/`, built into `dist/concepts/`.
+2. One generated review picker at `dist/index.html`.
+3. One generated asset catalog at `dist/design-assets.html`.
+4. Direction-specific logos, favicons, palettes, design tokens, and supporting graphic elements.
+5. Optimized client media when source video or animation is supplied.
+6. Desktop and mobile preview images when browser automation is available.
+7. A lean static deployment ZIP with `index.html` at its root.
+8. A separate complete design-assets handoff ZIP.
+9. A machine-readable and human-readable QA report.
+
+Use `scripts/web_design_picker.py` as the unified command-line entry point for scaffolding, building, validating, browser-testing, and packaging. Read [the workflow reference](references/workflow.md) before beginning a full project.
+
+## Non-negotiable rules
+
+- Build three distinct design theses, not one template with three palettes.
+- Each direction must differ in information architecture, typography, spacing, geometry, media treatment, interaction, and emotional register.
+- Keep each concept independently usable as a static page with its own title, viewport metadata, favicon, accessible navigation, and responsive layout.
+- Use real supplied content and media as evidence. Do not invent capabilities, clients, metrics, certifications, software compatibility, or testimonials.
+- Treat trademarks and product names accurately. Never imply an affiliation that does not exist.
+- Do not use stock imagery merely to fill a composition. Prefer client assets, purposeful diagrams, custom vector elements, crops of real work, or restrained typography.
+- Avoid generic AI-site styling. Apply [the anti-slop guardrails](references/anti-slop-guardrails.md) and run `scripts/slop_lint.py` before packaging.
+- Do not make a fake contact flow. A prototype form may download a structured brief or clearly state that submission is not connected. Production submission requires a real endpoint.
+- Do not bundle font files for handoff unless the user owns redistribution rights. Prefer system fonts, licensed web delivery, or outlined logo artwork.
+- Every direction and the review shell must include a favicon set.
+- Preserve reduced-motion preferences and keyboard operation.
+- Do not place a wrapper folder inside the Cloudflare Drop ZIP. The first archive entry must be `index.html`.
+- Keep the deployment ZIP lean. Do not place the complete handoff ZIP inside it. The asset page should assemble ZIP downloads client-side from individual static files.
+
+## Workflow
+
+### 1. Ingest and establish truth
+
+Inspect the current site, supplied files, brand material, screenshots, source copy, and media. Extract:
+
+- audiences and jobs-to-be-done;
+- actual services or products;
+- strongest proof and differentiators;
+- current conversion path;
+- factual constraints and unknowns;
+- required legal, trademark, privacy, accessibility, or geographic language;
+- reusable and missing assets.
+
+Create a concise source-of-truth brief. Mark every assumption that needs confirmation, but continue with a defensible prototype when the answer is not necessary to build it.
+
+### 2. Define three orthogonal directions
+
+For each direction, write a short thesis containing:
+
+- the perception it should create;
+- the primary audience or buying concern it prioritizes;
+- its information architecture;
+- its typographic and spatial system;
+- its media strategy;
+- its interaction idea;
+- the deliberate tradeoff it makes.
+
+Use [the direction strategy rubric](references/direction-strategy.md). Reject a set when two directions could be made equivalent by changing only colors, fonts, or border radius.
+
+### 3. Design content before decoration
+
+Write a shared factual content model, then decide how each direction edits, sequences, and frames it. A design direction may emphasize different content, but factual claims must stay consistent.
+
+Prefer concrete language: inputs, outputs, process, deliverables, evidence, constraints, next action. Remove boilerplate such as “bringing visions to life,” “innovative solutions,” or “trusted partner” unless the organization has specific evidence supporting it.
+
+### 4. Build the standalone concepts
+
+Create complete responsive HTML pages. Inline CSS and lightweight JavaScript are acceptable; local assets should use relative paths. Each page must:
+
+- have a recognizable opening composition rather than a generic hero-card stack;
+- include real sections with meaningful transitions and hierarchy;
+- make the differentiator prominent rather than burying it in a service grid;
+- use interaction sparingly and purposefully;
+- include labeled form controls when a form is shown;
+- provide an honest prototype behavior;
+- work at approximately 390 px, 768 px, 1280 px, and 1440 px widths;
+- include a direction-specific favicon.
+
+Do at least three passes: content accuracy, visual distinctiveness, and responsive/alignment polish. Then run the anti-slop review.
+
+### 5. Build the asset system
+
+For every direction, export the useful design ingredients, not just screenshots:
+
+- primary mark and monochrome mark;
+- horizontal lockup when applicable;
+- editable SVG and transparent PNG versions;
+- favicon SVG, ICO, 32 px, 180 px, 192 px, and 512 px exports;
+- palette sheet plus CSS and JSON tokens;
+- reusable diagrams, patterns, frames, rules, arrows, icons, or interface graphics;
+- poster images and web media derivatives;
+- notes identifying concept-only marks, licensing limits, or trademark constraints.
+
+Record assets in `config/assets.json`. Follow [the asset catalog and handoff specification](references/asset-catalog-and-handoff.md).
+
+### 6. Optimize media
+
+When video is supplied, inspect representative frames and preserve the content that proves the claim. Create an H.264 MP4 with `faststart`, a WebM when useful, at least one poster frame, and only a short GIF fallback when it has a real presentation use.
+
+Run:
+
+```bash
+python scripts/optimize_video.py INPUT.mp4 OUTPUT_DIR --name demo --width 1280 --fps 24 --poster-times 1.5 --gif
+```
+
+Read [the media and favicon reference](references/media-and-favicons.md) for defaults and exceptions.
+
+### 7. Generate the picker and asset page
+
+Initialize or adapt a project:
+
+```bash
+python scripts/web_design_picker.py init PROJECT_DIR --name "Client website directions" --slug client-site
+```
+
+Replace the starter concepts and assets, update `config/project.json`, `config/directions.json`, and `config/assets.json`, then run:
+
+```bash
+python scripts/web_design_picker.py build PROJECT_DIR
+```
+
+The generated picker must provide:
+
+- persistent direction tabs;
+- accessible tab semantics and live status text;
+- URL hash state;
+- left/right arrow and number-key switching;
+- a full-screen presentation mode with a visible restoration control;
+- a current-direction standalone link;
+- a direct path to the asset catalog;
+- iframe isolation so each design can have an independent CSS system.
+
+The asset catalog must provide:
+
+- grouped, full-width asset rows rather than a bento dashboard;
+- a usable preview for visual assets;
+- direct downloads for every listed variant;
+- a client-side ZIP for each multi-file asset family;
+- a client-side ZIP containing all cataloged assets;
+- search and format/group filters when the asset count warrants them;
+- production, licensing, trademark, and concept-status notes.
+
+### 8. Validate and render
+
+Run:
+
+```bash
+python scripts/web_design_picker.py validate PROJECT_DIR --strict
+python scripts/web_design_picker.py preview PROJECT_DIR --test-downloads
+```
+
+Treat missing files, missing root `index.html`, broken local references, missing favicons, unlabeled controls, unsafe archive paths, nested archives, and oversized deployment assets as release blockers. Treat heuristic slop findings as design-review prompts, not automatic proof of a defect.
+
+### 9. Package two archives
+
+Run:
+
+```bash
+python scripts/web_design_picker.py package PROJECT_DIR
+```
+
+Produce:
+
+- `PROJECT_SLUG-cloudflare-drop.zip`: only deployable static files, with `index.html` at the archive root and no enclosing folder or nested ZIP.
+- `PROJECT_SLUG-design-assets.zip`: the full editable/raster asset handoff, manifest, tokens, notes, and source derivatives.
+
+Follow [the QA and Cloudflare Drop checklist](references/qa-and-cloudflare-drop.md). Never tell the user a site has been deployed when only a ZIP was created.
+
+### 10. Deliver clearly
+
+Give the user direct links to:
+
+- the Cloudflare Drop ZIP;
+- the separate design-assets ZIP;
+- the QA report;
+- the review `index.html` when local artifact linking is available;
+- optional preview screenshots.
+
+State what is functional, what is prototype-only, and what still requires a production backend or owner confirmation.
+
+## Tool map
+
+- `scripts/web_design_picker.py`: unified entry point for `init`, `build`, `validate`, `preview`, `package`, `run`, and `self-test`.
+- `scripts/new_project.py`: scaffold a two-to-five-direction project, three by default.
+- `scripts/build_picker.py`: build the review picker, standalone concepts, and asset catalog.
+- `scripts/run_factory.py`: run the end-to-end build, validation, browser QA, and packaging pipeline.
+- `scripts/optimize_video.py`: produce MP4, WebM, poster, and optional GIF derivatives.
+- `scripts/make_favicons.py`: generate a complete favicon set from an SVG or PNG.
+- `scripts/make_asset_variants.py`: export raster variants while preserving the editable vector.
+- `scripts/make_palette.py`: create palette sheets plus CSS and JSON tokens.
+- `scripts/browser_qa.py`: serve the build locally, test interactions and downloads, and capture desktop/mobile screenshots.
+- `scripts/check_distinctness.py`: enforce material separation among design directions.
+- `scripts/validate_site.py`: inspect static references, metadata, accessibility basics, and Drop constraints.
+- `scripts/package_delivery.py`: create deterministic Cloudflare Drop, review, source, asset, and full-handoff archives.
+- `scripts/slop_lint.py`: flag common generic AI-site patterns for human review.
+- `scripts/validate_skill.py`: validate this skill’s directory and `SKILL.md` metadata.
+
+## Reference loading guide
+
+Read only what the project needs:
+
+- Full project process: [workflow](references/workflow.md)
+- Making the three concepts genuinely different: [direction strategy](references/direction-strategy.md)
+- Avoiding generic AI design tells: [anti-slop guardrails](references/anti-slop-guardrails.md)
+- Catalog structure and export naming: [asset catalog and handoff](references/asset-catalog-and-handoff.md)
+- Video and favicon production: [media and favicons](references/media-and-favicons.md)
+- Release validation and Drop packaging: [QA and Cloudflare Drop](references/qa-and-cloudflare-drop.md)
+- Example prompts and invocation patterns: [examples](examples/prompts.md)

--- a/web-design-picker/agents/openai.yaml
+++ b/web-design-picker/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Web design picker"
+  short_description: "Distinct site directions, review picker, assets, and delivery packages"

--- a/web-design-picker/assets/asset-page.html
+++ b/web-design-picker/assets/asset-page.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="__LANG__">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="__ROBOTS__">
+  <meta name="theme-color" content="__THEME_COLOR__">
+  <title>__PROJECT_NAME__: design assets</title>
+  <meta name="description" content="Downloadable brand and website assets for __PROJECT_NAME__ design directions.">
+  <link rel="icon" href="__FAVICON_SVG__" type="image/svg+xml">
+  <link rel="icon" href="__FAVICON_ICO__" sizes="any">
+  <link rel="apple-touch-icon" href="__TOUCH_ICON__">
+  <style>
+    :root { --ink: #151719; --paper: #f3f2ed; --muted: #5d6366; --line: #a9aca9; --panel: #fff; --accent: __ACTIVE_COLOR__; }
+    * { box-sizing: border-box; }
+    html { background: var(--paper); }
+    body { margin: 0; color: var(--ink); background: var(--paper); font-family: Arial, Helvetica, sans-serif; }
+    a { color: inherit; }
+    :focus-visible { outline: 3px solid #176b87; outline-offset: 3px; }
+    .topbar {
+      position: sticky; top: 0; z-index: 10;
+      display: grid; grid-template-columns: minmax(0, 1fr) auto;
+      align-items: center; gap: 20px; min-height: 68px;
+      padding: 12px max(18px, calc((100vw - 1260px) / 2));
+      color: #fff; background: var(--ink); border-bottom: 1px solid #3f4548;
+    }
+    .topbar strong { display: block; font-size: 14px; letter-spacing: .06em; text-transform: uppercase; }
+    .topbar span { display: block; margin-top: 4px; color: #c1c6c8; font: 12px/1.2 "Courier New", monospace; }
+    .top-actions { display: flex; align-items: stretch; border: 1px solid #666b6d; }
+    .top-actions a, .top-actions button { display: flex; align-items: center; min-height: 40px; padding: 0 14px; border: 0; border-right: 1px solid #666b6d; border-radius: 0; color: #fff; background: transparent; text-decoration: none; font-size: 12px; font-weight: 700; text-transform: uppercase; cursor: pointer; }
+    .top-actions > :last-child { border-right: 0; }
+    .top-actions a:hover, .top-actions button:hover { background: #2b3033; }
+    .top-actions button:disabled { color: #9aa0a3; cursor: progress; }
+    main { width: min(1260px, calc(100% - 36px)); margin: 0 auto; padding: 54px 0 90px; }
+    .intro { display: grid; grid-template-columns: minmax(0, 1.45fr) minmax(260px, .55fr); gap: 50px; padding-bottom: 42px; border-bottom: 2px solid var(--ink); }
+    .intro h1 { max-width: 900px; margin: 0; font-size: clamp(40px, 7vw, 92px); line-height: .93; letter-spacing: -.055em; }
+    .intro p { margin: 4px 0 0; color: var(--muted); font-size: 16px; line-height: 1.55; }
+    .search { align-self: end; }
+    .search label { display: block; margin-bottom: 8px; font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: .06em; }
+    .search input { width: 100%; min-height: 48px; padding: 10px 12px; border: 1px solid var(--ink); border-radius: 0; background: #fff; color: var(--ink); font: 16px/1.2 inherit; }
+    .notes { margin: 28px 0 0; padding: 18px 0; border-bottom: 1px solid var(--line); color: var(--muted); line-height: 1.55; }
+    .download-status { min-height: 22px; margin: 16px 0 0; color: var(--muted); font: 12px/1.45 "Courier New", monospace; }
+    .direction { margin-top: 64px; border-top: 8px solid var(--accent); }
+    .direction > header { display: grid; grid-template-columns: 180px minmax(0, 1fr); gap: 24px; padding: 20px 0 22px; border-bottom: 1px solid var(--ink); }
+    .direction > header p { margin: 4px 0 0; font: 12px/1.3 "Courier New", monospace; text-transform: uppercase; }
+    .direction > header h2 { margin: 0; font-size: clamp(30px, 4vw, 54px); letter-spacing: -.035em; }
+    .asset-row { display: grid; grid-template-columns: minmax(260px, .85fr) minmax(0, 1.15fr); gap: 30px; padding: 28px 0; border-bottom: 1px solid var(--line); }
+    .preview { min-height: 220px; display: grid; place-items: center; overflow: hidden; background: var(--panel); border: 1px solid #d2d4d1; }
+    .preview.checker { background-color: #fff; background-image: linear-gradient(45deg,#e8e8e8 25%,transparent 25%),linear-gradient(-45deg,#e8e8e8 25%,transparent 25%),linear-gradient(45deg,transparent 75%,#e8e8e8 75%),linear-gradient(-45deg,transparent 75%,#e8e8e8 75%); background-size: 24px 24px; background-position: 0 0,0 12px,12px -12px,-12px 0; }
+    .preview img, .preview video { display: block; max-width: 100%; max-height: 420px; object-fit: contain; }
+    .asset-copy h3 { margin: 0; font-size: 25px; letter-spacing: -.02em; }
+    .asset-copy p { max-width: 720px; color: var(--muted); line-height: 1.55; }
+    .meta { font: 12px/1.5 "Courier New", monospace; }
+    .downloads { display: flex; flex-wrap: wrap; border-top: 1px solid var(--ink); margin-top: 20px; }
+    .downloads a, .downloads button { min-width: 94px; padding: 12px 14px; border: 0; border-right: 1px solid var(--ink); border-bottom: 1px solid var(--ink); border-radius: 0; background: transparent; color: inherit; cursor: pointer; text-decoration: none; font-size: 12px; font-weight: 700; text-transform: uppercase; }
+    .downloads a:hover, .downloads button:hover { background: var(--ink); color: #fff; }
+    .graphic-list { padding: 24px 0; border-bottom: 1px solid var(--line); }
+    .graphic-list h3 { margin: 0 0 14px; font-size: 20px; }
+    .graphic-list a { display: inline-block; margin: 0 16px 10px 0; font-size: 14px; }
+    .empty { padding: 48px 0; color: var(--muted); border-bottom: 1px solid var(--line); }
+    footer { padding: 26px max(18px, calc((100vw - 1260px) / 2)); border-top: 1px solid var(--ink); color: var(--muted); font: 12px/1.5 "Courier New", monospace; }
+    [hidden] { display: none !important; }
+    @media (max-width: 760px) {
+      .topbar { grid-template-columns: 1fr; gap: 10px; }
+      .top-actions { width: 100%; }
+      .top-actions a, .top-actions button { flex: 1; justify-content: center; }
+      main { padding-top: 36px; }
+      .intro { grid-template-columns: 1fr; gap: 28px; }
+      .direction > header { grid-template-columns: 1fr; gap: 8px; }
+      .asset-row { grid-template-columns: 1fr; }
+      .preview { min-height: 180px; }
+    }
+    @media (prefers-reduced-motion: reduce) { * { scroll-behavior: auto !important; } }
+  </style>
+</head>
+<body>
+  <header class="topbar">
+    <div><strong>__PROJECT_NAME__</strong><span>Design asset library</span></div>
+    <nav class="top-actions" aria-label="Asset library actions">
+      <a href="index.html">Back to review</a>
+      <a href="asset-manifest.json" download>Manifest</a>
+      __DOWNLOAD_ALL_ACTION__
+    </nav>
+  </header>
+  <main>
+    <section class="intro">
+      <h1>Design assets, separated and ready to use.</h1>
+      <div class="search">
+        <label for="asset-search">Filter assets</label>
+        <input id="asset-search" type="search" placeholder="Logo, favicon, SVG, video…" autocomplete="off">
+      </div>
+    </section>
+    <p class="notes">__LIBRARY_NOTE__</p>
+    <p class="download-status" role="status" aria-live="polite" data-download-status></p>
+    __ASSET_SECTIONS__
+  </main>
+  <footer>__PROJECT_NAME__ / website design review package / __YEAR__</footer>
+  <script>
+    __DOWNLOAD_ALL_SCRIPT__
+
+    const search = document.querySelector('#asset-search');
+    const searchable = [...document.querySelectorAll('[data-search]')];
+    search?.addEventListener('input', () => {
+      const query = search.value.trim().toLowerCase();
+      searchable.forEach(item => { item.hidden = Boolean(query) && !item.dataset.search.toLowerCase().includes(query); });
+      document.querySelectorAll('.direction').forEach(section => {
+        const visible = [...section.querySelectorAll('[data-search]')].some(item => !item.hidden);
+        section.hidden = Boolean(query) && !visible;
+      });
+    });
+  </script>
+</body>
+</html>

--- a/web-design-picker/assets/assets.schema.json
+++ b/web-design-picker/assets/assets.schema.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Design asset library manifest",
+  "type": "object",
+  "properties": {
+    "shared": {
+      "$ref": "#/$defs/groups"
+    },
+    "directions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "label"
+        ],
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "accent": {
+            "type": "string"
+          },
+          "groups": {
+            "$ref": "#/$defs/groups"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "preview": {
+            "type": "string"
+          },
+          "preview_alt": {
+            "type": "string"
+          },
+          "preview_class": {
+            "type": "string"
+          },
+          "meta": {
+            "type": "string"
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "label",
+                "href"
+              ],
+              "properties": {
+                "label": {
+                  "type": "string"
+                },
+                "href": {
+                  "type": "string"
+                },
+                "format": {
+                  "type": "string"
+                },
+                "dimensions": {
+                  "type": "string"
+                },
+                "notes": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "poster": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/web-design-picker/assets/concept-starter.html
+++ b/web-design-picker/assets/concept-starter.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex,nofollow">
+  <title>__PROJECT_NAME__: __DIRECTION_LABEL__</title>
+  <meta name="description" content="__DIRECTION_DESCRIPTION__">
+  <link rel="icon" href="../assets/brand/__DIRECTION_KEY__/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="../assets/brand/__DIRECTION_KEY__/favicon.ico" sizes="any">
+  <link rel="apple-touch-icon" href="../assets/brand/__DIRECTION_KEY__/favicon-180.png">
+  <style>
+    :root { --background: __BACKGROUND__; --text: __TEXT__; --accent: __ACCENT__; --line: __LINE__; }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body { margin: 0; background: var(--background); color: var(--text); font-family: Arial, Helvetica, sans-serif; }
+    a { color: inherit; }
+    :focus-visible { outline: 3px solid var(--accent); outline-offset: 3px; }
+    header, main, footer { width: min(1180px, calc(100% - 36px)); margin-inline: auto; }
+    .site-header { min-height: 76px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--line); }
+    .site-header strong { letter-spacing: .06em; text-transform: uppercase; }
+    .site-header nav { display: flex; gap: 22px; }
+    .hero { min-height: 68vh; display: grid; align-content: center; grid-template-columns: minmax(0, 1.25fr) minmax(280px, .75fr); gap: 56px; border-bottom: 1px solid var(--line); }
+    h1 { margin: 0; font-size: clamp(48px, 8vw, 112px); line-height: .9; letter-spacing: -.06em; }
+    .hero p { margin: 0; align-self: end; font-size: clamp(18px, 2vw, 26px); line-height: 1.35; }
+    .section { padding: 84px 0; border-bottom: 1px solid var(--line); }
+    .section h2 { max-width: 850px; margin: 0 0 28px; font-size: clamp(32px, 5vw, 64px); letter-spacing: -.04em; }
+    .section p { max-width: 760px; font-size: 18px; line-height: 1.6; }
+    footer { padding: 28px 0 42px; }
+    @media (max-width: 760px) {
+      .site-header nav { display: none; }
+      .hero { min-height: auto; grid-template-columns: 1fr; gap: 34px; padding: 74px 0; }
+      .section { padding: 58px 0; }
+    }
+    @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
+  </style>
+</head>
+<body>
+  <header class="site-header">
+    <strong>__PROJECT_NAME__</strong>
+    <nav aria-label="Primary"><a href="#offer">Offer</a><a href="#proof">Proof</a><a href="#process">Process</a><a href="#contact">Start</a></nav>
+  </header>
+  <main>
+    <section class="hero">
+      <h1>Replace this with the direction’s specific promise.</h1>
+      <p>This file is only a semantic scaffold. Rebuild its composition, typography, rhythm, and interactions around the approved direction brief.</p>
+    </section>
+    <section class="section" id="offer"><h2>Explain the offer through concrete deliverables.</h2><p>Do not leave this starter structure intact across all directions. The final concepts should differ materially in architecture and emphasis.</p></section>
+    <section class="section" id="proof"><h2>Feature the strongest evidence.</h2><p>Use real work, tools, media, methods, or outcomes supplied by the user. Avoid invented claims.</p></section>
+    <section class="section" id="process"><h2>Make the working relationship legible.</h2><p>Show inputs, decisions, reviews, and outputs in a form appropriate to this direction.</p></section>
+    <section class="section" id="contact"><h2>Use an honest conversion path.</h2><p>Connect a real endpoint or provide a clearly labeled local prototype action such as downloading a project brief.</p></section>
+  </main>
+  <footer>__PROJECT_NAME__ / __DIRECTION_LABEL__</footer>
+</body>
+</html>

--- a/web-design-picker/assets/directions.schema.json
+++ b/web-design-picker/assets/directions.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Website design directions",
+  "type": "array",
+  "minItems": 2,
+  "items": {
+    "type": "object",
+    "required": [
+      "key",
+      "label",
+      "file"
+    ],
+    "properties": {
+      "key": {
+        "type": "string",
+        "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+      },
+      "label": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "file": {
+        "type": "string"
+      },
+      "accent": {
+        "type": "string"
+      },
+      "background": {
+        "type": "string"
+      },
+      "text": {
+        "type": "string"
+      },
+      "line": {
+        "type": "string"
+      },
+      "tradeoff": {
+        "type": "string"
+      },
+      "favicon_base": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": true
+  },
+  "maxItems": 5
+}

--- a/web-design-picker/assets/generic-favicon.svg
+++ b/web-design-picker/assets/generic-favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#111315"/>
+  <path d="M14 14L32 32L14 50M50 14L32 32L50 50" fill="none" stroke="#fff" stroke-width="5" stroke-linecap="square"/>
+  <path d="M10 56H54" stroke="#ff5a1f" stroke-width="4"/>
+</svg>

--- a/web-design-picker/assets/manifest.webmanifest
+++ b/web-design-picker/assets/manifest.webmanifest
@@ -1,10 +1,10 @@
 {
-  "name": "__PROJECT_NAME__ design review",
-  "short_name": "__SHORT_NAME__",
+  "name": "Website design review",
+  "short_name": "Website",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#111315",
-  "theme_color": "__THEME_COLOR__",
+  "theme_color": "#111315",
   "icons": [
     {"src": "assets/brand/review/favicon-192.png", "sizes": "192x192", "type": "image/png"},
     {"src": "assets/brand/review/favicon-512.png", "sizes": "512x512", "type": "image/png"}

--- a/web-design-picker/assets/manifest.webmanifest
+++ b/web-design-picker/assets/manifest.webmanifest
@@ -1,0 +1,12 @@
+{
+  "name": "__PROJECT_NAME__ design review",
+  "short_name": "__SHORT_NAME__",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#111315",
+  "theme_color": "__THEME_COLOR__",
+  "icons": [
+    {"src": "assets/brand/review/favicon-192.png", "sizes": "192x192", "type": "image/png"},
+    {"src": "assets/brand/review/favicon-512.png", "sizes": "512x512", "type": "image/png"}
+  ]
+}

--- a/web-design-picker/assets/picker-shell.html
+++ b/web-design-picker/assets/picker-shell.html
@@ -211,11 +211,13 @@
       }
     });
     document.addEventListener('keydown', event => {
-      const activeIndex = Math.max(0, tabs.findIndex(tab => tab.getAttribute('aria-selected') === 'true'));
       if (event.key === 'Escape') {
         document.body.classList.remove('presentation');
         return;
       }
+      const sourceTab = event.target.closest?.('[role="tab"]');
+      if (!sourceTab || !tabs.includes(sourceTab)) return;
+      const activeIndex = Math.max(0, tabs.findIndex(tab => tab.getAttribute('aria-selected') === 'true'));
       let targetIndex = null;
       if (event.key === 'ArrowRight') targetIndex = (activeIndex + 1) % tabs.length;
       if (event.key === 'ArrowLeft') targetIndex = (activeIndex - 1 + tabs.length) % tabs.length;

--- a/web-design-picker/assets/picker-shell.html
+++ b/web-design-picker/assets/picker-shell.html
@@ -1,0 +1,235 @@
+<!doctype html>
+<html lang="__LANG__">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="__THEME_COLOR__">
+  <meta name="robots" content="__ROBOTS__">
+  <title>__PAGE_TITLE__</title>
+  <meta name="description" content="__PAGE_DESCRIPTION__">
+  <link rel="icon" href="__FAVICON_SVG__" type="image/svg+xml">
+  <link rel="icon" href="__FAVICON_ICO__" sizes="any">
+  <link rel="apple-touch-icon" href="__TOUCH_ICON__">
+  <link rel="manifest" href="manifest.webmanifest">
+  <style>
+    :root {
+      --review-bar-height: 78px;
+      --shell-bg: #111315;
+      --shell-panel: #252a2d;
+      --shell-hover: #1b1f21;
+      --shell-line: #4b5053;
+      --shell-text: #ffffff;
+      --shell-muted: #b8bec1;
+      --active: __ACTIVE_COLOR__;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; height: 100%; overflow: hidden; background: var(--shell-bg); font-family: Arial, Helvetica, sans-serif; }
+    button, a { font: inherit; }
+    :focus-visible { outline: 3px solid #66d6ff; outline-offset: -3px; }
+    .review-bar {
+      position: relative;
+      z-index: 10;
+      height: var(--review-bar-height);
+      display: grid;
+      grid-template-columns: minmax(220px, .85fr) minmax(500px, 1.75fr) minmax(300px, .9fr);
+      color: var(--shell-text);
+      background: var(--shell-bg);
+      border-bottom: 1px solid var(--shell-line);
+    }
+    .identity {
+      min-width: 0;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 0 20px;
+      border-right: 1px solid var(--shell-line);
+    }
+    .identity img, .identity svg { width: 38px; height: 38px; object-fit: contain; flex: 0 0 auto; }
+    .identity-copy { min-width: 0; }
+    .identity strong { display: block; font-size: 13px; line-height: 1.1; letter-spacing: .07em; text-transform: uppercase; }
+    .identity span { display: block; margin-top: 5px; color: var(--shell-muted); font: 12px/1.2 "Courier New", monospace; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .tabs { display: grid; grid-template-columns: repeat(__DIRECTION_COUNT__, minmax(0, 1fr)); }
+    .tab {
+      border: 0;
+      border-right: 1px solid var(--shell-line);
+      background: transparent;
+      color: var(--shell-muted);
+      padding: 10px 16px;
+      text-align: left;
+      cursor: pointer;
+    }
+    .tab:last-child { border-right: 0; }
+    .tab:hover { color: var(--shell-text); background: var(--shell-hover); }
+    .tab[aria-selected="true"] { color: var(--shell-text); background: var(--shell-panel); box-shadow: inset 0 -5px 0 var(--active); }
+    .tab b { display: block; font-size: 15px; line-height: 1.2; }
+    .tab span { display: block; margin-top: 5px; color: inherit; font: 11px/1.2 "Courier New", monospace; }
+    .actions { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); border-left: 1px solid var(--shell-line); }
+    .actions a, .actions button {
+      min-width: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border: 0;
+      border-right: 1px solid var(--shell-line);
+      background: transparent;
+      color: var(--shell-text);
+      text-decoration: none;
+      text-align: center;
+      padding: 0 10px;
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: .05em;
+      text-transform: uppercase;
+      cursor: pointer;
+    }
+    .actions > :last-child { border-right: 0; }
+    .actions a:hover, .actions button:hover { background: var(--shell-panel); }
+    .stage { position: relative; height: calc(100dvh - var(--review-bar-height)); background: #222; }
+    .concept-frame { position: absolute; inset: 0; width: 100%; height: 100%; border: 0; background: #fff; visibility: hidden; }
+    .concept-frame[data-active="true"] { visibility: visible; }
+    .restore {
+      display: none;
+      position: fixed;
+      z-index: 20;
+      top: 12px;
+      right: 12px;
+      border: 1px solid #fff;
+      background: var(--shell-bg);
+      color: #fff;
+      padding: 11px 14px;
+      font-size: 12px;
+      font-weight: 700;
+      text-transform: uppercase;
+      cursor: pointer;
+    }
+    body.presentation .review-bar { display: none; }
+    body.presentation .stage { height: 100dvh; }
+    body.presentation .restore { display: block; }
+    .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; }
+    @media (max-width: 1060px) {
+      :root { --review-bar-height: 114px; }
+      .review-bar { grid-template-columns: 1fr auto; grid-template-rows: 49px 65px; }
+      .identity { grid-column: 1; grid-row: 1; border-right: 0; padding: 0 14px; }
+      .identity img, .identity svg { width: 30px; height: 30px; }
+      .identity span { display: none; }
+      .actions { grid-column: 2; grid-row: 1; }
+      .tabs { grid-column: 1 / -1; grid-row: 2; border-top: 1px solid var(--shell-line); }
+      .tab { padding: 8px 12px; }
+      .tab span { display: none; }
+    }
+    @media (max-width: 620px) {
+      :root { --review-bar-height: 122px; }
+      .identity strong { font-size: 11px; }
+      .actions { grid-template-columns: 1fr; width: 104px; }
+      .actions a { display: none; }
+      .actions button { border-right: 0; }
+      .tab { padding-inline: 5px; text-align: center; }
+      .tab b { font-size: 12px; }
+    }
+    @media (prefers-reduced-motion: reduce) { * { scroll-behavior: auto !important; } }
+  </style>
+</head>
+<body>
+  <header class="review-bar" aria-label="Design review controls">
+    <div class="identity">
+      __IDENTITY_MARK__
+      <div class="identity-copy">
+        <strong>__PROJECT_NAME__</strong>
+        <span>__REVIEW_SUBTITLE__</span>
+      </div>
+    </div>
+    <nav class="tabs" aria-label="Choose a website direction" role="tablist">
+      __TABS__
+    </nav>
+    <div class="actions">
+      <a href="design-assets.html">Assets</a>
+      <a href="__DEFAULT_STANDALONE__" data-open-selected>Open selected</a>
+      <button type="button" data-presentation>Full-screen view</button>
+    </div>
+  </header>
+  <main class="stage">
+    __FRAMES__
+  </main>
+  <button class="restore" type="button" data-restore>Show design controls</button>
+  <p class="sr-only" aria-live="polite" data-live>__DEFAULT_ANNOUNCEMENT__</p>
+  <script>
+    const directions = __DIRECTIONS_JSON__;
+    const tabs = [...document.querySelectorAll('[role="tab"]')];
+    const frames = [...document.querySelectorAll('.concept-frame')];
+    const live = document.querySelector('[data-live]');
+    const openSelected = document.querySelector('[data-open-selected]');
+    const defaultKey = __DEFAULT_KEY_JSON__;
+
+    function directionFor(key) {
+      return directions.find(direction => direction.key === key) || directions.find(direction => direction.key === defaultKey) || directions[0];
+    }
+
+    function setDesign(requestedKey, updateHash = true, focusTab = false) {
+      const direction = directionFor(requestedKey);
+      if (!direction) return;
+      const key = direction.key;
+      tabs.forEach(tab => {
+        const active = tab.dataset.key === key;
+        tab.setAttribute('aria-selected', String(active));
+        tab.tabIndex = active ? 0 : -1;
+        if (active && focusTab) tab.focus();
+      });
+      frames.forEach(frame => {
+        const active = frame.dataset.key === key;
+        frame.dataset.active = String(active);
+        frame.setAttribute('aria-hidden', String(!active));
+        try {
+          frame.contentDocument?.querySelectorAll('video').forEach(video => {
+            if (active && video.muted && video.autoplay) video.play().catch(() => {});
+            if (!active) video.pause();
+          });
+        } catch (_) {}
+      });
+      if (live) live.textContent = `${direction.label} direction selected.`;
+      if (openSelected) openSelected.href = direction.file;
+      if (updateHash && location.hash !== `#${key}`) history.replaceState(null, '', `#${key}`);
+      document.documentElement.style.setProperty('--active', direction.accent || '__ACTIVE_COLOR__');
+    }
+
+    tabs.forEach(tab => tab.addEventListener('click', () => setDesign(tab.dataset.key)));
+    frames.forEach(frame => frame.addEventListener('load', () => {
+      if (frame.dataset.active !== 'true') {
+        try { frame.contentDocument.querySelectorAll('video').forEach(video => video.pause()); } catch (_) {}
+      }
+    }));
+
+    document.querySelector('[data-presentation]').addEventListener('click', async () => {
+      document.body.classList.add('presentation');
+      try { await document.documentElement.requestFullscreen?.(); } catch (_) {}
+    });
+    document.querySelector('[data-restore]').addEventListener('click', async () => {
+      document.body.classList.remove('presentation');
+      try { if (document.fullscreenElement) await document.exitFullscreen(); } catch (_) {}
+    });
+    document.addEventListener('fullscreenchange', () => {
+      if (!document.fullscreenElement && document.body.classList.contains('presentation')) {
+        document.body.classList.remove('presentation');
+      }
+    });
+    document.addEventListener('keydown', event => {
+      const activeIndex = Math.max(0, tabs.findIndex(tab => tab.getAttribute('aria-selected') === 'true'));
+      if (event.key === 'Escape') {
+        document.body.classList.remove('presentation');
+        return;
+      }
+      let targetIndex = null;
+      if (event.key === 'ArrowRight') targetIndex = (activeIndex + 1) % tabs.length;
+      if (event.key === 'ArrowLeft') targetIndex = (activeIndex - 1 + tabs.length) % tabs.length;
+      if (event.key === 'Home') targetIndex = 0;
+      if (event.key === 'End') targetIndex = tabs.length - 1;
+      if (/^[1-9]$/.test(event.key)) targetIndex = Number(event.key) - 1;
+      if (targetIndex !== null && tabs[targetIndex]) {
+        event.preventDefault();
+        setDesign(tabs[targetIndex].dataset.key, true, true);
+      }
+    });
+    window.addEventListener('hashchange', () => setDesign(location.hash.slice(1), false));
+    setDesign(location.hash.slice(1) || defaultKey, false);
+  </script>
+</body>
+</html>

--- a/web-design-picker/assets/picker-shell.html
+++ b/web-design-picker/assets/picker-shell.html
@@ -120,9 +120,8 @@
     @media (max-width: 620px) {
       :root { --review-bar-height: 122px; }
       .identity strong { font-size: 11px; }
-      .actions { grid-template-columns: 1fr; width: 104px; }
-      .actions a { display: none; }
-      .actions button { border-right: 0; }
+      .actions { grid-template-columns: repeat(3, minmax(0, 1fr)); width: 198px; }
+      .actions a, .actions button { padding: 0 4px; font-size: 11px; line-height: 1.1; letter-spacing: .035em; }
       .tab { padding-inline: 5px; text-align: center; }
       .tab b { font-size: 12px; }
     }
@@ -142,8 +141,8 @@
       __TABS__
     </nav>
     <div class="actions">
-      <a href="design-assets.html">Assets</a>
-      <a href="__DEFAULT_STANDALONE__" data-open-selected>Open selected</a>
+      <a href="design-assets.html">Asset catalog</a>
+      <a href="__DEFAULT_STANDALONE__" data-open-selected>Open concept</a>
       <button type="button" data-presentation>Full-screen view</button>
     </div>
   </header>

--- a/web-design-picker/assets/project.schema.json
+++ b/web-design-picker/assets/project.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Web design picker project configuration",
+  "type": "object",
+  "required": [
+    "name",
+    "slug"
+  ],
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "slug": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "language": {
+      "type": "string",
+      "default": "en"
+    },
+    "review_title": {
+      "type": "string"
+    },
+    "review_subtitle": {
+      "type": "string"
+    },
+    "review_description": {
+      "type": "string"
+    },
+    "theme_color": {
+      "type": "string"
+    },
+    "active_color": {
+      "type": "string"
+    },
+    "robots": {
+      "type": "string"
+    },
+    "default_direction": {
+      "type": "string"
+    },
+    "library_note": {
+      "type": "string"
+    },
+    "review_favicon": {
+      "type": "string"
+    },
+    "asset_zip_name": {
+      "type": "string"
+    },
+    "identity_mark": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": true
+}

--- a/web-design-picker/assets/robots.txt
+++ b/web-design-picker/assets/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/web-design-picker/examples/prompts.md
+++ b/web-design-picker/examples/prompts.md
@@ -1,0 +1,17 @@
+# Invocation examples
+
+## Full redesign exploration
+
+Use the `web-design-picker` skill to redesign this site with three genuinely distinct directions. Research the current site, use the attached brand and product media, make each direction a complete responsive standalone page, then build the comparison picker, full-screen mode, asset catalog, favicon sets, downloadable variants, browser-generated family/all-assets ZIPs, QA reports, and a Cloudflare Drop package. Do not deploy it.
+
+## Existing concepts to package
+
+Use the `web-design-picker` skill to take these three HTML concepts and turn them into one review site. Preserve each concept unchanged except for missing metadata or favicon references. Build the toggler, presentation mode, asset page, design handoff, validation, screenshots, and Cloudflare Drop ZIP.
+
+## Two directions only
+
+Use the `web-design-picker` skill to make two equally complete directions rather than three. One should be evidence-led and editorial; the other should behave like an operational interface. Score their structural distinctness before presenting them.
+
+## Asset-heavy project
+
+Use the `web-design-picker` skill and treat the supplied logos, drawings, UI video, posters, and diagrams as a formal asset library. Export SVG and PNG variants, complete favicon families, optimized MP4/WebM and poster frames, CSS/JSON color tokens, individual downloads, per-family ZIPs, and one all-assets download.

--- a/web-design-picker/references/accessibility.md
+++ b/web-design-picker/references/accessibility.md
@@ -1,0 +1,47 @@
+# Accessibility baseline
+
+The design picker is a prototype, but it should not normalize inaccessible patterns.
+
+## Required on every page
+
+- `<html lang>`
+- descriptive `<title>`
+- viewport meta tag
+- one clear page-level heading
+- semantic landmarks
+- visible keyboard focus
+- labels for form controls
+- useful image alternative text
+- captions or surrounding explanation for product media when needed
+- sufficient text contrast
+- controls that remain usable at 200% zoom
+- `prefers-reduced-motion` handling
+
+## Picker-specific requirements
+
+- tablist/tab roles and `aria-selected`
+- `aria-controls` matching iframe IDs
+- descriptive iframe titles
+- live-region announcement when the selected direction changes
+- keyboard switching with focus management
+- visible way to exit presentation mode
+- actions that do not rely only on color
+
+## Mobile requirements
+
+- no horizontal page overflow at 390 px
+- touch targets generally at least 44 CSS px in one dimension
+- no critical text below a readable size
+- no interaction available only on hover
+- no fixed control that covers important content
+
+## Forms
+
+- labels must remain visible; placeholders are not labels
+- errors must be textual, not color-only
+- do not claim successful submission without a backend response
+- local prototype actions must explain what occurred
+
+## Motion
+
+Do not rely on scroll reveal to expose essential content. Under reduced motion, stop autoplay where appropriate and remove nonessential transitions.

--- a/web-design-picker/references/anti-slop-guardrails.md
+++ b/web-design-picker/references/anti-slop-guardrails.md
@@ -1,0 +1,68 @@
+# Anti-slop guardrails
+
+Use this as a review checklist, not a rigid style ban. A pattern can be valid when the subject, content, and interaction justify it. The failure mode is defaulting to the pattern because it is easy or currently fashionable.
+
+## Supplied design tells
+
+- Leading zeroes before section numbers such as 01, 02, 03.
+- Tiny low-contrast subtext.
+- Fake depth with a box behind another box for no functional reason.
+- Tan sites dominated by oversized calls to action.
+- The same stock “editorial” serif used in generic AI layouts.
+- A small explanatory line above every headline.
+- Bento grids.
+- A random italic word in a headline.
+- Gradient blobs in the background.
+- A genre-claim pill with a glowing dot above the main CTA.
+- Random colored left edges on blocks, buttons, or cards.
+- Eyebrows formatted as a dash plus text.
+- Rounded cards with a colored top or side rule.
+- Eyebrows formatted as chips with dots.
+- Self-justifying subheads only the creator understands.
+- Inconsistent light/dark mode behavior.
+- Defaulting to Geist Mono.
+- Purple gradients or gradient overuse.
+- Excessive glassmorphism.
+- Colors used without semantic logic.
+- Verbose sections that do not help the user decide.
+- Random sliding text carousels.
+- Incorrect strokes around rounded boxes.
+- Defaulting to Inter for everything.
+- Pulsing dots in lists.
+- Generic startup-SaaS styling for unrelated organizations.
+- Oversized custom cursors.
+- Scroll-triggered reveal effects.
+- Pill-shaped everything.
+- Defaulting to Space Grotesk.
+- Contact buttons that only open an email client while pretending to be a form.
+- Purple-heavy pages with no real form.
+- One undifferentiated scroll sequence with no meaningful sections.
+- Newsletter forms that exist only because a template included one.
+- Underlining the random italicized word in a headline.
+
+Original list updated August 25, 2026.
+
+## Review method
+
+For every flagged pattern, ask:
+
+1. What user, content, or brand need does this solve?
+2. Would the page still communicate its idea without it?
+3. Is it repeated because it is part of a coherent system or because the template repeats it?
+4. Does it make the subject feel more specific or more like a generic startup?
+5. Is there a less familiar but clearer solution?
+
+## Stronger alternatives
+
+- Replace decorative eyebrows with direct headings or meaningful metadata.
+- Replace rounded card grids with editorial rows, diagrams, tables, spatial groupings, or full-width sections.
+- Replace gradient atmosphere with a deliberate palette, texture, photography, drawing, or negative space.
+- Replace reveal animation with state change, comparison, layer toggles, or no animation.
+- Replace stock font pairings with type chosen for the organization’s actual voice and licensing context.
+- Replace generic “learn more” CTAs with a concrete next action.
+- Replace a mailto CTA with a real intake flow or an honest downloadable project brief.
+- Replace vague claims with inputs, outputs, process, evidence, or constraints.
+
+## Automated lint limitations
+
+`scripts/slop_lint.py` uses string and CSS heuristics. It will produce false positives and cannot judge whether a pattern is justified. Use it to force a review, not to outsource design judgment.

--- a/web-design-picker/references/asset-catalog-and-handoff.md
+++ b/web-design-picker/references/asset-catalog-and-handoff.md
@@ -1,0 +1,154 @@
+# Asset catalog and handoff specification
+
+## Asset taxonomy
+
+Organize assets by direction and function:
+
+```text
+site/assets/
+├── brand/                         # neutral review-shell identity
+├── direction-a/
+│   ├── logos/
+│   ├── favicons/
+│   ├── palettes/
+│   ├── graphics/
+│   └── previews/
+├── direction-b/
+├── direction-c/
+└── shared/
+    ├── media/
+    └── documents/
+```
+
+The handoff may use a more descriptive hierarchy, but manifest paths must remain valid relative to `site/`.
+
+## Naming
+
+Use lowercase kebab-case filenames. Include meaning before format or size:
+
+- `primary-mark.svg`
+- `primary-mark-512.png`
+- `horizontal-lockup-outlined.svg`
+- `favicon-180.png`
+- `palette.css`
+- `palette.json`
+- `clash-detection-workflow.svg`
+- `software-demo-poster-overview.jpg`
+
+Do not name deliverables `final-final`, `new-logo`, `asset-1`, or `image-copy-2`.
+
+## Required favicon family
+
+For each direction:
+
+- `favicon.svg`
+- `favicon.ico`
+- `favicon-32.png`
+- `favicon-180.png`
+- `favicon-192.png`
+- `favicon-512.png`
+
+The standalone page should reference the SVG, ICO fallback, and touch icon.
+
+## Logo exports
+
+When a direction includes a proposed mark, export:
+
+- editable SVG;
+- outlined SVG when text is present and outlines can be produced safely;
+- transparent PNG at 512 px for a mark;
+- PNG at 1600–2400 px wide for a horizontal lockup;
+- monochrome variant;
+- light/dark variants only when the system actually requires them.
+
+Label concept marks as concept work and do not imply trademark clearance.
+
+## Palette and token exports
+
+Export:
+
+- visual palette sheet in SVG and PNG;
+- CSS custom properties;
+- JSON token file;
+- notes on semantic use, not only hex values.
+
+Example:
+
+```css
+:root {
+  --color-ink: #111315;
+  --color-surface: #f4f3ed;
+  --color-accent: #e45535;
+  --color-line: #8b8f90;
+}
+```
+
+## Manifest schema
+
+`config/assets.json` is the source for the generated catalog. Paths are relative to the built site root:
+
+```json
+{
+  "shared": [
+    {
+      "title": "Shared software demonstration",
+      "description": "Media used across directions.",
+      "preview": "assets/design-package/media/web/demo-poster.jpg",
+      "poster": "assets/design-package/media/web/demo-poster.jpg",
+      "files": [
+        {"label": "MP4", "href": "assets/design-package/media/web/demo.mp4", "format": "MP4"},
+        {"label": "Poster", "href": "assets/design-package/media/web/demo-poster.jpg", "format": "JPG"}
+      ]
+    }
+  ],
+  "directions": [
+    {
+      "key": "direction-a",
+      "label": "Direction A: Evidence ledger",
+      "accent": "#d84a32",
+      "groups": [
+        {
+          "title": "Primary mark",
+          "description": "Working identity mark for the concept.",
+          "preview": "assets/design-package/logos/direction-a/primary-mark.svg",
+          "preview_alt": "Primary mark for Direction A",
+          "files": [
+            {"href": "assets/design-package/logos/direction-a/primary-mark.svg", "label": "SVG"},
+            {"href": "assets/design-package/logos/direction-a/primary-mark-512.png", "label": "PNG 512", "dimensions": "512×512"}
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Every `files[].href`, `preview`, and `poster` path must exist after the build. Keep provenance and licensing notes in `design-package/notes/`.
+
+## Catalog interaction
+
+The generated catalog:
+
+- renders groups as sections and assets as full-width rows;
+- previews images and video;
+- exposes every file variant as a normal download link;
+- generates family and all-assets ZIPs in the browser;
+- reports download progress and failure;
+- preserves relative paths within the generated ZIP;
+- does not require a nested ZIP in the deployed site.
+
+For very large collections, still provide a separate prebuilt handoff ZIP in the release folder. The browser-generated download is a convenience, not the archival source of truth.
+
+## Handoff README
+
+Include:
+
+- project and direction names;
+- concept status;
+- how to use logos and favicons;
+- color and typography notes;
+- source and license notes;
+- trademark or independence language;
+- media provenance;
+- known omissions;
+- which ZIP is for deployment and which is for design handoff.

--- a/web-design-picker/references/content-and-trust.md
+++ b/web-design-picker/references/content-and-trust.md
@@ -1,0 +1,65 @@
+# Content and trust rules
+
+Design credibility depends on factual credibility.
+
+## Build a claim ledger
+
+Before writing marketing copy, classify each statement:
+
+- verified from the existing site or supplied files
+- supplied directly by the user
+- reasonable interpretation that should be labeled as such
+- unverified and therefore excluded
+
+Do not invent:
+
+- clients or partner logos
+- testimonials
+- licenses or certifications
+- software compatibility
+- years of experience
+- turnaround times
+- savings or performance metrics
+- service territory
+- project outcomes
+- security or privacy claims
+
+## Write concrete copy
+
+Prefer:
+
+- inputs, actions, and outputs
+- specific audiences
+- specific deliverables
+- defined review and handoff steps
+- real software, formats, and project stages
+- constraints and boundaries
+
+Avoid generic phrases such as:
+
+- bringing your vision to life
+- where creativity meets precision
+- innovative solutions
+- one-stop shop
+- cutting-edge technology
+- trusted partner
+- tailored solutions for every need
+
+## Conversion integrity
+
+A call to action must lead somewhere real.
+
+Accepted prototype treatments:
+
+- a functioning static intake form that generates a local downloadable brief
+- a secure hosted form endpoint supplied by the user
+- a scheduling or contact system the user has approved
+- a clearly labeled prototype control that does not claim submission
+
+Do not disguise a `mailto:` link as a submitted project-intake workflow.
+
+## Trademark and professional-service boundaries
+
+Use product names accurately. Do not include third-party logos unless permission and source are clear. Add an independence statement when the presentation could imply endorsement.
+
+Do not describe drafting, documentation, consulting, or production support as licensed architecture, engineering, legal, medical, or other regulated professional service unless that status is verified.

--- a/web-design-picker/references/direction-strategy.md
+++ b/web-design-picker/references/direction-strategy.md
@@ -1,0 +1,93 @@
+# Direction strategy rubric
+
+Three directions are useful only when they expose real choices. This rubric prevents “same layout, different paint.”
+
+## Orthogonality test
+
+Score every pair of directions from 0 to 2 in each dimension:
+
+- **0:** effectively the same;
+- **1:** noticeably different but structurally related;
+- **2:** built on a different principle.
+
+| Dimension | A vs B | A vs C | B vs C |
+|---|---:|---:|---:|
+| Positioning and primary message |  |  |  |
+| Information architecture |  |  |  |
+| Hero/opening composition |  |  |  |
+| Typography |  |  |  |
+| Grid and spatial rhythm |  |  |  |
+| Shape/edge language |  |  |  |
+| Color logic |  |  |  |
+| Image/video treatment |  |  |  |
+| Interaction model |  |  |  |
+| CTA and conversion pattern |  |  |  |
+| Emotional register |  |  |  |
+
+A pair should score at least 15 out of 22. If it does not, redesign one direction before presenting.
+
+## Thesis requirements
+
+Every direction must have:
+
+- a name derived from the organizing idea;
+- a clear audience and decision it supports;
+- a dominant visual rule;
+- a dominant content rule;
+- one signature interaction or media behavior;
+- a tradeoff.
+
+Examples of real tradeoffs:
+
+- denser technical information in exchange for stronger expert credibility;
+- fewer pages and shorter copy in exchange for a more forceful first impression;
+- more product-interface language in exchange for less traditional professional-services tone.
+
+A direction without a tradeoff is usually just a styling exercise.
+
+## Ways to create real difference
+
+Change the system, not only the variables:
+
+- linear narrative versus indexed reference;
+- editorial page versus operational dashboard versus cinematic campaign;
+- centered composition versus asymmetric split versus strict modular grid;
+- typography-led versus evidence-led media versus interactive model/video;
+- conventional top navigation versus section index versus persistent utility rail;
+- broad emotional appeal versus technical confidence versus premium restraint;
+- direct project intake versus consultation framing versus proof-first conversion.
+
+## Equal-fidelity rule
+
+All concepts should have comparable:
+
+- content completeness;
+- responsive polish;
+- asset quality;
+- interaction reliability;
+- accessibility baseline;
+- number of real sections;
+- quality of final CTA and footer.
+
+Do not use obviously weaker directions to steer the client toward a predetermined answer.
+
+## Hybridization rule
+
+Do not merge directions during the first presentation. Let reviewers respond to coherent systems. After feedback, identify which principles, rather than isolated decorations, earned support, then create a deliberate synthesis.
+
+## Naming rule
+
+Avoid:
+
+- Option 1 / 2 / 3;
+- Modern / Bold / Clean;
+- Light / Dark / Colorful.
+
+Prefer names that tell the reviewer what the design is doing, such as:
+
+- Field Notes to Final Set;
+- Coordination Console;
+- Across the Handoffs;
+- Public Record;
+- Operating Manual;
+- Local Signal.

--- a/web-design-picker/references/media-and-favicons.md
+++ b/web-design-picker/references/media-and-favicons.md
@@ -79,4 +79,4 @@ Requirements:
 python scripts/make_favicons.py source-mark.svg PROJECT/src/assets/brand/direction-a --background transparent
 ```
 
-The script requires Pillow. SVG input also requires CairoSVG. Inspect 16 px and 32 px results manually; automated resizing cannot fix a mark that is too detailed.
+The script requires Pillow. SVG input also requires resvg-cli. Inspect 16 px and 32 px results manually; automated resizing cannot fix a mark that is too detailed.

--- a/web-design-picker/references/media-and-favicons.md
+++ b/web-design-picker/references/media-and-favicons.md
@@ -1,0 +1,82 @@
+# Media and favicon production
+
+## Video inspection
+
+Before embedding a client video:
+
+1. Read duration, dimensions, frame rate, codec, audio, and file size.
+2. Inspect frames near the beginning, middle, end, and any important interaction.
+3. Identify UI chrome or private information that should be cropped or redacted.
+4. Decide whether the video belongs in a hero, proof section, interface viewport, or case study.
+5. Avoid autoplay with sound.
+
+## Web video defaults
+
+Use H.264 MP4 as the broad fallback:
+
+- H.264, `yuv420p`;
+- `-movflags +faststart`;
+- width no larger than needed for the rendered slot;
+- 20–30 fps for interface demos;
+- no audio unless it adds real information;
+- preserve readable UI detail.
+
+Use WebM when it materially reduces size or improves quality. Supply `<source>` elements and a poster image.
+
+Example:
+
+```html
+<video muted loop playsinline controls poster="assets/shared/media/demo-poster.jpg">
+  <source src="assets/shared/media/demo.webm" type="video/webm">
+  <source src="assets/shared/media/demo.mp4" type="video/mp4">
+</video>
+```
+
+Do not use a large GIF as the primary website format. GIF is a fallback for presentations, email, or tools that cannot play video.
+
+## Poster selection
+
+Choose a frame that:
+
+- clearly demonstrates the claimed capability;
+- remains legible at the intended crop;
+- does not show a loading state, cursor obstruction, private data, or accidental desktop chrome;
+- has enough contrast for any overlaid controls;
+- does not imply a different software product than the one shown.
+
+Export at the video’s rendered aspect ratio, usually JPEG quality 82–88 or WebP quality 75–85.
+
+## Optimization command
+
+```bash
+python scripts/optimize_video.py input.mp4 PROJECT/design-package/media/web \
+  --name software-demo \
+  --width 1280 \
+  --fps 24 \
+  --poster-times 1.5 \
+  --gif
+```
+
+Use `--crop X:Y:W:H` only after visually checking the crop.
+
+## Favicon principles
+
+A favicon is not a shrunken horizontal logo. Use a simple, high-contrast mark that survives 16–32 px rendering.
+
+Requirements:
+
+- square artboard;
+- visible edge clearance;
+- no thin typography;
+- no dependence on subtle gradients;
+- transparent or deliberate background;
+- direction-specific treatment;
+- ICO fallback plus modern SVG/PNG exports.
+
+## Favicon generation
+
+```bash
+python scripts/make_favicons.py source-mark.svg PROJECT/src/assets/brand/direction-a --background transparent
+```
+
+The script requires Pillow. SVG input also requires CairoSVG. Inspect 16 px and 32 px results manually; automated resizing cannot fix a mark that is too detailed.

--- a/web-design-picker/references/preview-picker.md
+++ b/web-design-picker/references/preview-picker.md
@@ -1,0 +1,77 @@
+# Combined preview picker architecture
+
+The picker is a neutral review shell that lets a client compare complete sites without merging their CSS or JavaScript.
+
+## Required structure
+
+```html
+<header class="review-bar">
+  <div class="identity">…</div>
+  <nav role="tablist">…direction tabs…</nav>
+  <div class="actions">
+    <a href="design-assets.html">Assets</a>
+    <a data-open-selected>Open selected</a>
+    <button data-presentation>Full-screen view</button>
+  </div>
+</header>
+<main class="stage">
+  <iframe data-key="direction-a" src="concepts/direction-a.html"></iframe>
+  …
+</main>
+<button data-restore>Show design controls</button>
+<p aria-live="polite" class="sr-only"></p>
+```
+
+Use one iframe per direction. This prevents style collisions and ensures each concept remains a real standalone page.
+
+## State and navigation
+
+- Store selected direction in the URL hash.
+- Read the hash on initial load and `hashchange`.
+- Preserve unknown hashes by falling back to the configured default.
+- Use `aria-selected`, `aria-controls`, meaningful iframe titles, and a live region.
+- Support Left/Right arrows, Home, End, and optional keys 1 through 9.
+- Move focus with keyboard navigation.
+- Update the “Open selected” link whenever the direction changes.
+
+## Media management
+
+When a direction becomes inactive:
+
+- pause all videos inside its same-origin iframe
+- do not reset the current time unless the project requires it
+- attempt playback in the newly active frame only for muted autoplay media
+
+Wrap same-origin iframe access in `try/catch` so the picker does not fail if a future direction is hosted elsewhere.
+
+## Presentation mode
+
+Use a reliable class-based presentation mode:
+
+- hide the review bar
+- expand the stage to the full viewport
+- reveal a small restore control
+- exit on Escape
+
+The browser Fullscreen API may be added as an enhancement, but class-based presentation mode must still work when fullscreen permission is denied.
+
+## Responsive behavior
+
+Desktop:
+
+- project identity, direction tabs, and actions share one bar
+
+Tablet:
+
+- identity and actions occupy the first row
+- tabs occupy a second row
+
+Mobile:
+
+- keep all three direction labels visible
+- shorten supporting descriptions rather than shrinking text below a readable size
+- reduce secondary actions before compressing primary controls
+
+## Visual neutrality
+
+The picker must not make one direction look more important. Use a dark or otherwise neutral shell, consistent tab widths, and no direction-specific theme outside the active indicator.

--- a/web-design-picker/references/qa-and-cloudflare-drop.md
+++ b/web-design-picker/references/qa-and-cloudflare-drop.md
@@ -1,0 +1,131 @@
+# QA and Cloudflare Drop packaging
+
+## Release blockers
+
+Do not package until all of these pass:
+
+- `dist/index.html` exists.
+- Every configured direction entry exists.
+- Every standalone direction has a title, viewport meta tag, `lang`, and favicon.
+- All local `src`, `href`, and `poster` references resolve.
+- Every manifest asset and preview resolves.
+- Images have `alt` text unless explicitly decorative.
+- Form controls have associated labels or accessible names.
+- Buttons have a type.
+- Videos have usable sources and do not autoplay with sound.
+- No archive path is absolute or contains `..`.
+- No `.DS_Store`, temporary file, secret, source map, dependency directory, or build cache is included.
+- No nested ZIP is included in the deployment archive.
+- The deployment archive opens and passes CRC testing.
+- `index.html` is the first archive entry and is located at the archive root.
+
+## Visual QA widths
+
+At minimum inspect:
+
+- 390 × 844;
+- 768 × 1024;
+- 1280 × 800;
+- 1440 × 1000.
+
+Check:
+
+- no horizontal overflow;
+- no clipped nav, heading, button, form, iframe, or media;
+- readable line lengths;
+- intentional image and video crops;
+- stable section spacing;
+- no control bar overlap in the review picker;
+- full-screen restoration control remains visible;
+- focus state is visible;
+- reduced motion does not hide content.
+
+## Static reference rules
+
+Treat these as local and verify them:
+
+- relative paths;
+- root-relative paths when the deployment target supports them;
+- CSS `url()` references;
+- `srcset` entries;
+- video `<source>` paths;
+- manifest icon paths.
+
+Ignore normal external `https:`, `mailto:`, `tel:`, data URLs, and page fragments, but report them for review.
+
+## Cloudflare Drop archive
+
+The release ZIP should look like this when opened:
+
+```text
+index.html
+favicon.ico
+manifest.webmanifest
+robots.txt
+concepts/
+assets/
+design-assets.html
+```
+
+It must not look like:
+
+```text
+project-name/
+  dist/
+    index.html
+```
+
+or:
+
+```text
+index.html
+source/
+node_modules/
+complete-design-assets.zip
+```
+
+The builder creates deterministic, cross-platform ZIP metadata, stores already-compressed media without recompressing it, and keeps the deployment handoff separate.
+
+## Size policy
+
+Default hard limit per static file: 25,000,000 bytes. Set a lower project-specific limit when practical.
+
+Recommended targets:
+
+- deployment ZIP below 20 MiB when media permits;
+- ordinary images below 500 KiB;
+- hero/poster images below 1.5 MiB;
+- video sized to actual display need;
+- no duplicate MP4/WebM/GIF unless each serves an explicit fallback purpose.
+
+## Local smoke test
+
+Serve `dist` through HTTP, not `file://`:
+
+```bash
+python -m http.server 8123 --directory PROJECT_DIR/dist
+```
+
+Test:
+
+- direct root load;
+- each direction hash;
+- each standalone concept URL;
+- asset catalog;
+- individual download links;
+- family ZIP generation;
+- all-assets ZIP generation;
+- full-screen and restore;
+- browser console and network errors.
+
+## Release language
+
+Use precise status terms:
+
+- **built:** files were generated;
+- **validated:** automated checks passed;
+- **previewed:** screenshots or browser inspection occurred;
+- **packaged:** ZIPs were created;
+- **deployed:** a host returned a live URL.
+
+Never substitute one status for another.

--- a/web-design-picker/references/troubleshooting.md
+++ b/web-design-picker/references/troubleshooting.md
@@ -1,0 +1,56 @@
+# Troubleshooting
+
+## Host says “Something went wrong”
+
+Check in this order:
+
+1. Is `index.html` at ZIP root?
+2. Is there an unnecessary enclosing directory?
+3. Does the ZIP contain another large ZIP?
+4. Are there symlinks, absolute paths, or path traversal entries?
+5. Are filenames using unusual characters?
+6. Is an individual file unusually large?
+7. Does the archive pass CRC/integrity testing?
+8. Does the extracted site work through a local HTTP server?
+9. Do all HTML references remain inside the extracted root?
+
+Repackage from a clean staging directory rather than modifying the failed ZIP in place.
+
+## Picker shows a blank frame
+
+- open the standalone concept URL directly
+- inspect the iframe `src`
+- verify filename case
+- use a local HTTP server rather than `file://`
+- check whether a restrictive Content Security Policy blocks framing
+- verify the concept does not redirect to an external origin
+
+## Videos do not autoplay
+
+- ensure `muted` and `playsinline` are present
+- provide a poster so the page still communicates the idea
+- do not depend on autoplay for essential information
+- test whether the browser blocks autoplay because audio remains
+
+## Download link does nothing
+
+- confirm the file exists at the resolved relative path
+- avoid links to container or conversation-only locations
+- use actual files rather than data URLs for large downloads
+- verify the host serves the file type
+
+## Favicon is missing
+
+- provide SVG and ICO fallbacks
+- make paths relative to each page depth
+- include a root `/favicon.ico` only when the host root is stable
+- clear browser cache during testing
+- verify small-size legibility
+
+## Three directions look too similar
+
+Return to the distinctness matrix. Change page architecture and content emphasis before changing decorative details. Different typography or color is not enough.
+
+## Site looks generic
+
+Remove decorative conventions, then rebuild around the strongest evidence, the client’s actual working materials, and a specific organizing metaphor.

--- a/web-design-picker/references/workflow.md
+++ b/web-design-picker/references/workflow.md
@@ -1,0 +1,119 @@
+# End-to-end workflow
+
+Use this sequence for every website picker project. The goal is not merely to generate three HTML pages. The goal is to create a fair, credible, client-usable design decision environment.
+
+## Phase A: intake and evidence
+
+1. Read the existing site, brief, attachments, and prior decisions.
+2. Inventory factual content and source assets.
+3. Identify the primary audience, decision, and conversion action.
+4. Identify the most defensible differentiator or proof point.
+5. Record uncertainties. Do not convert uncertainties into claims.
+6. Confirm whether the final output is a local package, Cloudflare Drop ZIP, another static host, or a live deployment.
+
+Recommended working notes:
+
+```text
+Audience:
+Problem the site solves:
+Primary promise:
+Strongest evidence:
+Required pages/sections:
+Primary conversion:
+Secondary conversion:
+Provided assets:
+Restrictions:
+Unverified claims:
+Hosting target:
+```
+
+## Phase B: content model
+
+Build one canonical content outline before visual exploration. The three directions should use the same content facts, though order and emphasis can differ.
+
+Minimum content model:
+
+- identity and positioning
+- audience-specific needs
+- concrete services or offers
+- inputs, process, and outputs
+- proof, differentiator, product, or case study
+- trust and risk reduction
+- conversion path
+- footer and contact information
+
+Create concise copy. A design picker becomes less useful when one direction is visibly stronger only because it received better writing.
+
+## Phase C: direction briefs
+
+Write three one-page direction briefs. Each must answer:
+
+- What strategic idea does this direction embody?
+- What should a visitor feel within five seconds?
+- What is the visual grammar?
+- Where does the proof live?
+- How is navigation handled?
+- What is the interaction ceiling?
+- What conventions does it reject?
+- What kind of client would choose it?
+
+Complete `DIRECTION-BRIEFS.md` and score every pair in `config/distinctness.json` before final packaging.
+
+## Phase D: asset preparation
+
+1. Preserve originals in a source directory.
+2. Rename working copies with predictable lowercase names.
+3. Optimize supplied video and create posters.
+4. Extract or redraw only graphics that can be represented accurately.
+5. Create favicon sets for the review shell and each direction.
+6. Prepare an asset manifest before the asset page is built.
+
+Never overwrite the only copy of an original asset.
+
+## Phase E: standalone directions
+
+Build each direction as its own HTML document and its own design system. Shared factual media may be referenced from a common assets directory, but direction styling must not leak through the parent picker.
+
+A direction is ready only when it has enough sections to judge hierarchy, rhythm, proof, conversion, and responsive behavior.
+
+## Phase F: picker and asset page
+
+1. Generate the review shell from `config/directions.json`.
+2. Load each direction in an iframe.
+3. Add hash-based direct links and keyboard switching.
+4. Add presentation mode and restore controls.
+5. Generate the asset page from `config/assets.json`.
+6. Expose every variant as a normal download and generate family/all-assets ZIPs in the browser.
+7. Package a separate archival design-assets ZIP while keeping the Cloudflare Drop ZIP free of nested archives.
+
+## Phase G: QA
+
+Run both machine and visual checks:
+
+- broken references and missing downloads
+- HTML metadata and favicon declarations
+- labels and alternative text
+- desktop, tablet, and mobile overflow
+- tab switching and URL hashes
+- full-screen/presentation restore behavior
+- video playback and inactive pausing
+- asset downloads
+- static hosting under a local HTTP server
+- ZIP extraction and root structure
+- anti-slop review
+- factual claim review
+
+Fix issues and repeat. Screenshots are evidence, not decoration.
+
+## Phase H: delivery
+
+Return clearly labeled files:
+
+- combined review site or its ZIP
+- Cloudflare Drop ZIP
+- design-assets ZIP
+- source-project ZIP
+- optional standalone HTML files
+- optional screenshots and QA report
+
+Do not call a local file a published site. Do not call an upload package a deployment.

--- a/web-design-picker/references/workflow.md
+++ b/web-design-picker/references/workflow.md
@@ -113,6 +113,7 @@ Return clearly labeled files:
 - Cloudflare Drop ZIP
 - design-assets ZIP
 - source-project ZIP
+- website-design-handoff ZIP
 - optional standalone HTML files
 - optional screenshots and QA report
 

--- a/web-design-picker/requirements-optional.txt
+++ b/web-design-picker/requirements-optional.txt
@@ -1,0 +1,4 @@
+Pillow>=10
+playwright>=1.45
+PyYAML>=6
+resvg-cli>=0.44

--- a/web-design-picker/scripts/_common.py
+++ b/web-design-picker/scripts/_common.py
@@ -19,6 +19,12 @@ ALREADY_COMPRESSED = {
     ".mp3", ".mp4", ".pdf", ".png", ".webm", ".webp", ".zip",
 }
 SLUG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+OUTPUT_STEM_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+WINDOWS_RESERVED_NAMES = {
+    "con", "prn", "aux", "nul", "clock$",
+    *(f"com{number}" for number in range(1, 10)),
+    *(f"lpt{number}" for number in range(1, 10)),
+}
 SECRET_SUFFIXES = {".key", ".pem", ".p12", ".pfx", ".pkcs12", ".jks", ".keystore"}
 SSH_PRIVATE_KEY_NAMES = {
     "id_rsa", "id_dsa", "id_ecdsa", "id_ecdsa_sk", "id_ed25519",
@@ -40,6 +46,19 @@ def slugify(value: str) -> str:
 def validate_slug(value: str) -> str:
     if not isinstance(value, str) or not SLUG_PATTERN.fullmatch(value):
         raise ValueError("Slug must contain lowercase letters, numbers, and single hyphens only")
+    return value
+
+
+def validate_output_stem(value: str) -> str:
+    """Accept one portable output-file stem, without any path semantics."""
+    if not isinstance(value, str) or not value or value in {".", ".."}:
+        raise ValueError("Output name must be a non-empty filename stem")
+    if value.endswith((".", " ")) or "/" in value or "\\" in value or Path(value).is_absolute():
+        raise ValueError("Output name must be a single filename stem")
+    if not OUTPUT_STEM_PATTERN.fullmatch(value):
+        raise ValueError("Output name may contain only letters, numbers, dots, underscores, and hyphens")
+    if value.casefold().split(".", 1)[0] in WINDOWS_RESERVED_NAMES:
+        raise ValueError("Output name uses a reserved Windows device name")
     return value
 
 

--- a/web-design-picker/scripts/_common.py
+++ b/web-design-picker/scripts/_common.py
@@ -18,6 +18,7 @@ ALREADY_COMPRESSED = {
     ".7z", ".avif", ".gif", ".gz", ".ico", ".jpeg", ".jpg", ".mov",
     ".mp3", ".mp4", ".pdf", ".png", ".webm", ".webp", ".zip",
 }
+SLUG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 
 
 def slugify(value: str) -> str:
@@ -25,6 +26,12 @@ def slugify(value: str) -> str:
     value = re.sub(r"[^a-z0-9]+", "-", value)
     value = re.sub(r"-+", "-", value).strip("-")
     return value or "website-project"
+
+
+def validate_slug(value: str) -> str:
+    if not isinstance(value, str) or not SLUG_PATTERN.fullmatch(value):
+        raise ValueError("Slug must contain lowercase letters, numbers, and single hyphens only")
+    return value
 
 
 def read_json(path: Path) -> Any:
@@ -183,6 +190,10 @@ def load_project(project_root: Path) -> tuple[dict[str, Any], list[dict[str, Any
     assets = read_json(config / "assets.json")
     if not isinstance(project, dict):
         raise SystemExit("project.json must contain a JSON object")
+    try:
+        validate_slug(project.get("slug"))
+    except ValueError as exc:
+        raise SystemExit(f"project.json has an invalid slug: {exc}") from exc
     if not isinstance(directions, list) or not 2 <= len(directions) <= 5:
         raise SystemExit("directions.json must contain two to five directions")
     if not isinstance(assets, dict):

--- a/web-design-picker/scripts/_common.py
+++ b/web-design-picker/scripts/_common.py
@@ -68,6 +68,7 @@ def format_bytes(size: int) -> str:
 
 
 def copy_contents(source: Path, destination: Path, *, overwrite: bool = True) -> None:
+    reject_symlinks(source)
     if not source.exists():
         return
     destination.mkdir(parents=True, exist_ok=True)
@@ -78,6 +79,21 @@ def copy_contents(source: Path, destination: Path, *, overwrite: bool = True) ->
         elif overwrite or not target.exists():
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(item, target)
+
+
+def reject_symlinks(root: Path, *, exclude_names: set[str] | None = None) -> None:
+    """Fail before copying a tree that could follow an external link."""
+    exclude_names = exclude_names or set()
+    if root.is_symlink():
+        raise ValueError(f"Symlinks are not allowed in delivery packages: {root}")
+    if not root.exists():
+        return
+    for path in root.rglob("*"):
+        relative = path.relative_to(root)
+        if any(part in exclude_names for part in relative.parts):
+            continue
+        if path.is_symlink():
+            raise ValueError(f"Symlinks are not allowed in delivery packages: {path}")
 
 
 def safe_archive_path(relative_path: Path) -> str:

--- a/web-design-picker/scripts/_common.py
+++ b/web-design-picker/scripts/_common.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Shared helpers for the web-design-picker skill."""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import shutil
+import tempfile
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+FIXED_ZIP_TIME = (2026, 1, 1, 0, 0, 0)
+ALREADY_COMPRESSED = {
+    ".7z", ".avif", ".gif", ".gz", ".ico", ".jpeg", ".jpg", ".mov",
+    ".mp3", ".mp4", ".pdf", ".png", ".webm", ".webp", ".zip",
+}
+
+
+def slugify(value: str) -> str:
+    value = value.strip().lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    value = re.sub(r"-+", "-", value).strip("-")
+    return value or "website-project"
+
+
+def read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise SystemExit(f"Required JSON file not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Invalid JSON in {path}: {exc}") from exc
+
+
+def write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def format_bytes(size: int) -> str:
+    units = ["B", "KiB", "MiB", "GiB"]
+    value = float(size)
+    for unit in units:
+        if value < 1024 or unit == units[-1]:
+            return f"{value:.0f} {unit}" if unit == "B" else f"{value:.2f} {unit}"
+        value /= 1024
+    return f"{size} B"
+
+
+def copy_contents(source: Path, destination: Path, *, overwrite: bool = True) -> None:
+    if not source.exists():
+        return
+    destination.mkdir(parents=True, exist_ok=True)
+    for item in source.iterdir():
+        target = destination / item.name
+        if item.is_dir():
+            shutil.copytree(item, target, dirs_exist_ok=True)
+        elif overwrite or not target.exists():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(item, target)
+
+
+def safe_archive_path(relative_path: Path) -> str:
+    if relative_path.is_absolute() or ".." in relative_path.parts:
+        raise ValueError(f"Unsafe archive path: {relative_path}")
+    return relative_path.as_posix()
+
+
+def iter_files(root: Path, *, exclude_names: set[str] | None = None) -> Iterable[Path]:
+    exclude_names = exclude_names or set()
+    for path in sorted(root.rglob("*")):
+        if path.is_symlink():
+            raise ValueError(f"Symlinks are not allowed in delivery packages: {path}")
+        if path.is_file() and not any(part in exclude_names for part in path.parts):
+            yield path
+
+
+def _zip_order(path: Path, root: Path) -> tuple[int, str]:
+    relative = path.relative_to(root).as_posix()
+    # Static hosts are happiest when the entry point is obvious and first.
+    return (0 if relative == "index.html" else 1, relative)
+
+
+def deterministic_zip(
+    source_dir: Path,
+    output_zip: Path,
+    *,
+    include_root: bool = False,
+    exclude_suffixes: tuple[str, ...] = (),
+    exclude_names: set[str] | None = None,
+    allow_zip64: bool = False,
+) -> dict[str, Any]:
+    """Create a deterministic, portable ZIP and test its CRCs.
+
+    Media that is already compressed is stored rather than recompressed. The
+    root index is written first when present. ZIP64 is disabled by default so a
+    package that silently exceeds conservative static-host limits fails loudly.
+    """
+    source_dir = source_dir.resolve()
+    output_zip.parent.mkdir(parents=True, exist_ok=True)
+    output_zip.unlink(missing_ok=True)
+
+    files = [
+        path for path in iter_files(source_dir, exclude_names=exclude_names)
+        if not (exclude_suffixes and path.name.lower().endswith(exclude_suffixes))
+    ]
+    files.sort(key=lambda path: _zip_order(path, source_dir))
+
+    with zipfile.ZipFile(output_zip, "w", allowZip64=allow_zip64) as archive:
+        for path in files:
+            relative = path.relative_to(source_dir)
+            if include_root:
+                relative = Path(source_dir.name) / relative
+            arcname = safe_archive_path(relative)
+            info = zipfile.ZipInfo(arcname, FIXED_ZIP_TIME)
+            info.create_system = 0
+            info.external_attr = 0o100644 << 16
+            compression = zipfile.ZIP_STORED if path.suffix.lower() in ALREADY_COMPRESSED else zipfile.ZIP_DEFLATED
+            info.compress_type = compression
+            archive.writestr(info, path.read_bytes(), compress_type=compression, compresslevel=9)
+
+    with zipfile.ZipFile(output_zip, "r") as archive:
+        bad = archive.testzip()
+        if bad:
+            raise RuntimeError(f"ZIP integrity check failed at {bad}")
+        names = archive.namelist()
+
+    return {
+        "path": str(output_zip),
+        "file_count": len(files),
+        "size_bytes": output_zip.stat().st_size,
+        "sha256": sha256_file(output_zip),
+        "entries": names,
+    }
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def temporary_directory(prefix: str = "web-design-picker-"):
+    return tempfile.TemporaryDirectory(prefix=prefix)
+
+
+def replace_tokens(template: str, replacements: dict[str, str]) -> str:
+    rendered = template
+    for key, value in replacements.items():
+        rendered = rendered.replace(f"__{key}__", value)
+    missing = sorted(set(re.findall(r"__[A-Z0-9_]+__", rendered)))
+    if missing:
+        raise ValueError(f"Unreplaced template tokens: {', '.join(missing)}")
+    return rendered
+
+
+def ensure_clean_dir(path: Path) -> None:
+    if path.exists():
+        shutil.rmtree(path)
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def load_project(project_root: Path) -> tuple[dict[str, Any], list[dict[str, Any]], dict[str, Any]]:
+    project_root = project_root.resolve()
+    config = project_root / "config"
+    project = read_json(config / "project.json")
+    directions = read_json(config / "directions.json")
+    assets = read_json(config / "assets.json")
+    if not isinstance(project, dict):
+        raise SystemExit("project.json must contain a JSON object")
+    if not isinstance(directions, list) or not 2 <= len(directions) <= 5:
+        raise SystemExit("directions.json must contain two to five directions")
+    if not isinstance(assets, dict):
+        raise SystemExit("assets.json must contain a JSON object")
+    return project, directions, assets
+
+
+def relative_web_path(path: str) -> str:
+    normalized = path.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    parts = normalized.split("/")
+    if (
+        not normalized
+        or normalized.startswith("/")
+        or re.match(r"^[a-zA-Z]:", normalized)
+        or ".." in parts
+    ):
+        raise ValueError(f"Path must stay inside the static site: {path}")
+    return normalized
+
+
+def write_checksum(path: Path) -> Path:
+    checksum_path = path.with_suffix(path.suffix + ".sha256.txt")
+    checksum_path.write_text(f"{sha256_file(path)}  {path.name}\n", encoding="utf-8")
+    return checksum_path

--- a/web-design-picker/scripts/_common.py
+++ b/web-design-picker/scripts/_common.py
@@ -19,6 +19,15 @@ ALREADY_COMPRESSED = {
     ".mp3", ".mp4", ".pdf", ".png", ".webm", ".webp", ".zip",
 }
 SLUG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+SECRET_SUFFIXES = {".key", ".pem", ".p12", ".pfx", ".pkcs12", ".jks", ".keystore"}
+SSH_PRIVATE_KEY_NAMES = {
+    "id_rsa", "id_dsa", "id_ecdsa", "id_ecdsa_sk", "id_ed25519",
+    "id_ed25519_sk", "id_xmss", "identity", "private_key", "privatekey",
+}
+PRIVATE_KEY_MARKERS = (
+    b"-----BEGIN PRIVATE KEY-----", b"-----BEGIN OPENSSH PRIVATE KEY-----",
+    b"-----BEGIN RSA PRIVATE KEY-----", b"-----BEGIN EC PRIVATE KEY-----",
+)
 
 
 def slugify(value: str) -> str:
@@ -117,6 +126,20 @@ def _zip_order(path: Path, root: Path) -> tuple[int, str]:
     return (0 if relative == "index.html" else 1, relative)
 
 
+def archive_secrets(source_files: Iterable[Path]) -> list[Path]:
+    secrets = []
+    for path in source_files:
+        name = path.name.lower()
+        if name == ".env" or name.startswith(".env.") or name in SSH_PRIVATE_KEY_NAMES or path.suffix.lower() in SECRET_SUFFIXES:
+            secrets.append(path)
+            continue
+        with path.open("rb") as handle:
+            sample = handle.read(4096)
+        if any(marker in sample for marker in PRIVATE_KEY_MARKERS):
+            secrets.append(path)
+    return secrets
+
+
 def deterministic_zip(
     source_dir: Path,
     output_zip: Path,
@@ -137,6 +160,9 @@ def deterministic_zip(
     source_maps = [path.relative_to(source_dir).as_posix() for path in source_files if path.suffix.lower() == ".map"]
     if source_maps:
         raise ValueError(f"Source map files are not allowed in delivery archives: {', '.join(source_maps)}")
+    secrets = [path.relative_to(source_dir).as_posix() for path in archive_secrets(source_files)]
+    if secrets:
+        raise ValueError(f"Secret files are not allowed in delivery archives: {', '.join(secrets)}")
 
     files = [
         path for path in source_files

--- a/web-design-picker/scripts/_common.py
+++ b/web-design-picker/scripts/_common.py
@@ -133,14 +133,19 @@ def deterministic_zip(
     package that silently exceeds conservative static-host limits fails loudly.
     """
     source_dir = source_dir.resolve()
-    output_zip.parent.mkdir(parents=True, exist_ok=True)
-    output_zip.unlink(missing_ok=True)
+    source_files = list(iter_files(source_dir, exclude_names=exclude_names))
+    source_maps = [path.relative_to(source_dir).as_posix() for path in source_files if path.suffix.lower() == ".map"]
+    if source_maps:
+        raise ValueError(f"Source map files are not allowed in delivery archives: {', '.join(source_maps)}")
 
     files = [
-        path for path in iter_files(source_dir, exclude_names=exclude_names)
+        path for path in source_files
         if not (exclude_suffixes and path.name.lower().endswith(exclude_suffixes))
     ]
     files.sort(key=lambda path: _zip_order(path, source_dir))
+
+    output_zip.parent.mkdir(parents=True, exist_ok=True)
+    output_zip.unlink(missing_ok=True)
 
     with zipfile.ZipFile(output_zip, "w", allowZip64=allow_zip64) as archive:
         for path in files:

--- a/web-design-picker/scripts/browser_qa.py
+++ b/web-design-picker/scripts/browser_qa.py
@@ -85,7 +85,12 @@ def main() -> int:
                 launch_args["executable_path"] = executable
             browser = playwright.chromium.launch(**launch_args)
 
-            for size_name, width, height in (("desktop", 1440, 1000), ("mobile", 390, 844)):
+            for size_name, width, height in (
+                ("desktop", 1440, 1000),
+                ("laptop", 1280, 800),
+                ("tablet", 768, 1024),
+                ("mobile", 390, 844),
+            ):
                 context = browser.new_context(viewport={"width": width, "height": height}, accept_downloads=True)
                 page = context.new_page()
                 page.on("console", record_console)

--- a/web-design-picker/scripts/browser_qa.py
+++ b/web-design-picker/scripts/browser_qa.py
@@ -119,6 +119,28 @@ def main() -> int:
                     if open_href != direction["file"]:
                         errors.append(f"Open-selected link is wrong for {key}: {open_href!r}")
 
+                    if size_name == "mobile":
+                        asset_catalog = page.locator('a[href="design-assets.html"]')
+                        open_selected = page.locator("[data-open-selected]")
+                        if not asset_catalog.is_visible():
+                            errors.append("Asset catalog control is hidden at mobile size")
+                        if not open_selected.is_visible():
+                            errors.append("Open concept control is hidden at mobile size")
+                        if index == 0:
+                            try:
+                                asset_catalog.click()
+                                page.wait_for_url(f"{base}/design-assets.html", timeout=5_000)
+                            except PlaywrightTimeoutError:
+                                errors.append("Asset catalog control did not open at mobile size")
+                            page.goto(f"{base}/index.html#{key}", wait_until="networkidle")
+                            try:
+                                page.locator("[data-open-selected]").click()
+                                page.wait_for_url(f"{base}/{direction['file']}", timeout=5_000)
+                            except PlaywrightTimeoutError:
+                                errors.append("Open concept control did not open at mobile size")
+                            finally:
+                                page.goto(f"{base}/index.html#{key}", wait_until="networkidle")
+
                     if index == 0:
                         page.locator("[data-presentation]").click()
                         page.wait_for_timeout(100)

--- a/web-design-picker/scripts/browser_qa.py
+++ b/web-design-picker/scripts/browser_qa.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Run browser interaction, responsive, media, and download QA with Playwright."""
+from __future__ import annotations
+
+import argparse
+import functools
+import http.server
+import json
+import shutil
+import socketserver
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+
+from _common import load_project, utc_now, write_json
+
+
+class QAError(RuntimeError):
+    pass
+
+
+class QuietHandler(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, format: str, *args) -> None:  # noqa: A003
+        pass
+
+
+class ReusableTCPServer(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("project_dir", type=Path)
+    parser.add_argument("--chromium", type=Path, help="Path to a Chromium executable")
+    parser.add_argument("--wait-ms", type=int, default=350)
+    parser.add_argument("--test-downloads", action="store_true", help="Build one family ZIP and the all-assets ZIP in the browser")
+    parser.add_argument("--report-json", type=Path)
+    args = parser.parse_args()
+
+    try:
+        from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+        from playwright.sync_api import sync_playwright
+    except ImportError as exc:
+        print("ERROR: Playwright is required: python -m pip install playwright", file=sys.stderr)
+        return 2
+
+    root = args.project_dir.resolve()
+    project, directions, _ = load_project(root)
+    dist = root / "dist"
+    if not (dist / "index.html").is_file():
+        print("ERROR: build the project before browser QA", file=sys.stderr)
+        return 2
+    previews = root / "previews"
+    previews.mkdir(parents=True, exist_ok=True)
+    downloads = root / "qa/browser-downloads"
+    downloads.mkdir(parents=True, exist_ok=True)
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    captures: list[dict[str, Any]] = []
+    console_errors: list[str] = []
+    request_failures: list[str] = []
+
+    handler = functools.partial(QuietHandler, directory=str(dist))
+    server = ReusableTCPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    port = server.server_address[1]
+    base = f"http://127.0.0.1:{port}"
+    executable = str(args.chromium) if args.chromium else shutil.which("chromium") or shutil.which("chromium-browser") or shutil.which("google-chrome")
+
+    def record_console(message) -> None:
+        if message.type == "error":
+            console_errors.append(message.text)
+
+    def record_failure(request) -> None:
+        request_failures.append(f"{request.url}: {request.failure}")
+
+    try:
+        with sync_playwright() as playwright:
+            launch_args: dict[str, Any] = {"headless": True, "args": ["--no-sandbox", "--disable-dev-shm-usage"]}
+            if executable:
+                launch_args["executable_path"] = executable
+            browser = playwright.chromium.launch(**launch_args)
+
+            for size_name, width, height in (("desktop", 1440, 1000), ("mobile", 390, 844)):
+                context = browser.new_context(viewport={"width": width, "height": height}, accept_downloads=True)
+                page = context.new_page()
+                page.on("console", record_console)
+                page.on("requestfailed", record_failure)
+
+                for index, direction in enumerate(directions):
+                    key = direction["key"]
+                    page.goto(f"{base}/index.html#{key}", wait_until="networkidle")
+                    page.wait_for_timeout(args.wait_ms)
+                    selected = page.locator(f'[role="tab"][data-key="{key}"]').get_attribute("aria-selected")
+                    active = page.locator(f'iframe[data-key="{key}"]').get_attribute("data-active")
+                    if selected != "true" or active != "true":
+                        errors.append(f"Picker did not activate {key} at {size_name} size")
+                    if page.evaluate("document.documentElement.scrollWidth > window.innerWidth + 1"):
+                        errors.append(f"Picker has horizontal overflow at {width}px for {key}")
+                    iframe_overflow = page.locator(f'iframe[data-key="{key}"]').evaluate(
+                        "frame => frame.contentDocument ? frame.contentDocument.documentElement.scrollWidth > frame.contentWindow.innerWidth + 1 : false"
+                    )
+                    if iframe_overflow:
+                        errors.append(f"Direction {key} overflows horizontally inside the picker at {width}px")
+                    shot = previews / f"review-{key}-{size_name}.png"
+                    page.screenshot(path=str(shot), full_page=False)
+                    captures.append({"page": "review", "direction": key, "size": size_name, "path": shot.name})
+
+                    open_href = page.locator("[data-open-selected]").get_attribute("href")
+                    if open_href != direction["file"]:
+                        errors.append(f"Open-selected link is wrong for {key}: {open_href!r}")
+
+                    if index == 0:
+                        page.locator("[data-presentation]").click()
+                        page.wait_for_timeout(100)
+                        if not page.locator("body").evaluate("body => body.classList.contains('presentation')"):
+                            errors.append("Presentation mode did not apply its fallback class")
+                        page.locator("[data-restore]").click()
+                        page.wait_for_timeout(100)
+                        if page.locator("body").evaluate("body => body.classList.contains('presentation')"):
+                            errors.append("Restore control did not exit presentation mode")
+
+                    page.goto(f"{base}/{direction['file']}", wait_until="networkidle")
+                    page.wait_for_timeout(args.wait_ms)
+                    if page.evaluate("document.documentElement.scrollWidth > window.innerWidth + 1"):
+                        errors.append(f"Standalone direction {key} overflows horizontally at {width}px")
+                    if page.locator('link[rel~="icon"]').count() == 0:
+                        errors.append(f"Standalone direction {key} has no favicon declaration")
+                    shot = previews / f"{key}-{size_name}.png"
+                    page.screenshot(path=str(shot), full_page=True)
+                    captures.append({"page": "standalone", "direction": key, "size": size_name, "path": shot.name})
+
+                page.goto(f"{base}/design-assets.html", wait_until="networkidle")
+                page.wait_for_timeout(args.wait_ms)
+                if page.evaluate("document.documentElement.scrollWidth > window.innerWidth + 1"):
+                    errors.append(f"Asset catalog overflows horizontally at {width}px")
+                broken_media = page.evaluate("""() => [...document.querySelectorAll('img')].filter(img => img.complete && img.naturalWidth === 0).map(img => img.src)""")
+                if broken_media:
+                    errors.extend(f"Broken image in asset catalog: {url}" for url in broken_media)
+                manifest_paths = page.evaluate("""async () => (await (await fetch('asset-manifest.json')).json()).assets.map(asset => asset.path)""")
+                failed_fetches = page.evaluate("""async paths => {
+                  const results = [];
+                  for (const path of paths) {
+                    const response = await fetch(path);
+                    if (!response.ok) results.push(`${response.status} ${path}`);
+                  }
+                  return results;
+                }""", manifest_paths)
+                if failed_fetches:
+                    errors.extend(f"Asset download failed: {item}" for item in failed_fetches)
+                shot = previews / f"asset-catalog-{size_name}.png"
+                page.screenshot(path=str(shot), full_page=True)
+                captures.append({"page": "assets", "size": size_name, "path": shot.name})
+
+                if args.test_downloads and size_name == "desktop" and manifest_paths:
+                    family = page.locator("[data-download-family]").first
+                    if family.count():
+                        try:
+                            with page.expect_download(timeout=30_000) as download_info:
+                                family.click()
+                            download = download_info.value
+                            target = downloads / download.suggested_filename
+                            download.save_as(target)
+                            if target.stat().st_size == 0:
+                                errors.append("Family ZIP download was empty")
+                        except PlaywrightTimeoutError:
+                            errors.append("Timed out while generating a family ZIP")
+                    all_button = page.locator("[data-download-all]")
+                    if all_button.count():
+                        try:
+                            with page.expect_download(timeout=60_000) as download_info:
+                                all_button.click()
+                            download = download_info.value
+                            target = downloads / download.suggested_filename
+                            download.save_as(target)
+                            if target.stat().st_size == 0:
+                                errors.append("All-assets ZIP download was empty")
+                        except PlaywrightTimeoutError:
+                            errors.append("Timed out while generating the all-assets ZIP")
+
+                context.close()
+            browser.close()
+    except Exception as exc:
+        errors.append(f"Browser QA runtime failure: {exc}")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    # Avoid duplicating the same browser message dozens of times across pages.
+    for message in sorted(set(console_errors)):
+        errors.append(f"Browser console error: {message}")
+    for failure in sorted(set(request_failures)):
+        errors.append(f"Request failed: {failure}")
+
+    report = {
+        "generated_at": utc_now(),
+        "project": project["name"],
+        "base_url": base,
+        "errors": errors,
+        "warnings": warnings,
+        "captures": captures,
+        "download_tests": args.test_downloads,
+        "passed": not errors,
+    }
+    report_path = args.report_json or (root / "qa/browser-qa.json")
+    write_json(report_path, report)
+    print(f"Browser QA: {len(errors)} error(s), {len(warnings)} warning(s), {len(captures)} screenshot(s)")
+    for error in errors:
+        print(f"ERROR: {error}")
+    for warning in warnings:
+        print(f"WARNING: {warning}")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web-design-picker/scripts/browser_qa.py
+++ b/web-design-picker/scripts/browser_qa.py
@@ -119,6 +119,26 @@ def main() -> int:
                     if open_href != direction["file"]:
                         errors.append(f"Open-selected link is wrong for {key}: {open_href!r}")
 
+                    if index == 0:
+                        open_selected = page.locator("[data-open-selected]")
+                        open_selected.focus()
+                        page.keyboard.press("ArrowRight")
+                        selected_after_action = page.locator('[role="tab"][aria-selected="true"]').get_attribute("data-key")
+                        if selected_after_action != key:
+                            errors.append("ArrowRight on Open concept changed the selected direction")
+                        if not open_selected.evaluate("link => document.activeElement === link"):
+                            errors.append("ArrowRight on Open concept moved focus away from the action link")
+
+                        tab = page.locator(f'[role="tab"][data-key="{key}"]')
+                        tab.focus()
+                        page.keyboard.press("ArrowRight")
+                        expected_key = directions[(index + 1) % len(directions)]["key"]
+                        selected_after_tab = page.locator('[role="tab"][aria-selected="true"]').get_attribute("data-key")
+                        focused_key = page.locator(":focus").get_attribute("data-key")
+                        if selected_after_tab != expected_key or focused_key != expected_key:
+                            errors.append("ArrowRight on a direction tab did not select and focus the next direction")
+                        page.goto(f"{base}/index.html#{key}", wait_until="networkidle")
+
                     if size_name == "mobile":
                         asset_catalog = page.locator('a[href="design-assets.html"]')
                         open_selected = page.locator("[data-open-selected]")

--- a/web-design-picker/scripts/build_picker.py
+++ b/web-design-picker/scripts/build_picker.py
@@ -158,6 +158,29 @@ def validate_directions(directions: list[dict[str, Any]]) -> None:
         files.add(file)
 
 
+def validate_asset_directions(assets: dict[str, Any], directions: list[dict[str, Any]]) -> None:
+    configured_keys = [str(direction["key"]) for direction in directions]
+    asset_directions = assets.get("directions")
+    if not isinstance(asset_directions, list):
+        raise ValueError("assets.json must contain a directions array")
+
+    asset_keys = []
+    for item in asset_directions:
+        if not isinstance(item, dict) or not isinstance(item.get("key"), str) or not item["key"]:
+            raise ValueError("Every assets.json direction requires a non-empty string key")
+        asset_keys.append(item["key"])
+
+    duplicates = sorted({key for key in asset_keys if asset_keys.count(key) > 1})
+    unknown = sorted(set(asset_keys) - set(configured_keys))
+    missing = sorted(set(configured_keys) - set(asset_keys))
+    if duplicates:
+        raise ValueError(f"assets.json direction keys must be unique; duplicate: {', '.join(duplicates)}")
+    if unknown:
+        raise ValueError(f"assets.json contains unknown direction key(s): {', '.join(unknown)}")
+    if missing:
+        raise ValueError(f"assets.json omits configured direction key(s): {', '.join(missing)}")
+
+
 def build_tabs(directions: list[dict[str, Any]], default_key: str) -> str:
     rows = []
     for direction in directions:
@@ -194,6 +217,17 @@ def relative_from_page(target: str, page: str) -> str:
     return posixpath.relpath(target, start=start)
 
 
+def has_favicon_link(text: str, relation: str, href: str) -> bool:
+    for match in re.finditer(r"<link\b[^>]*>", text, re.I):
+        attributes: dict[str, str] = {}
+        for attribute in re.finditer(r"\b(rel|href)\s*=\s*(?:\"([^\"]*)\"|'([^']*)'|([^\s>]+))", match.group(), re.I):
+            value = next((part for part in attribute.group(2, 3, 4) if part is not None), "")
+            attributes[attribute.group(1).lower()] = html.unescape(value)
+        if relation in attributes.get("rel", "").lower().split() and attributes.get("href") == href:
+            return True
+    return False
+
+
 def ensure_direction_metadata(dist: Path, direction: dict[str, Any]) -> None:
     page_rel = relative_web_path(str(direction["file"]))
     page = dist / page_rel
@@ -208,12 +242,15 @@ def ensure_direction_metadata(dist: Path, direction: dict[str, Any]) -> None:
         additions.append('<meta name="viewport" content="width=device-width, initial-scale=1">')
     if "name=\"robots\"" not in lower and "name='robots'" not in lower:
         additions.append('<meta name="robots" content="noindex,nofollow">')
-    if not re.search(r"<link\b[^>]*rel=[\"'][^\"']*icon", text, re.I):
-        additions.extend([
-            f'<link rel="icon" href="{esc(relative_from_page(favicon_base + "/favicon.svg", page_rel))}" type="image/svg+xml">',
-            f'<link rel="icon" href="{esc(relative_from_page(favicon_base + "/favicon.ico", page_rel))}" sizes="any">',
-            f'<link rel="apple-touch-icon" href="{esc(relative_from_page(favicon_base + "/favicon-180.png", page_rel))}">',
-        ])
+    favicon_links = [
+        ("icon", relative_from_page(favicon_base + "/favicon.svg", page_rel), 'type="image/svg+xml"'),
+        ("icon", relative_from_page(favicon_base + "/favicon.ico", page_rel), 'sizes="any"'),
+        ("apple-touch-icon", relative_from_page(favicon_base + "/favicon-180.png", page_rel), ""),
+    ]
+    for relation, href, attributes in favicon_links:
+        if not has_favicon_link(text, relation, href):
+            suffix = f" {attributes}" if attributes else ""
+            additions.append(f'<link rel="{relation}" href="{esc(href)}"{suffix}>')
     if additions:
         text = re.sub(r"</head\s*>", "  " + "\n  ".join(additions) + "\n</head>", text, count=1, flags=re.I)
         page.write_text(text, encoding="utf-8")
@@ -365,6 +402,7 @@ def main() -> int:
     project, directions, assets = load_project(root)
     try:
         validate_directions(directions)
+        validate_asset_directions(assets, directions)
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1

--- a/web-design-picker/scripts/build_picker.py
+++ b/web-design-picker/scripts/build_picker.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""Build the comparison picker, standalone concepts, and asset catalog."""
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import mimetypes
+import posixpath
+import re
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import urlsplit
+
+from _common import (
+    SKILL_ROOT,
+    copy_contents,
+    ensure_clean_dir,
+    load_project,
+    relative_web_path,
+    replace_tokens,
+    slugify,
+    utc_now,
+    write_json,
+    write_text,
+)
+
+IMAGE_SUFFIXES = {".svg", ".png", ".jpg", ".jpeg", ".webp", ".gif", ".avif"}
+VIDEO_SUFFIXES = {".mp4", ".webm", ".mov", ".m4v", ".ogg"}
+
+BROWSER_ZIP_JS = r'''
+const zipEncoder = new TextEncoder();
+const crcTable = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = (c & 1) ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+function crc32(bytes) {
+  let c = 0xffffffff;
+  for (const byte of bytes) c = crcTable[(c ^ byte) & 0xff] ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+}
+function localHeader(name, data, crc) {
+  const nameBytes = zipEncoder.encode(name);
+  const out = new Uint8Array(30 + nameBytes.length);
+  const view = new DataView(out.buffer);
+  view.setUint32(0, 0x04034b50, true); view.setUint16(4, 20, true);
+  view.setUint16(6, 0x0800, true); view.setUint16(8, 0, true);
+  view.setUint16(10, 0, true); view.setUint16(12, 0x0021, true);
+  view.setUint32(14, crc, true); view.setUint32(18, data.length, true);
+  view.setUint32(22, data.length, true); view.setUint16(26, nameBytes.length, true);
+  view.setUint16(28, 0, true); out.set(nameBytes, 30); return out;
+}
+function centralHeader(name, data, crc, offset) {
+  const nameBytes = zipEncoder.encode(name);
+  const out = new Uint8Array(46 + nameBytes.length);
+  const view = new DataView(out.buffer);
+  view.setUint32(0, 0x02014b50, true); view.setUint16(4, 20, true);
+  view.setUint16(6, 20, true); view.setUint16(8, 0x0800, true);
+  view.setUint16(10, 0, true); view.setUint16(12, 0, true);
+  view.setUint16(14, 0x0021, true); view.setUint32(16, crc, true);
+  view.setUint32(20, data.length, true); view.setUint32(24, data.length, true);
+  view.setUint16(28, nameBytes.length, true); view.setUint16(30, 0, true);
+  view.setUint16(32, 0, true); view.setUint16(34, 0, true);
+  view.setUint16(36, 0, true); view.setUint32(38, 0, true);
+  view.setUint32(42, offset, true); out.set(nameBytes, 46); return out;
+}
+async function buildAssetZip(rawPaths, status) {
+  const paths = [...new Set(rawPaths)];
+  if (!paths.length) throw new Error('No downloadable assets are registered.');
+  if (paths.length > 65535) throw new Error('Too many files for the browser ZIP builder.');
+  const files = [];
+  for (let index = 0; index < paths.length; index++) {
+    const path = paths[index];
+    status.textContent = `Collecting ${index + 1} of ${paths.length}: ${path}`;
+    const response = await fetch(path);
+    if (!response.ok) throw new Error(`${response.status} ${response.statusText}: ${path}`);
+    const data = new Uint8Array(await response.arrayBuffer());
+    files.push({ name: path.replace(/^\.\//, ''), data });
+  }
+  const locals = [], centrals = [];
+  let offset = 0;
+  for (const file of files) {
+    const crc = crc32(file.data);
+    const header = localHeader(file.name, file.data, crc);
+    locals.push(header, file.data);
+    centrals.push(centralHeader(file.name, file.data, crc, offset));
+    offset += header.length + file.data.length;
+  }
+  const centralOffset = offset;
+  const centralSize = centrals.reduce((sum, part) => sum + part.length, 0);
+  const end = new Uint8Array(22);
+  const view = new DataView(end.buffer);
+  view.setUint32(0, 0x06054b50, true); view.setUint16(4, 0, true);
+  view.setUint16(6, 0, true); view.setUint16(8, files.length, true);
+  view.setUint16(10, files.length, true); view.setUint32(12, centralSize, true);
+  view.setUint32(16, centralOffset, true); view.setUint16(20, 0, true);
+  return new Blob([...locals, ...centrals, end], { type: 'application/zip' });
+}
+function triggerDownload(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url; link.download = filename; document.body.appendChild(link);
+  link.click(); link.remove(); setTimeout(() => URL.revokeObjectURL(url), 30000);
+}
+async function prepareZip(button, paths, name) {
+  const status = document.querySelector('[data-download-status]');
+  const original = button.textContent;
+  button.disabled = true; button.textContent = 'Building ZIP…';
+  try {
+    const blob = await buildAssetZip(paths, status);
+    triggerDownload(blob, name);
+    status.textContent = `Prepared ${[...new Set(paths)].length} files as ${name}.`;
+  } catch (error) {
+    status.textContent = `Could not build the ZIP: ${error.message}. Serve the site through HTTP rather than file://.`;
+  } finally {
+    button.disabled = false; button.textContent = original;
+  }
+}
+document.querySelectorAll('[data-download-family]').forEach(button => {
+  button.addEventListener('click', () => prepareZip(button, JSON.parse(button.dataset.paths), button.dataset.name));
+});
+'''
+
+
+def esc(value: Any) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def validate_directions(directions: list[dict[str, Any]]) -> None:
+    keys: set[str] = set()
+    files: set[str] = set()
+    for direction in directions:
+        for field in ("key", "label", "file"):
+            if not direction.get(field):
+                raise ValueError(f"Every direction requires {field!r}")
+        key = str(direction["key"])
+        file = relative_web_path(str(direction["file"]))
+        if key in keys:
+            raise ValueError(f"Duplicate direction key: {key}")
+        if file in files:
+            raise ValueError(f"Duplicate direction file: {file}")
+        keys.add(key)
+        files.add(file)
+
+
+def build_tabs(directions: list[dict[str, Any]], default_key: str) -> str:
+    rows = []
+    for direction in directions:
+        key = esc(direction["key"])
+        active = direction["key"] == default_key
+        rows.append(
+            f'<button class="tab" id="tab-{key}" type="button" role="tab" '
+            f'aria-selected="{str(active).lower()}" aria-controls="frame-{key}" '
+            f'tabindex="{0 if active else -1}" data-key="{key}">'
+            f'<b>{esc(direction["label"])}</b><span>{esc(direction.get("description", ""))}</span></button>'
+        )
+    return "\n      ".join(rows)
+
+
+def build_frames(directions: list[dict[str, Any]], default_key: str) -> str:
+    rows = []
+    for index, direction in enumerate(directions):
+        key = esc(direction["key"])
+        active = direction["key"] == default_key
+        loading = "" if active or index == 0 else ' loading="lazy"'
+        rows.append(
+            f'<iframe id="frame-{key}" class="concept-frame" role="tabpanel" '
+            f'aria-labelledby="tab-{key}" data-key="{key}" data-active="{str(active).lower()}" '
+            f'aria-hidden="{str(not active).lower()}" src="{esc(direction["file"])}" '
+            f'title="{esc(direction["label"])} website direction"{loading}></iframe>'
+        )
+    return "\n    ".join(rows)
+
+
+def relative_from_page(target: str, page: str) -> str:
+    page_parent = PurePosixPath(page).parent
+    start = str(page_parent) if str(page_parent) != "." else "."
+    return posixpath.relpath(target, start=start)
+
+
+def ensure_direction_metadata(dist: Path, direction: dict[str, Any]) -> None:
+    page_rel = relative_web_path(str(direction["file"]))
+    page = dist / page_rel
+    text = page.read_text(encoding="utf-8")
+    if not re.search(r"</head\s*>", text, re.I):
+        raise ValueError(f"Direction page has no closing </head>: {page_rel}")
+    lower = text.lower()
+    key = str(direction["key"])
+    favicon_base = relative_web_path(str(direction.get("favicon_base") or f"assets/brand/{key}"))
+    additions: list[str] = []
+    if "name=\"viewport\"" not in lower and "name='viewport'" not in lower:
+        additions.append('<meta name="viewport" content="width=device-width, initial-scale=1">')
+    if "name=\"robots\"" not in lower and "name='robots'" not in lower:
+        additions.append('<meta name="robots" content="noindex,nofollow">')
+    if not re.search(r"<link\b[^>]*rel=[\"'][^\"']*icon", text, re.I):
+        additions.extend([
+            f'<link rel="icon" href="{esc(relative_from_page(favicon_base + "/favicon.svg", page_rel))}" type="image/svg+xml">',
+            f'<link rel="icon" href="{esc(relative_from_page(favicon_base + "/favicon.ico", page_rel))}" sizes="any">',
+            f'<link rel="apple-touch-icon" href="{esc(relative_from_page(favicon_base + "/favicon-180.png", page_rel))}">',
+        ])
+    if additions:
+        text = re.sub(r"</head\s*>", "  " + "\n  ".join(additions) + "\n</head>", text, count=1, flags=re.I)
+        page.write_text(text, encoding="utf-8")
+
+
+def media_preview(preview: str, alt: str, group: dict[str, Any]) -> str:
+    if not preview:
+        return '<div class="preview"><span>No preview supplied</span></div>'
+    path = urlsplit(preview).path
+    suffix = Path(path).suffix.lower()
+    preview_class = " ".join(token for token in str(group.get("preview_class", "")).split() if token.replace("-", "").isalnum())
+    class_attr = f"preview {preview_class}".strip()
+    if suffix in VIDEO_SUFFIXES:
+        poster = group.get("poster")
+        poster_attr = f' poster="{esc(poster)}"' if poster else ""
+        return (
+            f'<div class="{class_attr}"><video controls muted playsinline preload="metadata"{poster_attr}>'
+            f'<source src="{esc(preview)}" type="{esc(mimetypes.guess_type(preview)[0] or "video/mp4")}">'
+            "Your browser cannot play this video.</video></div>"
+        )
+    if suffix in IMAGE_SUFFIXES:
+        return f'<div class="{class_attr}"><img src="{esc(preview)}" alt="{esc(alt)}" loading="lazy"></div>'
+    return f'<div class="{class_attr}"><span>{esc(Path(path).name)}</span></div>'
+
+
+def clean_file_items(files: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    output = []
+    seen = set()
+    for item in files:
+        if not isinstance(item, dict) or not item.get("href"):
+            continue
+        href = relative_web_path(str(item["href"]))
+        if href in seen:
+            continue
+        seen.add(href)
+        output.append({**item, "href": href})
+    return output
+
+
+def build_downloads(files: list[dict[str, Any]], family_name: str) -> str:
+    files = clean_file_items(files)
+    links = []
+    for item in files:
+        href = str(item["href"])
+        label = item.get("label") or item.get("format") or Path(href).suffix.lstrip(".") or "File"
+        title_parts = [item.get("format"), item.get("dimensions"), item.get("notes")]
+        title = " · ".join(str(part) for part in title_parts if part)
+        title_attr = f' title="{esc(title)}"' if title else ""
+        links.append(f'<a href="{esc(href)}" download{title_attr}>{esc(label)}</a>')
+    if files:
+        paths_json = json.dumps([item["href"] for item in files], ensure_ascii=False)
+        zip_name = f"{slugify(family_name)}-assets.zip"
+        links.append(
+            f'<button type="button" data-download-family data-paths="{esc(paths_json)}" '
+            f'data-name="{esc(zip_name)}">Family ZIP</button>'
+        )
+    return "".join(links)
+
+
+def build_group(group: dict[str, Any], direction_label: str) -> str:
+    title = group.get("title", "Untitled asset")
+    description = group.get("description", "")
+    preview = group.get("preview", "")
+    alt = group.get("preview_alt") or f"Preview of {title} for {direction_label}"
+    files = clean_file_items(group.get("files") or [])
+    meta = group.get("meta", "")
+    searchable = " ".join(
+        [direction_label, str(title), str(description), str(meta)]
+        + [" ".join(str(value) for value in item.values() if value) for item in files]
+    )
+    downloads = build_downloads(files, f"{direction_label}-{title}")
+    return f"""
+      <article class="asset-row" data-search="{esc(searchable.lower())}">
+        {media_preview(str(preview), str(alt), group)}
+        <div class="asset-copy">
+          <h3>{esc(title)}</h3>
+          {f'<p>{esc(description)}</p>' if description else ''}
+          {f'<p class="meta">{esc(meta)}</p>' if meta else ''}
+          {f'<div class="downloads" aria-label="Downloads for {esc(title)}">{downloads}</div>' if downloads else '<p class="meta">No downloadable file listed.</p>'}
+        </div>
+      </article>"""
+
+
+def build_asset_section(label: str, section_note: str, accent: str, groups: list[dict[str, Any]], section_key: str) -> str:
+    group_html = "\n".join(build_group(group, label) for group in groups) if groups else '<p class="empty" data-search="empty">No assets have been added to this section.</p>'
+    return f"""
+    <section class="direction" id="{esc(section_key)}" style="--accent:{esc(accent)}">
+      <header><p>{esc(section_note)}</p><h2>{esc(label)}</h2></header>
+      {group_html}
+    </section>"""
+
+
+def build_asset_sections(assets: dict[str, Any], directions: list[dict[str, Any]]) -> str:
+    sections = []
+    if assets.get("shared"):
+        sections.append(build_asset_section("Shared assets", "Common to all directions", "#111315", assets["shared"], "shared-assets"))
+    asset_directions = {item.get("key"): item for item in assets.get("directions") or [] if isinstance(item, dict)}
+    for index, direction in enumerate(directions):
+        item = asset_directions.get(direction["key"], {})
+        label = item.get("label") or direction["label"]
+        accent = item.get("accent") or direction.get("accent") or "#111315"
+        sections.append(build_asset_section(label, f"Concept {index + 1}", accent, item.get("groups") or [], direction["key"]))
+    return "\n".join(sections)
+
+
+def flatten_asset_manifest(project: dict[str, Any], assets: dict[str, Any]) -> dict[str, Any]:
+    flattened = []
+    seen = set()
+
+    def consume(direction_key: str, direction_label: str, groups: list[dict[str, Any]]) -> None:
+        for group in groups:
+            for item in clean_file_items(group.get("files") or []):
+                href = str(item["href"])
+                if href in seen:
+                    continue
+                seen.add(href)
+                flattened.append({
+                    "direction": direction_key,
+                    "direction_label": direction_label,
+                    "group": group.get("title", ""),
+                    "name": Path(urlsplit(href).path).stem,
+                    "path": href,
+                    "format": item.get("format") or Path(urlsplit(href).path).suffix.lstrip("."),
+                    "dimensions": item.get("dimensions"),
+                    "notes": item.get("notes"),
+                })
+
+    consume("shared", "Shared assets", assets.get("shared") or [])
+    for direction in assets.get("directions") or []:
+        if isinstance(direction, dict):
+            consume(str(direction.get("key", "")), str(direction.get("label", "")), direction.get("groups") or [])
+    return {"project": project["name"], "slug": project["slug"], "generated_at": utc_now(), "assets": flattened}
+
+
+def copy_review_favicon_to_root(dist: Path) -> None:
+    source = dist / "assets/brand/review/favicon.ico"
+    if source.exists():
+        shutil.copy2(source, dist / "favicon.ico")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("project_dir", type=Path)
+    parser.add_argument("--no-clean", action="store_true", help="Do not clear dist before building")
+    args = parser.parse_args()
+
+    root = args.project_dir.resolve()
+    project, directions, assets = load_project(root)
+    try:
+        validate_directions(directions)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    dist = root / "dist"
+    if not args.no_clean:
+        ensure_clean_dir(dist)
+    else:
+        dist.mkdir(parents=True, exist_ok=True)
+
+    copy_contents(root / "src/concepts", dist / "concepts")
+    copy_contents(root / "src/assets", dist / "assets")
+    copy_contents(root / "design-package", dist / "assets/design-package")
+
+    try:
+        for direction in directions:
+            expected = dist / relative_web_path(str(direction["file"]))
+            if not expected.is_file():
+                raise ValueError(f"Direction file does not exist after copy: {expected}")
+            ensure_direction_metadata(dist, direction)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    default_key = project.get("default_direction") or directions[0]["key"]
+    if default_key not in {direction["key"] for direction in directions}:
+        default_key = directions[0]["key"]
+    default_direction = next(direction for direction in directions if direction["key"] == default_key)
+
+    active_color = project.get("active_color") or default_direction.get("accent") or "#ff5a1f"
+    favicon_svg = project.get("review_favicon", "assets/brand/review/favicon.svg")
+    favicon_ico = "assets/brand/review/favicon.ico"
+    touch_icon = "assets/brand/review/favicon-180.png"
+    identity_mark = project.get("identity_mark") or favicon_svg
+    identity_html = f'<img src="{esc(identity_mark)}" alt="" aria-hidden="true">'
+
+    picker_template = (SKILL_ROOT / "assets/picker-shell.html").read_text(encoding="utf-8")
+    picker = replace_tokens(
+        picker_template,
+        {
+            "LANG": esc(project.get("language", "en")),
+            "THEME_COLOR": esc(project.get("theme_color", "#111315")),
+            "ROBOTS": esc(project.get("robots", "noindex,nofollow")),
+            "PAGE_TITLE": esc(project.get("review_title") or f'{project["name"]}: website design review'),
+            "PAGE_DESCRIPTION": esc(project.get("review_description") or f'Compare website directions for {project["name"]}.'),
+            "FAVICON_SVG": esc(favicon_svg),
+            "FAVICON_ICO": esc(favicon_ico),
+            "TOUCH_ICON": esc(touch_icon),
+            "ACTIVE_COLOR": esc(active_color),
+            "DIRECTION_COUNT": str(len(directions)),
+            "IDENTITY_MARK": identity_html,
+            "PROJECT_NAME": esc(project["name"]),
+            "REVIEW_SUBTITLE": esc(project.get("review_subtitle", "Website direction review")),
+            "TABS": build_tabs(directions, default_key),
+            "FRAMES": build_frames(directions, default_key),
+            "DEFAULT_STANDALONE": esc(default_direction["file"]),
+            "DEFAULT_ANNOUNCEMENT": esc(f'{default_direction["label"]} direction selected.'),
+            "DIRECTIONS_JSON": json.dumps([
+                {"key": direction["key"], "label": direction["label"], "file": direction["file"], "accent": direction.get("accent", active_color)}
+                for direction in directions
+            ], ensure_ascii=False).replace("</", "<\\/"),
+            "DEFAULT_KEY_JSON": json.dumps(default_key),
+        },
+    )
+    write_text(dist / "index.html", picker)
+
+    asset_manifest = flatten_asset_manifest(project, assets)
+    all_asset_paths = [item["path"] for item in asset_manifest["assets"]]
+    bundle_name = project.get("asset_zip_name") or f'{project["slug"]}-all-design-assets.zip'
+    if all_asset_paths:
+        download_action = '<button type="button" data-download-all>Download all</button>'
+        all_script = BROWSER_ZIP_JS + (
+            "\nconst allAssetPaths=" + json.dumps(all_asset_paths, ensure_ascii=False).replace("</", "<\\/") + ";\n"
+            "const downloadAll=document.querySelector('[data-download-all]');\n"
+            "downloadAll?.addEventListener('click',()=>prepareZip(downloadAll,allAssetPaths," + json.dumps(bundle_name) + "));\n"
+        )
+    else:
+        download_action = ""
+        all_script = BROWSER_ZIP_JS
+
+    asset_template = (SKILL_ROOT / "assets/asset-page.html").read_text(encoding="utf-8")
+    asset_page = replace_tokens(
+        asset_template,
+        {
+            "LANG": esc(project.get("language", "en")),
+            "ROBOTS": esc(project.get("robots", "noindex,nofollow")),
+            "THEME_COLOR": esc(project.get("theme_color", "#111315")),
+            "PROJECT_NAME": esc(project["name"]),
+            "FAVICON_SVG": esc(favicon_svg),
+            "FAVICON_ICO": esc(favicon_ico),
+            "TOUCH_ICON": esc(touch_icon),
+            "ACTIVE_COLOR": esc(active_color),
+            "DOWNLOAD_ALL_ACTION": download_action,
+            "DOWNLOAD_ALL_SCRIPT": all_script,
+            "LIBRARY_NOTE": esc(project.get("library_note", "Review licensing and production requirements before public use.")),
+            "ASSET_SECTIONS": build_asset_sections(assets, directions),
+            "YEAR": str(datetime.now().year),
+        },
+    )
+    write_text(dist / "design-assets.html", asset_page)
+    write_json(dist / "asset-manifest.json", asset_manifest)
+    write_json(dist / "site-manifest.json", {
+        "project": project,
+        "directions": directions,
+        "generated_at": utc_now(),
+        "entry": "index.html",
+        "asset_library": "design-assets.html",
+        "browser_asset_zip": bundle_name,
+    })
+
+    webmanifest_template = (SKILL_ROOT / "assets/manifest.webmanifest").read_text(encoding="utf-8")
+    webmanifest = replace_tokens(webmanifest_template, {
+        "PROJECT_NAME": project["name"],
+        "SHORT_NAME": project.get("short_name") or project["name"][:24],
+        "THEME_COLOR": project.get("theme_color", "#111315"),
+    })
+    write_text(dist / "manifest.webmanifest", webmanifest)
+    shutil.copy2(SKILL_ROOT / "assets/robots.txt", dist / "robots.txt")
+    copy_review_favicon_to_root(dist)
+
+    # Fail early if the catalog promises files that are not in the build.
+    missing = [path for path in all_asset_paths if not (dist / path).is_file()]
+    if missing:
+        print("error: asset manifest references files missing from dist:", file=sys.stderr)
+        for path in missing:
+            print(f"  {path}", file=sys.stderr)
+        return 1
+
+    print(f"Built review site at {dist}")
+    print(f"Entry point: {dist / 'index.html'}")
+    print(f"Asset library: {dist / 'design-assets.html'} ({len(all_asset_paths)} downloadable files)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web-design-picker/scripts/build_picker.py
+++ b/web-design-picker/scripts/build_picker.py
@@ -442,6 +442,12 @@ def main() -> int:
         download_action = ""
         all_script = BROWSER_ZIP_JS
 
+    try:
+        asset_sections = build_asset_sections(assets, directions)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
     asset_template = (SKILL_ROOT / "assets/asset-page.html").read_text(encoding="utf-8")
     asset_page = replace_tokens(
         asset_template,
@@ -457,7 +463,7 @@ def main() -> int:
             "DOWNLOAD_ALL_ACTION": download_action,
             "DOWNLOAD_ALL_SCRIPT": all_script,
             "LIBRARY_NOTE": esc(project.get("library_note", "Review licensing and production requirements before public use.")),
-            "ASSET_SECTIONS": build_asset_sections(assets, directions),
+            "ASSET_SECTIONS": asset_sections,
             "YEAR": str(datetime.now().year),
         },
     )

--- a/web-design-picker/scripts/build_picker.py
+++ b/web-design-picker/scripts/build_picker.py
@@ -20,10 +20,12 @@ from _common import (
     copy_contents,
     ensure_clean_dir,
     load_project,
+    reject_symlinks,
     relative_web_path,
     replace_tokens,
     slugify,
     utc_now,
+    validate_slug,
     write_json,
     write_text,
 )
@@ -138,10 +140,15 @@ def validate_directions(directions: list[dict[str, Any]]) -> None:
     keys: set[str] = set()
     files: set[str] = set()
     for direction in directions:
+        if not isinstance(direction, dict):
+            raise ValueError("Every direction must be a JSON object")
         for field in ("key", "label", "file"):
             if not direction.get(field):
                 raise ValueError(f"Every direction requires {field!r}")
-        key = str(direction["key"])
+        try:
+            key = validate_slug(direction["key"])
+        except ValueError as exc:
+            raise ValueError(f"Invalid direction key {direction['key']!r}: {exc}") from exc
         file = relative_web_path(str(direction["file"]))
         if key in keys:
             raise ValueError(f"Duplicate direction key: {key}")
@@ -343,6 +350,7 @@ def flatten_asset_manifest(project: dict[str, Any], assets: dict[str, Any]) -> d
 
 def copy_review_favicon_to_root(dist: Path) -> None:
     source = dist / "assets/brand/review/favicon.ico"
+    reject_symlinks(source)
     if source.exists():
         shutil.copy2(source, dist / "favicon.ico")
 
@@ -478,13 +486,14 @@ def main() -> int:
         "browser_asset_zip": bundle_name,
     })
 
-    webmanifest_template = (SKILL_ROOT / "assets/manifest.webmanifest").read_text(encoding="utf-8")
-    webmanifest = replace_tokens(webmanifest_template, {
-        "PROJECT_NAME": project["name"],
-        "SHORT_NAME": project.get("short_name") or project["name"][:24],
-        "THEME_COLOR": project.get("theme_color", "#111315"),
+    webmanifest = json.loads((SKILL_ROOT / "assets/manifest.webmanifest").read_text(encoding="utf-8"))
+    project_name = str(project["name"])
+    webmanifest.update({
+        "name": f"{project_name} design review",
+        "short_name": str(project.get("short_name") or project_name[:24]),
+        "theme_color": str(project.get("theme_color", "#111315")),
     })
-    write_text(dist / "manifest.webmanifest", webmanifest)
+    write_json(dist / "manifest.webmanifest", webmanifest)
     shutil.copy2(SKILL_ROOT / "assets/robots.txt", dist / "robots.txt")
     copy_review_favicon_to_root(dist)
 

--- a/web-design-picker/scripts/build_picker.py
+++ b/web-design-picker/scripts/build_picker.py
@@ -428,7 +428,13 @@ def main() -> int:
     )
     write_text(dist / "index.html", picker)
 
-    asset_manifest = flatten_asset_manifest(project, assets)
+    try:
+        asset_manifest = flatten_asset_manifest(project, assets)
+        asset_sections = build_asset_sections(assets, directions)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
     all_asset_paths = [item["path"] for item in asset_manifest["assets"]]
     bundle_name = project.get("asset_zip_name") or f'{project["slug"]}-all-design-assets.zip'
     if all_asset_paths:
@@ -441,12 +447,6 @@ def main() -> int:
     else:
         download_action = ""
         all_script = BROWSER_ZIP_JS
-
-    try:
-        asset_sections = build_asset_sections(assets, directions)
-    except ValueError as exc:
-        print(f"error: {exc}", file=sys.stderr)
-        return 1
 
     asset_template = (SKILL_ROOT / "assets/asset-page.html").read_text(encoding="utf-8")
     asset_page = replace_tokens(

--- a/web-design-picker/scripts/build_picker.py
+++ b/web-design-picker/scripts/build_picker.py
@@ -169,12 +169,13 @@ def build_frames(directions: list[dict[str, Any]], default_key: str) -> str:
     rows = []
     for index, direction in enumerate(directions):
         key = esc(direction["key"])
+        source = esc(relative_web_path(str(direction["file"])))
         active = direction["key"] == default_key
         loading = "" if active or index == 0 else ' loading="lazy"'
         rows.append(
             f'<iframe id="frame-{key}" class="concept-frame" role="tabpanel" '
             f'aria-labelledby="tab-{key}" data-key="{key}" data-active="{str(active).lower()}" '
-            f'aria-hidden="{str(not active).lower()}" src="{esc(direction["file"])}" '
+            f'aria-hidden="{str(not active).lower()}" src="{source}" '
             f'title="{esc(direction["label"])} website direction"{loading}></iframe>'
         )
     return "\n    ".join(rows)
@@ -411,10 +412,15 @@ def main() -> int:
             "REVIEW_SUBTITLE": esc(project.get("review_subtitle", "Website direction review")),
             "TABS": build_tabs(directions, default_key),
             "FRAMES": build_frames(directions, default_key),
-            "DEFAULT_STANDALONE": esc(default_direction["file"]),
+            "DEFAULT_STANDALONE": esc(relative_web_path(str(default_direction["file"]))),
             "DEFAULT_ANNOUNCEMENT": esc(f'{default_direction["label"]} direction selected.'),
             "DIRECTIONS_JSON": json.dumps([
-                {"key": direction["key"], "label": direction["label"], "file": direction["file"], "accent": direction.get("accent", active_color)}
+                {
+                    "key": direction["key"],
+                    "label": direction["label"],
+                    "file": relative_web_path(str(direction["file"])),
+                    "accent": direction.get("accent", active_color),
+                }
                 for direction in directions
             ], ensure_ascii=False).replace("</", "<\\/"),
             "DEFAULT_KEY_JSON": json.dumps(default_key),

--- a/web-design-picker/scripts/check_distinctness.py
+++ b/web-design-picker/scripts/check_distinctness.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Score whether website directions are strategically and structurally distinct."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from _common import read_json, utc_now, write_json
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("project_dir", type=Path)
+    parser.add_argument("--strict", action="store_true", help="Fail on incomplete scores or pairs below target")
+    parser.add_argument("--report-json", type=Path)
+    args = parser.parse_args()
+
+    root = args.project_dir.resolve()
+    config_path = root / "config/distinctness.json"
+    if not config_path.is_file():
+        message = f"Missing {config_path}"
+        print(f"WARNING: {message}")
+        return 1 if args.strict else 0
+
+    data = read_json(config_path)
+    dimensions = data.get("dimensions") or []
+    pairs = data.get("pairs") or []
+    target = int(data.get("target", 15))
+    findings = []
+    complete = True
+    passed = True
+
+    for pair in pairs:
+        a = pair.get("a", "?")
+        b = pair.get("b", "?")
+        scores = pair.get("scores") or {}
+        missing = [dimension for dimension in dimensions if scores.get(dimension) is None]
+        invalid = [dimension for dimension in dimensions if scores.get(dimension) is not None and scores.get(dimension) not in (0, 1, 2)]
+        total = sum(int(scores.get(dimension) or 0) for dimension in dimensions if scores.get(dimension) in (0, 1, 2))
+        status = "pass"
+        if invalid:
+            status = "invalid"
+            passed = False
+        elif missing:
+            status = "incomplete"
+            complete = False
+        elif total < target:
+            status = "below-target"
+            passed = False
+        findings.append({"a": a, "b": b, "score": total, "possible": len(dimensions) * 2, "target": target, "status": status, "missing": missing, "invalid": invalid, "notes": pair.get("notes", "")})
+
+    report = {"generated_at": utc_now(), "target": target, "dimensions": dimensions, "complete": complete, "passed": passed and complete, "pairs": findings}
+    report_path = args.report_json or (root / "qa/distinctness.json")
+    write_json(report_path, report)
+
+    for finding in findings:
+        print(f"{finding['a']} vs {finding['b']}: {finding['score']}/{finding['possible']}, {finding['status']}")
+    if not findings:
+        print("WARNING: no direction pairs are defined")
+        return 1 if args.strict else 0
+    if args.strict and (not complete or not passed):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web-design-picker/scripts/check_distinctness.py
+++ b/web-design-picker/scripts/check_distinctness.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from itertools import combinations
 from pathlib import Path
 
 from _common import read_json, utc_now, write_json
+
+
+def valid_score(value: object) -> bool:
+    return type(value) is int and value in (0, 1, 2)
 
 
 def main() -> int:
@@ -25,22 +30,61 @@ def main() -> int:
         return 1 if args.strict else 0
 
     data = read_json(config_path)
+    directions = read_json(root / "config/directions.json")
+    if not isinstance(data, dict):
+        print("ERROR: distinctness.json must contain a JSON object")
+        return 1
+    if not isinstance(directions, list):
+        print("ERROR: directions.json must contain a JSON array")
+        return 1
+    try:
+        direction_keys = [direction["key"] for direction in directions]
+    except (KeyError, TypeError) as exc:
+        print(f"ERROR: directions.json has a direction without a key: {exc}")
+        return 1
+    if not all(isinstance(key, str) for key in direction_keys) or len(set(direction_keys)) != len(direction_keys):
+        print("ERROR: directions.json direction keys must be unique strings")
+        return 1
+
     dimensions = data.get("dimensions") or []
     pairs = data.get("pairs") or []
     target = int(data.get("target", 15))
     findings = []
     complete = True
     passed = True
+    expected_pairs = {tuple(sorted(pair)) for pair in combinations(direction_keys, 2)}
+    seen_pairs: set[tuple[str, str]] = set()
+    structure_invalid = False
 
-    for pair in pairs:
+    for index, pair in enumerate(pairs):
+        if not isinstance(pair, dict):
+            findings.append({"a": "?", "b": "?", "score": 0, "possible": len(dimensions) * 2, "target": target, "status": "unknown", "missing": [], "invalid": [], "notes": f"Pair {index + 1} is not an object"})
+            complete = False
+            passed = False
+            structure_invalid = True
+            continue
         a = pair.get("a", "?")
         b = pair.get("b", "?")
-        scores = pair.get("scores") or {}
+        pair_key = tuple(sorted((a, b))) if isinstance(a, str) and isinstance(b, str) else None
+        pair_status = ""
+        if pair_key not in expected_pairs:
+            pair_status = "unknown"
+        elif pair_key in seen_pairs:
+            pair_status = "duplicate"
+        else:
+            seen_pairs.add(pair_key)
+        raw_scores = pair.get("scores")
+        scores = raw_scores if isinstance(raw_scores, dict) else {}
         missing = [dimension for dimension in dimensions if scores.get(dimension) is None]
-        invalid = [dimension for dimension in dimensions if scores.get(dimension) is not None and scores.get(dimension) not in (0, 1, 2)]
-        total = sum(int(scores.get(dimension) or 0) for dimension in dimensions if scores.get(dimension) in (0, 1, 2))
+        invalid = [dimension for dimension in dimensions if scores.get(dimension) is not None and not valid_score(scores.get(dimension))]
+        total = sum(scores[dimension] for dimension in dimensions if valid_score(scores.get(dimension)))
         status = "pass"
-        if invalid:
+        if pair_status:
+            status = pair_status
+            complete = False
+            passed = False
+            structure_invalid = True
+        elif invalid:
             status = "invalid"
             passed = False
         elif missing:
@@ -51,16 +95,19 @@ def main() -> int:
             passed = False
         findings.append({"a": a, "b": b, "score": total, "possible": len(dimensions) * 2, "target": target, "status": status, "missing": missing, "invalid": invalid, "notes": pair.get("notes", "")})
 
-    report = {"generated_at": utc_now(), "target": target, "dimensions": dimensions, "complete": complete, "passed": passed and complete, "pairs": findings}
+    for a, b in sorted(expected_pairs - seen_pairs):
+        findings.append({"a": a, "b": b, "score": 0, "possible": len(dimensions) * 2, "target": target, "status": "missing", "missing": dimensions, "invalid": [], "notes": "No distinctness score was supplied for this direction pair."})
+        complete = False
+        passed = False
+        structure_invalid = True
+
+    report = {"generated_at": utc_now(), "target": target, "dimensions": dimensions, "complete": complete, "passed": passed and complete, "expected_pairs": [{"a": a, "b": b} for a, b in sorted(expected_pairs)], "pairs": findings}
     report_path = args.report_json or (root / "qa/distinctness.json")
     write_json(report_path, report)
 
     for finding in findings:
         print(f"{finding['a']} vs {finding['b']}: {finding['score']}/{finding['possible']}, {finding['status']}")
-    if not findings:
-        print("WARNING: no direction pairs are defined")
-        return 1 if args.strict else 0
-    if args.strict and (not complete or not passed):
+    if structure_invalid or (args.strict and (not complete or not passed)):
         return 1
     return 0
 

--- a/web-design-picker/scripts/check_distinctness.py
+++ b/web-design-picker/scripts/check_distinctness.py
@@ -9,10 +9,44 @@ from itertools import combinations
 from pathlib import Path
 
 from _common import read_json, utc_now, write_json
+from new_project import DISTINCTNESS_DIMENSIONS
+
+MINIMUM_TARGET = 15
 
 
 def valid_score(value: object) -> bool:
     return type(value) is int and value in (0, 1, 2)
+
+
+def rubric_errors(dimensions: object, target: object) -> list[str]:
+    errors = []
+    if not isinstance(dimensions, list):
+        errors.append("dimensions must be a JSON array")
+    else:
+        if not all(isinstance(dimension, str) for dimension in dimensions):
+            errors.append("dimensions must contain only strings")
+        duplicates = []
+        seen = set()
+        for dimension in dimensions:
+            if isinstance(dimension, str) and dimension in seen and dimension not in duplicates:
+                duplicates.append(dimension)
+            if isinstance(dimension, str):
+                seen.add(dimension)
+        missing = [dimension for dimension in DISTINCTNESS_DIMENSIONS if dimension not in dimensions]
+        unknown = [dimension for dimension in dimensions if dimension not in DISTINCTNESS_DIMENSIONS]
+        if duplicates:
+            errors.append(f"dimensions contain duplicates: {', '.join(str(dimension) for dimension in duplicates)}")
+        if missing:
+            errors.append(f"dimensions omit required rubric entries: {', '.join(missing)}")
+        if unknown:
+            errors.append(f"dimensions contain unknown rubric entries: {', '.join(str(dimension) for dimension in unknown)}")
+        if dimensions != DISTINCTNESS_DIMENSIONS:
+            errors.append("dimensions must exactly match the canonical 11-item rubric")
+    if type(target) is not int:
+        errors.append("target must be an integer")
+    elif target < MINIMUM_TARGET:
+        errors.append(f"target must be at least {MINIMUM_TARGET}")
+    return errors
 
 
 def main() -> int:
@@ -46,9 +80,17 @@ def main() -> int:
         print("ERROR: directions.json direction keys must be unique strings")
         return 1
 
-    dimensions = data.get("dimensions") or []
+    dimensions = data.get("dimensions")
     pairs = data.get("pairs") or []
-    target = int(data.get("target", 15))
+    target = data.get("target", MINIMUM_TARGET)
+    errors = rubric_errors(dimensions, target)
+    if errors:
+        report_path = args.report_json or (root / "qa/distinctness.json")
+        write_json(report_path, {"generated_at": utc_now(), "target": target, "dimensions": dimensions, "complete": False, "passed": False, "errors": errors, "pairs": []})
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+
     findings = []
     complete = True
     passed = True

--- a/web-design-picker/scripts/make_asset_variants.py
+++ b/web-design-picker/scripts/make_asset_variants.py
@@ -13,10 +13,7 @@ try:
 except ImportError as exc:  # pragma: no cover
     raise SystemExit("Pillow is required: pip install Pillow") from exc
 
-try:
-    import cairosvg
-except ImportError:
-    cairosvg = None
+from make_favicons import FaviconError, render_svg as render_svg_png
 
 
 def parse_sizes(value: str) -> list[int]:
@@ -33,9 +30,10 @@ def parse_sizes(value: str) -> list[int]:
 
 
 def render_svg(source: Path, long_edge: int) -> Image.Image:
-    if cairosvg is None:
-        raise SystemExit("CairoSVG is required for SVG input: pip install CairoSVG")
-    png = cairosvg.svg2png(url=str(source), output_width=long_edge)
+    try:
+        png = render_svg_png(source, long_edge)
+    except FaviconError as exc:
+        raise SystemExit(str(exc)) from exc
     return Image.open(io.BytesIO(png)).convert("RGBA")
 
 

--- a/web-design-picker/scripts/make_asset_variants.py
+++ b/web-design-picker/scripts/make_asset_variants.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Create reusable SVG/raster asset variants without distributing font files."""
+from __future__ import annotations
+
+import argparse
+import io
+import shutil
+import sys
+from pathlib import Path
+
+try:
+    from PIL import Image
+except ImportError as exc:  # pragma: no cover
+    raise SystemExit("Pillow is required: pip install Pillow") from exc
+
+try:
+    import cairosvg
+except ImportError:
+    cairosvg = None
+
+
+def parse_sizes(value: str) -> list[int]:
+    sizes = []
+    for piece in value.split(","):
+        piece = piece.strip()
+        if not piece:
+            continue
+        size = int(piece)
+        if size < 16 or size > 10000:
+            raise argparse.ArgumentTypeError("sizes must be between 16 and 10000 pixels")
+        sizes.append(size)
+    return sorted(set(sizes))
+
+
+def render_svg(source: Path, long_edge: int) -> Image.Image:
+    if cairosvg is None:
+        raise SystemExit("CairoSVG is required for SVG input: pip install CairoSVG")
+    png = cairosvg.svg2png(url=str(source), output_width=long_edge)
+    return Image.open(io.BytesIO(png)).convert("RGBA")
+
+
+def render_raster(source: Path, long_edge: int) -> Image.Image:
+    image = Image.open(source).convert("RGBA")
+    ratio = long_edge / max(image.width, image.height)
+    width = max(1, round(image.width * ratio))
+    height = max(1, round(image.height * ratio))
+    return image.resize((width, height), Image.Resampling.LANCZOS)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", type=Path)
+    parser.add_argument("output_dir", type=Path)
+    parser.add_argument("--name", help="Output stem; source stem by default")
+    parser.add_argument("--sizes", type=parse_sizes, default=[512, 1800], help="Comma-separated longest-edge PNG sizes")
+    parser.add_argument("--copy-vector", action=argparse.BooleanOptionalAction, default=True)
+    args = parser.parse_args()
+
+    source = args.source.resolve()
+    if not source.exists():
+        print(f"error: source not found: {source}", file=sys.stderr)
+        return 1
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stem = args.name or source.stem
+
+    outputs = []
+    if source.suffix.lower() == ".svg" and args.copy_vector:
+        vector_path = output_dir / f"{stem}.svg"
+        shutil.copy2(source, vector_path)
+        outputs.append(vector_path)
+
+    for size in args.sizes:
+        if source.suffix.lower() == ".svg":
+            image = render_svg(source, size)
+        else:
+            image = render_raster(source, size)
+        path = output_dir / f"{stem}-{size}.png"
+        image.save(path, "PNG", optimize=True)
+        outputs.append(path)
+
+    for path in outputs:
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web-design-picker/scripts/make_asset_variants.py
+++ b/web-design-picker/scripts/make_asset_variants.py
@@ -7,12 +7,14 @@ import io
 import shutil
 import sys
 from pathlib import Path
+from xml.etree import ElementTree
 
 try:
     from PIL import Image
 except ImportError as exc:  # pragma: no cover
     raise SystemExit("Pillow is required: pip install Pillow") from exc
 
+from _common import validate_output_stem
 from make_favicons import FaviconError, render_svg as render_svg_png
 
 
@@ -29,12 +31,40 @@ def parse_sizes(value: str) -> list[int]:
     return sorted(set(sizes))
 
 
-def render_svg(source: Path, long_edge: int) -> Image.Image:
+def svg_aspect_ratio(source: Path) -> float | None:
     try:
-        png = render_svg_png(source, long_edge)
+        root = ElementTree.parse(source).getroot()
+    except ElementTree.ParseError:
+        return None
+    view_box = root.get("viewBox", "").replace(",", " ").split()
+    if len(view_box) == 4:
+        try:
+            width, height = float(view_box[2]), float(view_box[3])
+            if width > 0 and height > 0:
+                return width / height
+        except ValueError:
+            pass
+    return None
+
+
+def fit_longest_edge(image: Image.Image, long_edge: int) -> Image.Image:
+    longest = max(image.width, image.height)
+    if longest == long_edge:
+        return image
+    ratio = long_edge / longest
+    width = max(1, round(image.width * ratio))
+    height = max(1, round(image.height * ratio))
+    return image.resize((width, height), Image.Resampling.LANCZOS)
+
+
+def render_svg(source: Path, long_edge: int) -> Image.Image:
+    aspect_ratio = svg_aspect_ratio(source)
+    render_width = long_edge if aspect_ratio is None or aspect_ratio >= 1 else max(1, round(long_edge * aspect_ratio))
+    try:
+        png = render_svg_png(source, render_width)
     except FaviconError as exc:
         raise SystemExit(str(exc)) from exc
-    return Image.open(io.BytesIO(png)).convert("RGBA")
+    return fit_longest_edge(Image.open(io.BytesIO(png)).convert("RGBA"), long_edge)
 
 
 def render_raster(source: Path, long_edge: int) -> Image.Image:
@@ -45,22 +75,26 @@ def render_raster(source: Path, long_edge: int) -> Image.Image:
     return image.resize((width, height), Image.Resampling.LANCZOS)
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("source", type=Path)
     parser.add_argument("output_dir", type=Path)
     parser.add_argument("--name", help="Output stem; source stem by default")
     parser.add_argument("--sizes", type=parse_sizes, default=[512, 1800], help="Comma-separated longest-edge PNG sizes")
     parser.add_argument("--copy-vector", action=argparse.BooleanOptionalAction, default=True)
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     source = args.source.resolve()
     if not source.exists():
         print(f"error: source not found: {source}", file=sys.stderr)
         return 1
+    try:
+        stem = validate_output_stem(args.name or source.stem)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     output_dir = args.output_dir.resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
-    stem = args.name or source.stem
 
     outputs = []
     if source.suffix.lower() == ".svg" and args.copy_vector:

--- a/web-design-picker/scripts/make_favicons.py
+++ b/web-design-picker/scripts/make_favicons.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Generate a complete SVG/ICO/PNG favicon family."""
+from __future__ import annotations
+
+import argparse
+import io
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+class FaviconError(RuntimeError):
+    pass
+
+
+def render_svg(source: Path, render_width: int, render_height: int | None = None) -> bytes:
+    """Render SVG bytes with resvg, then fall back to a working CairoSVG install."""
+    render_height = render_height or render_width
+    executable_name = "resvg.exe" if sys.platform == "win32" else "resvg"
+    resvg = shutil.which("resvg")
+    if not resvg:
+        adjacent = Path(sys.executable).with_name(executable_name)
+        if adjacent.is_file():
+            resvg = str(adjacent)
+
+    if resvg:
+        with tempfile.TemporaryDirectory(prefix="web-design-picker-svg-") as temporary:
+            output = Path(temporary) / "rendered.png"
+            result = subprocess.run(
+                [
+                    resvg,
+                    str(source),
+                    str(output),
+                    "--width",
+                    str(render_width),
+                    "--height",
+                    str(render_height),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0 and output.is_file():
+                return output.read_bytes()
+            detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+            raise FaviconError(f"resvg could not render {source.name}: {detail}")
+
+    try:
+        import cairosvg
+
+        return cairosvg.svg2png(
+            url=str(source),
+            output_width=render_width,
+            output_height=render_height,
+        )
+    except (ImportError, OSError) as exc:
+        raise FaviconError(
+            "SVG input requires resvg-cli, or CairoSVG with its native Cairo library: "
+            "python -m pip install resvg-cli"
+        ) from exc
+
+
+def load_image(source: Path, render_size: int):
+    try:
+        from PIL import Image
+    except ImportError as exc:
+        raise FaviconError("Pillow is required: python -m pip install Pillow") from exc
+    if source.suffix.lower() == ".svg":
+        png = render_svg(source, render_size)
+        return Image.open(io.BytesIO(png)).convert("RGBA")
+    return Image.open(source).convert("RGBA")
+
+
+def square_fit(image, size: int, background: str, padding: float):
+    from PIL import Image, ImageColor
+
+    fill = (0, 0, 0, 0) if background == "transparent" else ImageColor.getcolor(background, "RGBA")
+    canvas = Image.new("RGBA", (size, size), fill)
+    inner = max(1, round(size * (1 - padding * 2)))
+    work = image.copy()
+    work.thumbnail((inner, inner), Image.Resampling.LANCZOS)
+    x = (size - work.width) // 2
+    y = (size - work.height) // 2
+    canvas.alpha_composite(work, (x, y))
+    return canvas
+
+
+def generate_favicon_set(
+    source: Path,
+    output_dir: Path,
+    *,
+    background: str = "transparent",
+    padding: float = 0.08,
+) -> list[Path]:
+    """Generate SVG (when supplied), ICO, 32, 180, 192 and 512 PNGs."""
+    from PIL import Image
+
+    source = source.resolve()
+    output_dir = output_dir.resolve()
+    if not source.is_file():
+        raise FaviconError(f"Source image does not exist: {source}")
+    if not 0 <= padding <= 0.35:
+        raise FaviconError("padding must be between 0 and .35")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    base = load_image(source, 1024)
+    master = square_fit(base, 1024, background, padding)
+    generated: list[Path] = []
+    for size in (32, 180, 192, 512):
+        path = output_dir / f"favicon-{size}.png"
+        master.resize((size, size), Image.Resampling.LANCZOS).save(path, "PNG", optimize=True)
+        generated.append(path)
+
+    ico = output_dir / "favicon.ico"
+    master.save(ico, format="ICO", sizes=[(16, 16), (32, 32), (48, 48)])
+    generated.append(ico)
+
+    if source.suffix.lower() == ".svg":
+        svg = output_dir / "favicon.svg"
+        if source != svg.resolve():
+            shutil.copy2(source, svg)
+        generated.insert(0, svg)
+    else:
+        png = output_dir / "favicon.png"
+        master.save(png, "PNG", optimize=True)
+        generated.insert(0, png)
+    return generated
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", type=Path)
+    parser.add_argument("output_dir", type=Path)
+    parser.add_argument("--background", default="transparent", help="transparent or a CSS color such as #ffffff")
+    parser.add_argument("--padding", type=float, default=0.08, help="Fractional edge padding, from 0 to .35")
+    args = parser.parse_args(argv)
+    try:
+        generated = generate_favicon_set(
+            args.source,
+            args.output_dir,
+            background=args.background,
+            padding=args.padding,
+        )
+        print("Generated:")
+        for path in generated:
+            print(path)
+        return 0
+    except (FaviconError, OSError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web-design-picker/scripts/make_favicons.py
+++ b/web-design-picker/scripts/make_favicons.py
@@ -16,7 +16,7 @@ class FaviconError(RuntimeError):
 
 
 def render_svg(source: Path, render_width: int, render_height: int | None = None) -> bytes:
-    """Render SVG bytes with resvg, then fall back to a working CairoSVG install."""
+    """Render SVG bytes with resvg, or use CairoSVG when resvg is unavailable."""
     render_height = render_height or render_width
     executable_name = "resvg.exe" if sys.platform == "win32" else "resvg"
     resvg = shutil.which("resvg")

--- a/web-design-picker/scripts/make_favicons.py
+++ b/web-design-picker/scripts/make_favicons.py
@@ -17,7 +17,6 @@ class FaviconError(RuntimeError):
 
 def render_svg(source: Path, render_width: int, render_height: int | None = None) -> bytes:
     """Render SVG bytes with resvg, or use CairoSVG when resvg is unavailable."""
-    render_height = render_height or render_width
     executable_name = "resvg.exe" if sys.platform == "win32" else "resvg"
     resvg = shutil.which("resvg")
     if not resvg:
@@ -28,16 +27,11 @@ def render_svg(source: Path, render_width: int, render_height: int | None = None
     if resvg:
         with tempfile.TemporaryDirectory(prefix="web-design-picker-svg-") as temporary:
             output = Path(temporary) / "rendered.png"
+            command = [resvg, str(source), str(output), "--width", str(render_width)]
+            if render_height is not None:
+                command.extend(["--height", str(render_height)])
             result = subprocess.run(
-                [
-                    resvg,
-                    str(source),
-                    str(output),
-                    "--width",
-                    str(render_width),
-                    "--height",
-                    str(render_height),
-                ],
+                command,
                 capture_output=True,
                 text=True,
             )
@@ -49,11 +43,10 @@ def render_svg(source: Path, render_width: int, render_height: int | None = None
     try:
         import cairosvg
 
-        return cairosvg.svg2png(
-            url=str(source),
-            output_width=render_width,
-            output_height=render_height,
-        )
+        options = {"url": str(source), "output_width": render_width}
+        if render_height is not None:
+            options["output_height"] = render_height
+        return cairosvg.svg2png(**options)
     except (ImportError, OSError) as exc:
         raise FaviconError(
             "SVG input requires resvg-cli, or CairoSVG with its native Cairo library: "
@@ -67,7 +60,7 @@ def load_image(source: Path, render_size: int):
     except ImportError as exc:
         raise FaviconError("Pillow is required: python -m pip install Pillow") from exc
     if source.suffix.lower() == ".svg":
-        png = render_svg(source, render_size)
+        png = render_svg(source, render_size, render_size)
         return Image.open(io.BytesIO(png)).convert("RGBA")
     return Image.open(source).convert("RGBA")
 

--- a/web-design-picker/scripts/make_palette.py
+++ b/web-design-picker/scripts/make_palette.py
@@ -9,6 +9,7 @@ import re
 import sys
 from pathlib import Path
 
+from _common import validate_output_stem
 from make_favicons import FaviconError, render_svg
 
 HEX = re.compile(r"^#[0-9a-fA-F]{6}$")
@@ -31,14 +32,19 @@ def contrast_text(hex_color: str) -> str:
     return "#111111" if luminance > 0.6 else "#ffffff"
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("output_dir", type=Path)
     parser.add_argument("--name", default="palette")
     parser.add_argument("--title", default="Color palette")
     parser.add_argument("tokens", nargs="+", type=parse_token, help="Token assignments such as background=#f2efe8")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
+    try:
+        stem = validate_output_stem(args.name)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     output_dir = args.output_dir.resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
     tokens = dict(args.tokens)
@@ -64,8 +70,8 @@ def main() -> int:
         + '</svg>'
     )
 
-    svg_path = output_dir / f"{args.name}.svg"
-    png_path = output_dir / f"{args.name}.png"
+    svg_path = output_dir / f"{stem}.svg"
+    png_path = output_dir / f"{stem}.png"
     css_path = output_dir / "color-tokens.css"
     json_path = output_dir / "color-tokens.json"
 

--- a/web-design-picker/scripts/make_palette.py
+++ b/web-design-picker/scripts/make_palette.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Generate SVG/PNG palette sheets and CSS/JSON design tokens."""
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+import sys
+from pathlib import Path
+
+from make_favicons import FaviconError, render_svg
+
+HEX = re.compile(r"^#[0-9a-fA-F]{6}$")
+
+
+def parse_token(value: str) -> tuple[str, str]:
+    if "=" not in value:
+        raise argparse.ArgumentTypeError("tokens must use name=#rrggbb")
+    name, color = value.split("=", 1)
+    name = re.sub(r"[^a-z0-9-]+", "-", name.strip().lower()).strip("-")
+    color = color.strip()
+    if not name or not HEX.match(color):
+        raise argparse.ArgumentTypeError(f"invalid token: {value}")
+    return name, color.lower()
+
+
+def contrast_text(hex_color: str) -> str:
+    r, g, b = (int(hex_color[index:index + 2], 16) for index in (1, 3, 5))
+    luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
+    return "#111111" if luminance > 0.6 else "#ffffff"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output_dir", type=Path)
+    parser.add_argument("--name", default="palette")
+    parser.add_argument("--title", default="Color palette")
+    parser.add_argument("tokens", nargs="+", type=parse_token, help="Token assignments such as background=#f2efe8")
+    args = parser.parse_args()
+
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    tokens = dict(args.tokens)
+
+    swatch_width = 260
+    swatch_height = 150
+    width = swatch_width * len(tokens)
+    height = 220
+    swatches = []
+    for index, (name, color) in enumerate(tokens.items()):
+        x = index * swatch_width
+        text = contrast_text(color)
+        swatches.append(
+            f'<rect x="{x}" y="0" width="{swatch_width}" height="{swatch_height}" fill="{color}"/>'
+            f'<text x="{x + 18}" y="42" fill="{text}" font-family="Arial, Helvetica, sans-serif" font-size="18" font-weight="700">{html.escape(name)}</text>'
+            f'<text x="{x + 18}" y="126" fill="{text}" font-family="Courier New, monospace" font-size="16">{color.upper()}</text>'
+        )
+    svg = (
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">'
+        f'<rect width="{width}" height="{height}" fill="#ffffff"/>'
+        + "".join(swatches)
+        + f'<text x="18" y="194" fill="#111111" font-family="Arial, Helvetica, sans-serif" font-size="22" font-weight="700">{html.escape(args.title)}</text>'
+        + '</svg>'
+    )
+
+    svg_path = output_dir / f"{args.name}.svg"
+    png_path = output_dir / f"{args.name}.png"
+    css_path = output_dir / "color-tokens.css"
+    json_path = output_dir / "color-tokens.json"
+
+    svg_path.write_text(svg, encoding="utf-8")
+    try:
+        png_path.write_bytes(render_svg(svg_path, width, height))
+    except FaviconError as exc:
+        raise SystemExit(str(exc)) from exc
+    css_lines = [":root {"] + [f"  --color-{name}: {color};" for name, color in tokens.items()] + ["}"]
+    css_path.write_text("\n".join(css_lines) + "\n", encoding="utf-8")
+    json_path.write_text(json.dumps({"color": tokens}, indent=2) + "\n", encoding="utf-8")
+
+    for path in [svg_path, png_path, css_path, json_path]:
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web-design-picker/scripts/new_project.py
+++ b/web-design-picker/scripts/new_project.py
@@ -7,6 +7,8 @@ import html
 import json
 import shutil
 import sys
+import tempfile
+import uuid
 from itertools import combinations
 from pathlib import Path
 
@@ -151,25 +153,7 @@ def render_concept(template: str, project_name: str, direction: dict) -> str:
     return template
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("project_dir", type=Path)
-    parser.add_argument("--name", required=True, help="Organization or project name")
-    parser.add_argument("--slug", help="Output slug; generated from name by default")
-    parser.add_argument("--directions", type=int, default=3, choices=range(2, 6))
-    parser.add_argument("--force", action="store_true", help="Replace an existing project directory")
-    args = parser.parse_args()
-
-    root = args.project_dir.resolve()
-    if root.exists() and any(root.iterdir()) and not args.force:
-        print(f"error: {root} is not empty; use --force to replace it", file=sys.stderr)
-        return 1
-    try:
-        slug = validate_slug(args.slug) if args.slug else slugify(args.name)
-    except ValueError as exc:
-        print(f"error: {exc}", file=sys.stderr)
-        return 1
-
+def scaffold_project(root: Path, args: argparse.Namespace, slug: str) -> None:
     ensure_clean_dir(root)
     directions = []
     for index, seed in enumerate(DIRECTION_SEEDS[: args.directions]):
@@ -350,6 +334,55 @@ Cloudflare Drop receives `deliverables/{slug}-cloudflare-drop.zip`.
 """,
     )
     write_text(root / "design-package/notes/README.md", "# Asset notes\n\nRecord source, creator, license, modifications, trademark constraints, and intended use for every third-party or generated asset.\n")
+
+def replace_project(staged: Path, destination: Path) -> None:
+    backup = None
+    try:
+        if destination.exists():
+            backup = destination.with_name(f".{destination.name}.backup-{uuid.uuid4().hex}")
+            destination.replace(backup)
+        staged.replace(destination)
+    except OSError:
+        if backup and backup.exists():
+            backup.replace(destination)
+        raise
+    if backup and backup.exists():
+        shutil.rmtree(backup)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("project_dir", type=Path)
+    parser.add_argument("--name", required=True, help="Organization or project name")
+    parser.add_argument("--slug", help="Output slug; generated from name by default")
+    parser.add_argument("--directions", type=int, default=3, choices=range(2, 6))
+    parser.add_argument("--force", action="store_true", help="Replace an existing project directory")
+    args = parser.parse_args(argv)
+
+    root = args.project_dir.resolve()
+    if root.exists() and not root.is_dir():
+        print(f"error: {root} is not a directory", file=sys.stderr)
+        return 1
+    if root.exists() and any(root.iterdir()) and not args.force:
+        print(f"error: {root} is not empty; use --force to replace it", file=sys.stderr)
+        return 1
+    try:
+        slug = validate_slug(args.slug) if args.slug else slugify(args.name)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    root.parent.mkdir(parents=True, exist_ok=True)
+    staged = Path(tempfile.mkdtemp(prefix=f".{root.name}.staging-", dir=root.parent))
+    try:
+        scaffold_project(staged, args, slug)
+        replace_project(staged, root)
+    except Exception as exc:
+        print(f"error: could not create {root}: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        if staged.exists():
+            shutil.rmtree(staged)
 
     print(f"Created {root}")
     print("Next: complete the evidence and direction briefs, replace the starter concepts, register assets, and score distinctness.")

--- a/web-design-picker/scripts/new_project.py
+++ b/web-design-picker/scripts/new_project.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Scaffold a two-to-five direction web-design-picker project."""
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import shutil
+import sys
+from itertools import combinations
+from pathlib import Path
+
+from _common import SKILL_ROOT, ensure_clean_dir, slugify, write_json, write_text
+from make_favicons import generate_favicon_set
+
+DIRECTION_SEEDS = [
+    {
+        "key": "evidence-led",
+        "label": "Evidence-led editorial",
+        "description": "A proof-first direction organized around real work, artifacts, and outcomes.",
+        "accent": "#d84a32",
+        "background": "#f3f1ea",
+        "text": "#151719",
+        "line": "#9b9c98",
+    },
+    {
+        "key": "operational-system",
+        "label": "Operational system",
+        "description": "A task-oriented direction that makes workflow, tools, and handoffs visible.",
+        "accent": "#41b6d4",
+        "background": "#101416",
+        "text": "#f3f6f7",
+        "line": "#4d575b",
+    },
+    {
+        "key": "brand-statement",
+        "label": "Brand statement",
+        "description": "A forceful, typography-led direction built around one memorable organizing idea.",
+        "accent": "#f06428",
+        "background": "#f0eee8",
+        "text": "#121212",
+        "line": "#121212",
+    },
+    {
+        "key": "reference-manual",
+        "label": "Reference manual",
+        "description": "A structured, information-dense direction that behaves like a useful field guide.",
+        "accent": "#1d6c5b",
+        "background": "#f6f7f3",
+        "text": "#15201d",
+        "line": "#75827e",
+    },
+    {
+        "key": "human-narrative",
+        "label": "Human narrative",
+        "description": "A story-led direction that foregrounds people, context, and consequences.",
+        "accent": "#9c3f56",
+        "background": "#fffaf4",
+        "text": "#261b1e",
+        "line": "#a79b9e",
+    },
+]
+
+DISTINCTNESS_DIMENSIONS = [
+    "positioning-and-primary-message",
+    "information-architecture",
+    "hero-opening-composition",
+    "typography",
+    "grid-and-spatial-rhythm",
+    "shape-and-edge-language",
+    "color-logic",
+    "image-and-video-treatment",
+    "interaction-model",
+    "cta-and-conversion-pattern",
+    "emotional-register",
+]
+
+
+def mark_svg(label: str, accent: str, background: str, text: str, index: int) -> str:
+    safe = html.escape(label[:1].upper())
+    if index % 3 == 0:
+        form = f'<path d="M38 30 70 64 38 98M90 30 58 64 90 98" fill="none" stroke="{text}" stroke-width="12" stroke-linecap="square"/>'
+    elif index % 3 == 1:
+        form = f'<rect x="29" y="29" width="70" height="70" fill="none" stroke="{text}" stroke-width="10"/><path d="M29 82 99 46" stroke="{accent}" stroke-width="12"/>'
+    else:
+        form = f'<circle cx="64" cy="64" r="40" fill="none" stroke="{text}" stroke-width="10"/><text x="64" y="78" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="48" font-weight="700" fill="{accent}">{safe}</text>'
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128" role="img" aria-label="Placeholder mark for {html.escape(label)}"><rect width="128" height="128" fill="{background}"/>{form}</svg>'''
+
+
+def lockup_svg(project_name: str, label: str, mark_href: str, background: str, text: str, accent: str) -> str:
+    # Uses live text for easy editing. Production work should also export outlined artwork.
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="300" viewBox="0 0 1200 300" role="img" aria-label="{html.escape(project_name)} {html.escape(label)} placeholder lockup"><rect width="1200" height="300" fill="{background}"/><image href="{html.escape(mark_href)}" x="50" y="50" width="200" height="200"/><text x="300" y="142" font-family="Arial,Helvetica,sans-serif" font-size="72" font-weight="700" fill="{text}">{html.escape(project_name)}</text><text x="303" y="199" font-family="Courier New,monospace" font-size="26" fill="{accent}">{html.escape(label)}</text></svg>'''
+
+
+def palette_files(output_dir: Path, direction: dict) -> list[Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    colors = {
+        "background": direction["background"],
+        "text": direction["text"],
+        "accent": direction["accent"],
+        "line": direction["line"],
+    }
+    swatch_w = 280
+    swatches = []
+    for index, (name, color) in enumerate(colors.items()):
+        x = index * swatch_w
+        swatches.append(
+            f'<rect x="{x}" width="{swatch_w}" height="180" fill="{color}"/>'
+            f'<text x="{x + 18}" y="218" font-family="Arial,Helvetica,sans-serif" font-size="22" font-weight="700" fill="#111">{name}</text>'
+            f'<text x="{x + 18}" y="252" font-family="Courier New,monospace" font-size="18" fill="#333">{color.upper()}</text>'
+        )
+    svg = f'<svg xmlns="http://www.w3.org/2000/svg" width="{swatch_w * len(colors)}" height="280" viewBox="0 0 {swatch_w * len(colors)} 280"><rect width="100%" height="100%" fill="#fff"/>{"".join(swatches)}</svg>'
+    svg_path = output_dir / "palette.svg"
+    css_path = output_dir / "color-tokens.css"
+    json_path = output_dir / "color-tokens.json"
+    write_text(svg_path, svg)
+    write_text(css_path, ":root {\n" + "\n".join(f"  --color-{name}: {value};" for name, value in colors.items()) + "\n}\n")
+    write_json(json_path, {"color": colors})
+    try:
+        import cairosvg
+        png_path = output_dir / "palette.png"
+        cairosvg.svg2png(bytestring=svg.encode("utf-8"), write_to=str(png_path))
+        return [svg_path, png_path, css_path, json_path]
+    except Exception:
+        return [svg_path, css_path, json_path]
+
+
+def favicon_file_entries(prefix: str) -> list[dict[str, str]]:
+    return [
+        {"label": "SVG", "href": f"{prefix}/favicon.svg", "format": "SVG", "notes": "Editable vector"},
+        {"label": "ICO", "href": f"{prefix}/favicon.ico", "format": "ICO", "notes": "Browser fallback"},
+        {"label": "32 PNG", "href": f"{prefix}/favicon-32.png", "format": "PNG", "dimensions": "32×32"},
+        {"label": "Touch", "href": f"{prefix}/favicon-180.png", "format": "PNG", "dimensions": "180×180"},
+        {"label": "192 PNG", "href": f"{prefix}/favicon-192.png", "format": "PNG", "dimensions": "192×192"},
+        {"label": "512 PNG", "href": f"{prefix}/favicon-512.png", "format": "PNG", "dimensions": "512×512"},
+    ]
+
+
+def render_concept(template: str, project_name: str, direction: dict) -> str:
+    replacements = {
+        "__PROJECT_NAME__": project_name,
+        "__DIRECTION_LABEL__": direction["label"],
+        "__DIRECTION_DESCRIPTION__": direction["description"],
+        "__DIRECTION_KEY__": direction["key"],
+        "__BACKGROUND__": direction["background"],
+        "__TEXT__": direction["text"],
+        "__ACCENT__": direction["accent"],
+        "__LINE__": direction["line"],
+    }
+    for old, new in replacements.items():
+        template = template.replace(old, str(new))
+    return template
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("project_dir", type=Path)
+    parser.add_argument("--name", required=True, help="Organization or project name")
+    parser.add_argument("--slug", help="Output slug; generated from name by default")
+    parser.add_argument("--directions", type=int, default=3, choices=range(2, 6))
+    parser.add_argument("--force", action="store_true", help="Replace an existing project directory")
+    args = parser.parse_args()
+
+    root = args.project_dir.resolve()
+    if root.exists() and any(root.iterdir()) and not args.force:
+        print(f"error: {root} is not empty; use --force to replace it", file=sys.stderr)
+        return 1
+    ensure_clean_dir(root)
+
+    slug = args.slug or slugify(args.name)
+    directions = []
+    for index, seed in enumerate(DIRECTION_SEEDS[: args.directions]):
+        direction = dict(seed)
+        direction["file"] = f"concepts/{direction['key']}.html"
+        direction["tradeoff"] = "Replace with the real strategic tradeoff before presentation."
+        directions.append(direction)
+
+    project = {
+        "name": args.name,
+        "slug": slug,
+        "language": "en",
+        "review_title": f"{args.name}: website design review",
+        "review_subtitle": "Website direction review",
+        "review_description": f"Compare responsive website design directions for {args.name}.",
+        "theme_color": "#111315",
+        "active_color": directions[0]["accent"],
+        "robots": "noindex,nofollow",
+        "default_direction": directions[0]["key"],
+        "library_note": "Concept assets are supplied for review. Confirm trademark, licensing, font, privacy, and production requirements before public use.",
+        "review_favicon": "assets/brand/review/favicon.svg",
+        "asset_zip_name": f"{slug}-all-design-assets.zip",
+    }
+
+    for directory in [
+        "config",
+        "src/concepts",
+        "src/assets/brand/review",
+        "src/assets/brand",
+        "src/assets/media/originals",
+        "src/assets/media/web",
+        "design-package/logos",
+        "design-package/favicons",
+        "design-package/palettes",
+        "design-package/graphic-elements",
+        "design-package/media/originals",
+        "design-package/media/web",
+        "design-package/notes",
+        "dist",
+        "previews",
+        "qa",
+        "deliverables",
+    ]:
+        (root / directory).mkdir(parents=True, exist_ok=True)
+
+    concept_template = (SKILL_ROOT / "assets/concept-starter.html").read_text(encoding="utf-8")
+
+    # Neutral review-shell identity.
+    review_mark = root / "src/assets/brand/review/favicon.svg"
+    write_text(review_mark, mark_svg(args.name, "#f06428", "#111315", "#ffffff", 1))
+    generate_favicon_set(review_mark, review_mark.parent, padding=0.05)
+    shared_favicon_dir = root / "design-package/favicons/review-shell"
+    shutil.copytree(review_mark.parent, shared_favicon_dir, dirs_exist_ok=True)
+
+    shared_groups = [
+        {
+            "title": "Review-shell favicon family",
+            "description": "Neutral icons used by the comparison picker and asset catalog.",
+            "preview": "assets/design-package/favicons/review-shell/favicon-192.png",
+            "preview_alt": f"Placeholder review favicon for {args.name}",
+            "files": favicon_file_entries("assets/design-package/favicons/review-shell"),
+        }
+    ]
+    asset_directions = []
+
+    for index, direction in enumerate(directions):
+        key = direction["key"]
+        concept_file = root / "src" / direction["file"]
+        write_text(concept_file, render_concept(concept_template, args.name, direction))
+
+        logo_dir = root / "design-package/logos" / key
+        logo_dir.mkdir(parents=True, exist_ok=True)
+        mark_path = logo_dir / f"{slug}-{key}-mark.svg"
+        write_text(mark_path, mark_svg(direction["label"], direction["accent"], direction["background"], direction["text"], index))
+        lockup_path = logo_dir / f"{slug}-{key}-lockup.svg"
+        write_text(lockup_path, lockup_svg(args.name, direction["label"], mark_path.name, direction["background"], direction["text"], direction["accent"]))
+
+        favicon_dir = root / "src/assets/brand" / key
+        generate_favicon_set(mark_path, favicon_dir, padding=0.05)
+        design_favicon_dir = root / "design-package/favicons" / key
+        shutil.copytree(favicon_dir, design_favicon_dir, dirs_exist_ok=True)
+        palette_output = root / "design-package/palettes" / key
+        palette_outputs = palette_files(palette_output, direction)
+
+        group_prefix = f"assets/design-package"
+        groups = [
+            {
+                "title": "Concept identity",
+                "description": "Starter mark and editable lockup. Replace with approved production artwork.",
+                "preview": f"{group_prefix}/logos/{key}/{slug}-{key}-lockup.svg",
+                "preview_alt": f"Placeholder identity for {direction['label']}",
+                "files": [
+                    {"label": "Mark SVG", "href": f"{group_prefix}/logos/{key}/{slug}-{key}-mark.svg", "format": "SVG"},
+                    {"label": "Lockup SVG", "href": f"{group_prefix}/logos/{key}/{slug}-{key}-lockup.svg", "format": "SVG", "notes": "Live text; export outlined artwork for final handoff"},
+                ],
+            },
+            {
+                "title": "Favicon family",
+                "description": "Direction-specific SVG, ICO, touch icon, and app-icon sizes.",
+                "preview": f"{group_prefix}/favicons/{key}/favicon-192.png",
+                "preview_alt": f"Favicon for {direction['label']}",
+                "files": favicon_file_entries(f"{group_prefix}/favicons/{key}"),
+            },
+            {
+                "title": "Color palette and tokens",
+                "description": "Visual palette sheet plus machine-readable CSS and JSON tokens.",
+                "preview": f"{group_prefix}/palettes/{key}/palette.svg",
+                "preview_alt": f"Color palette for {direction['label']}",
+                "files": [
+                    {
+                        "label": output.suffix.lstrip(".").upper(),
+                        "href": f"{group_prefix}/palettes/{key}/{output.name}",
+                        "format": output.suffix.lstrip(".").upper(),
+                    }
+                    for output in palette_outputs
+                ],
+            },
+        ]
+        asset_directions.append({"key": key, "label": direction["label"], "accent": direction["accent"], "groups": groups})
+
+    assets = {"shared": shared_groups, "directions": asset_directions}
+    write_json(root / "config/project.json", project)
+    write_json(root / "config/directions.json", directions)
+    write_json(root / "config/assets.json", assets)
+
+    pairs = []
+    for a, b in combinations(directions, 2):
+        pairs.append({
+            "a": a["key"],
+            "b": b["key"],
+            "scores": {dimension: None for dimension in DISTINCTNESS_DIMENSIONS},
+            "notes": "",
+        })
+    write_json(root / "config/distinctness.json", {"target": 15, "dimensions": DISTINCTNESS_DIMENSIONS, "pairs": pairs})
+
+    brief = f"""# {args.name} website design brief
+
+## Audience
+
+## Primary decision or conversion
+
+## Current site and source files
+
+## Verified positioning and services
+
+## Strongest differentiator or proof
+
+## Required content
+
+## Constraints and anti-patterns
+
+## Unverified claims to exclude
+
+## Hosting and delivery target
+"""
+    write_text(root / "BRIEF.md", brief)
+    write_text(root / "CLAIM-LEDGER.md", "# Claim ledger\n\n| Claim | Source | Status | Use in concepts |\n|---|---|---|---|\n")
+    write_text(
+        root / "DIRECTION-BRIEFS.md",
+        "# Direction briefs\n\nFor each direction, document the strategic thesis, five-second impression, content rule, visual grammar, proof placement, interaction ceiling, rejected conventions, tradeoff, and likely chooser.\n",
+    )
+    write_text(
+        root / "README.md",
+        f"""# {args.name} web-design-picker project
+
+1. Complete `BRIEF.md`, `CLAIM-LEDGER.md`, and `DIRECTION-BRIEFS.md`.
+2. Rename and refine the directions in `config/directions.json`.
+3. Replace each starter page under `src/concepts/` with a genuinely distinct, complete responsive concept.
+4. Add production assets to `design-package/` and register every variant in `config/assets.json`.
+5. Score every pair in `config/distinctness.json`.
+6. Run:
+
+```bash
+python PATH_TO_SKILL/scripts/run_factory.py . --test-downloads
+```
+
+Cloudflare Drop receives `deliverables/{slug}-cloudflare-drop.zip`.
+""",
+    )
+    write_text(root / "design-package/notes/README.md", "# Asset notes\n\nRecord source, creator, license, modifications, trademark constraints, and intended use for every third-party or generated asset.\n")
+
+    print(f"Created {root}")
+    print("Next: complete the evidence and direction briefs, replace the starter concepts, register assets, and score distinctness.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web-design-picker/scripts/new_project.py
+++ b/web-design-picker/scripts/new_project.py
@@ -164,13 +164,13 @@ def main() -> int:
     if root.exists() and any(root.iterdir()) and not args.force:
         print(f"error: {root} is not empty; use --force to replace it", file=sys.stderr)
         return 1
-    ensure_clean_dir(root)
-
     try:
         slug = validate_slug(args.slug) if args.slug else slugify(args.name)
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
+
+    ensure_clean_dir(root)
     directions = []
     for index, seed in enumerate(DIRECTION_SEEDS[: args.directions]):
         direction = dict(seed)

--- a/web-design-picker/scripts/new_project.py
+++ b/web-design-picker/scripts/new_project.py
@@ -10,8 +10,8 @@ import sys
 from itertools import combinations
 from pathlib import Path
 
-from _common import SKILL_ROOT, ensure_clean_dir, slugify, write_json, write_text
-from make_favicons import generate_favicon_set
+from _common import SKILL_ROOT, ensure_clean_dir, slugify, validate_slug, write_json, write_text
+from make_favicons import FaviconError, generate_favicon_set, render_svg
 
 DIRECTION_SEEDS = [
     {
@@ -116,13 +116,12 @@ def palette_files(output_dir: Path, direction: dict) -> list[Path]:
     write_text(svg_path, svg)
     write_text(css_path, ":root {\n" + "\n".join(f"  --color-{name}: {value};" for name, value in colors.items()) + "\n}\n")
     write_json(json_path, {"color": colors})
+    png_path = output_dir / "palette.png"
     try:
-        import cairosvg
-        png_path = output_dir / "palette.png"
-        cairosvg.svg2png(bytestring=svg.encode("utf-8"), write_to=str(png_path))
-        return [svg_path, png_path, css_path, json_path]
-    except Exception:
+        png_path.write_bytes(render_svg(svg_path, swatch_w * len(colors), 280))
+    except FaviconError:
         return [svg_path, css_path, json_path]
+    return [svg_path, png_path, css_path, json_path]
 
 
 def favicon_file_entries(prefix: str) -> list[dict[str, str]]:
@@ -138,9 +137,9 @@ def favicon_file_entries(prefix: str) -> list[dict[str, str]]:
 
 def render_concept(template: str, project_name: str, direction: dict) -> str:
     replacements = {
-        "__PROJECT_NAME__": project_name,
-        "__DIRECTION_LABEL__": direction["label"],
-        "__DIRECTION_DESCRIPTION__": direction["description"],
+        "__PROJECT_NAME__": html.escape(project_name),
+        "__DIRECTION_LABEL__": html.escape(str(direction["label"])),
+        "__DIRECTION_DESCRIPTION__": html.escape(str(direction["description"])),
         "__DIRECTION_KEY__": direction["key"],
         "__BACKGROUND__": direction["background"],
         "__TEXT__": direction["text"],
@@ -167,7 +166,11 @@ def main() -> int:
         return 1
     ensure_clean_dir(root)
 
-    slug = args.slug or slugify(args.name)
+    try:
+        slug = validate_slug(args.slug) if args.slug else slugify(args.name)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     directions = []
     for index, seed in enumerate(DIRECTION_SEEDS[: args.directions]):
         direction = dict(seed)

--- a/web-design-picker/scripts/optimize_video.py
+++ b/web-design-picker/scripts/optimize_video.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Optimize supplied video for static website use and create poster frames."""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from _common import format_bytes
+
+
+def run(command: list[str]) -> None:
+    result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"Command failed:\n{' '.join(command)}\n{result.stderr[-4000:]}")
+
+
+def duration_seconds(source: Path) -> float:
+    result = subprocess.run(
+        ["ffprobe", "-v", "error", "-show_entries", "format=duration", "-of", "json", str(source)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"ffprobe failed: {result.stderr}")
+    data = json.loads(result.stdout)
+    return float(data["format"]["duration"])
+
+
+def scale_filter(width: int, fps: int) -> str:
+    return f"scale='min({width},iw)':-2:flags=lanczos,fps={fps}"
+
+
+def poster_times(duration: float, supplied: list[float] | None) -> list[float]:
+    if supplied:
+        return [max(0.0, min(value, max(0.0, duration - 0.05))) for value in supplied]
+    if duration <= 1:
+        return [0.0]
+    return [min(0.5, duration * 0.1), duration * 0.5, duration * 0.78]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", type=Path)
+    parser.add_argument("output_dir", type=Path)
+    parser.add_argument("--name", help="Output stem; source stem by default")
+    parser.add_argument("--width", type=int, default=1280)
+    parser.add_argument("--fps", type=int, default=24)
+    parser.add_argument("--mp4-crf", type=int, default=24)
+    parser.add_argument("--webm-crf", type=int, default=34)
+    parser.add_argument("--keep-audio", action="store_true")
+    parser.add_argument("--poster-times", type=float, nargs="*")
+    parser.add_argument("--gif", action="store_true", help="Create a short GIF fallback")
+    parser.add_argument("--gif-start", type=float, default=0.0)
+    parser.add_argument("--gif-duration", type=float, default=6.0)
+    parser.add_argument("--gif-width", type=int, default=800)
+    args = parser.parse_args()
+
+    if not shutil.which("ffmpeg") or not shutil.which("ffprobe"):
+        print("error: ffmpeg and ffprobe must be installed", file=sys.stderr)
+        return 1
+    source = args.source.resolve()
+    if not source.exists():
+        print(f"error: source not found: {source}", file=sys.stderr)
+        return 1
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stem = args.name or source.stem
+    audio = [] if args.keep_audio else ["-an"]
+    vf = scale_filter(args.width, args.fps)
+
+    mp4 = output_dir / f"{stem}.mp4"
+    webm = output_dir / f"{stem}.webm"
+    try:
+        run([
+            "ffmpeg", "-y", "-i", str(source), "-vf", vf,
+            "-c:v", "libx264", "-preset", "medium", "-crf", str(args.mp4_crf),
+            "-pix_fmt", "yuv420p", "-movflags", "+faststart", *audio, str(mp4),
+        ])
+        run([
+            "ffmpeg", "-y", "-i", str(source), "-vf", vf,
+            "-c:v", "libvpx-vp9", "-b:v", "0", "-crf", str(args.webm_crf),
+            "-row-mt", "1", *audio, str(webm),
+        ])
+
+        duration = duration_seconds(source)
+        labels = ["overview", "middle", "detail"]
+        poster_outputs: list[Path] = []
+        for index, timestamp in enumerate(poster_times(duration, args.poster_times)):
+            label = labels[index] if index < len(labels) else f"frame-{index + 1}"
+            jpg = output_dir / f"{stem}-poster-{label}.jpg"
+            webp = output_dir / f"{stem}-poster-{label}.webp"
+            run([
+                "ffmpeg", "-y", "-ss", f"{timestamp:.3f}", "-i", str(source),
+                "-frames:v", "1", "-vf", f"scale='min({args.width},iw)':-2:flags=lanczos",
+                "-q:v", "3", str(jpg),
+            ])
+            run([
+                "ffmpeg", "-y", "-ss", f"{timestamp:.3f}", "-i", str(source),
+                "-frames:v", "1", "-vf", f"scale='min({args.width},iw)':-2:flags=lanczos",
+                "-quality", "82", str(webp),
+            ])
+            poster_outputs.extend([jpg, webp])
+
+        gif = None
+        if args.gif:
+            gif = output_dir / f"{stem}-loop.gif"
+            palette = output_dir / f".{stem}-palette.png"
+            gif_vf = f"fps=12,scale='min({args.gif_width},iw)':-2:flags=lanczos"
+            run([
+                "ffmpeg", "-y", "-ss", str(args.gif_start), "-t", str(args.gif_duration),
+                "-i", str(source), "-vf", f"{gif_vf},palettegen=max_colors=128", str(palette),
+            ])
+            run([
+                "ffmpeg", "-y", "-ss", str(args.gif_start), "-t", str(args.gif_duration),
+                "-i", str(source), "-i", str(palette),
+                "-lavfi", f"{gif_vf}[x];[x][1:v]paletteuse=dither=bayer:bayer_scale=5", str(gif),
+            ])
+            palette.unlink(missing_ok=True)
+
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    outputs = [mp4, webm, *poster_outputs] + ([gif] if gif else [])
+    for path in outputs:
+        print(f"{path}  {format_bytes(path.stat().st_size)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web-design-picker/scripts/optimize_video.py
+++ b/web-design-picker/scripts/optimize_video.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from _common import format_bytes
+from _common import format_bytes, validate_output_stem
 
 
 def run(command: list[str]) -> None:
@@ -66,7 +66,7 @@ def poster_times(duration: float, supplied: list[float] | None) -> list[float]:
     return [min(0.5, duration * 0.1), duration * 0.5, duration * 0.78]
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("source", type=Path)
     parser.add_argument("output_dir", type=Path)
@@ -82,8 +82,13 @@ def main() -> int:
     parser.add_argument("--gif-start", type=float, default=0.0)
     parser.add_argument("--gif-duration", type=float, default=6.0)
     parser.add_argument("--gif-width", type=int, default=800)
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
+    try:
+        stem = validate_output_stem(args.name or args.source.stem)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     if not shutil.which("ffmpeg") or not shutil.which("ffprobe"):
         print("error: ffmpeg and ffprobe must be installed", file=sys.stderr)
         return 1
@@ -93,7 +98,6 @@ def main() -> int:
         return 1
     output_dir = args.output_dir.resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
-    stem = args.name or source.stem
     audio = [] if args.keep_audio else ["-an"]
     vf = scale_filter(args.width, args.fps, args.crop)
 

--- a/web-design-picker/scripts/optimize_video.py
+++ b/web-design-picker/scripts/optimize_video.py
@@ -31,8 +31,31 @@ def duration_seconds(source: Path) -> float:
     return float(data["format"]["duration"])
 
 
-def scale_filter(width: int, fps: int) -> str:
-    return f"scale='min({width},iw)':-2:flags=lanczos,fps={fps}"
+def parse_crop(value: str) -> tuple[int, int, int, int]:
+    try:
+        x, y, width, height = (int(part) for part in value.split(":"))
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("Crop must use X:Y:W:H with integer values") from exc
+    if x < 0 or y < 0 or width <= 0 or height <= 0:
+        raise argparse.ArgumentTypeError("Crop X and Y must be non-negative; W and H must be positive")
+    return x, y, width, height
+
+
+def crop_filter(crop: tuple[int, int, int, int] | None) -> str | None:
+    if crop is None:
+        return None
+    x, y, width, height = crop
+    return f"crop={width}:{height}:{x}:{y}"
+
+
+def scale_filter(width: int, fps: int, crop: tuple[int, int, int, int] | None = None) -> str:
+    filters = [filter_value for filter_value in (crop_filter(crop), f"scale='min({width},iw)':-2:flags=lanczos", f"fps={fps}") if filter_value]
+    return ",".join(filters)
+
+
+def poster_filter(width: int, crop: tuple[int, int, int, int] | None = None) -> str:
+    filters = [filter_value for filter_value in (crop_filter(crop), f"scale='min({width},iw)':-2:flags=lanczos") if filter_value]
+    return ",".join(filters)
 
 
 def poster_times(duration: float, supplied: list[float] | None) -> list[float]:
@@ -53,6 +76,7 @@ def main() -> int:
     parser.add_argument("--mp4-crf", type=int, default=24)
     parser.add_argument("--webm-crf", type=int, default=34)
     parser.add_argument("--keep-audio", action="store_true")
+    parser.add_argument("--crop", type=parse_crop, metavar="X:Y:W:H", help="Crop before scaling video, poster, and GIF derivatives")
     parser.add_argument("--poster-times", type=float, nargs="*")
     parser.add_argument("--gif", action="store_true", help="Create a short GIF fallback")
     parser.add_argument("--gif-start", type=float, default=0.0)
@@ -71,7 +95,7 @@ def main() -> int:
     output_dir.mkdir(parents=True, exist_ok=True)
     stem = args.name or source.stem
     audio = [] if args.keep_audio else ["-an"]
-    vf = scale_filter(args.width, args.fps)
+    vf = scale_filter(args.width, args.fps, args.crop)
 
     mp4 = output_dir / f"{stem}.mp4"
     webm = output_dir / f"{stem}.webm"
@@ -96,12 +120,12 @@ def main() -> int:
             webp = output_dir / f"{stem}-poster-{label}.webp"
             run([
                 "ffmpeg", "-y", "-ss", f"{timestamp:.3f}", "-i", str(source),
-                "-frames:v", "1", "-vf", f"scale='min({args.width},iw)':-2:flags=lanczos",
+                "-frames:v", "1", "-vf", poster_filter(args.width, args.crop),
                 "-q:v", "3", str(jpg),
             ])
             run([
                 "ffmpeg", "-y", "-ss", f"{timestamp:.3f}", "-i", str(source),
-                "-frames:v", "1", "-vf", f"scale='min({args.width},iw)':-2:flags=lanczos",
+                "-frames:v", "1", "-vf", poster_filter(args.width, args.crop),
                 "-quality", "82", str(webp),
             ])
             poster_outputs.extend([jpg, webp])
@@ -110,7 +134,7 @@ def main() -> int:
         if args.gif:
             gif = output_dir / f"{stem}-loop.gif"
             palette = output_dir / f".{stem}-palette.png"
-            gif_vf = f"fps=12,scale='min({args.gif_width},iw)':-2:flags=lanczos"
+            gif_vf = scale_filter(args.gif_width, 12, args.crop)
             run([
                 "ffmpeg", "-y", "-ss", str(args.gif_start), "-t", str(args.gif_duration),
                 "-i", str(source), "-vf", f"{gif_vf},palettegen=max_colors=128", str(palette),

--- a/web-design-picker/scripts/package_delivery.py
+++ b/web-design-picker/scripts/package_delivery.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Create Cloudflare Drop, review, design-assets, source, and full-handoff ZIPs."""
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Any
+
+from _common import deterministic_zip, format_bytes, load_project, utc_now, write_checksum, write_json, write_text
+
+EXCLUDE_NAMES = {".DS_Store", "Thumbs.db", "__pycache__", ".git", "node_modules"}
+
+
+def copy_tree(source: Path, destination: Path) -> None:
+    if source.exists():
+        shutil.copytree(source, destination, dirs_exist_ok=True, ignore=shutil.ignore_patterns(*EXCLUDE_NAMES))
+
+
+def remove_archives(root: Path) -> list[str]:
+    removed = []
+    for path in root.rglob("*"):
+        if path.is_file() and path.suffix.lower() in {".zip", ".7z", ".rar"}:
+            removed.append(path.relative_to(root).as_posix())
+            path.unlink()
+    return removed
+
+
+def inspect_zip(zip_path: Path, *, require_root_index: bool, max_file_bytes: int | None = None) -> dict[str, Any]:
+    with zipfile.ZipFile(zip_path) as archive:
+        bad = archive.testzip()
+        if bad:
+            raise RuntimeError(f"ZIP CRC failure: {bad}")
+        names = archive.namelist()
+        unsafe = [name for name in names if Path(name).is_absolute() or ".." in Path(name).parts]
+        if unsafe:
+            raise RuntimeError(f"Unsafe ZIP entries: {unsafe[:5]}")
+        if require_root_index and (not names or names[0] != "index.html" or "index.html" not in names):
+            raise RuntimeError(f"{zip_path.name} must contain index.html at archive root and write it first")
+        nested = [name for name in names if Path(name).suffix.lower() in {".zip", ".7z", ".rar"}]
+        oversize = []
+        if max_file_bytes:
+            oversize = [{"path": item.filename, "bytes": item.file_size} for item in archive.infolist() if item.file_size > max_file_bytes]
+        return {
+            "entries": len(names),
+            "first_entry": names[0] if names else None,
+            "root_index": "index.html" in names,
+            "nested_archives": nested,
+            "oversize_files": oversize,
+        }
+
+
+def validate_extracted(zip_path: Path, project_root: Path, *, cloudflare: bool) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="web-design-picker-validation-") as temp:
+        extracted = Path(temp)
+        with zipfile.ZipFile(zip_path) as archive:
+            archive.extractall(extracted)
+        report_path = project_root / "qa" / f"{zip_path.stem}-validation.json"
+        log_path = project_root / "qa" / f"{zip_path.stem}-validation.txt"
+        command = [
+            sys.executable,
+            str(Path(__file__).with_name("validate_site.py")),
+            str(extracted),
+            "--report-json",
+            str(report_path),
+        ]
+        if cloudflare:
+            command.append("--cloudflare")
+        result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        log_path.write_text(result.stdout, encoding="utf-8")
+        if result.returncode != 0:
+            raise RuntimeError(f"Static validation failed for {zip_path.name}; see {log_path}")
+        return {"report": str(report_path), "log": str(log_path)}
+
+
+def stage_source(root: Path, destination: Path) -> None:
+    for name in ["config", "src", "design-package"]:
+        copy_tree(root / name, destination / name)
+    for name in ["BRIEF.md", "CLAIM-LEDGER.md", "DIRECTION-BRIEFS.md", "README.md"]:
+        source = root / name
+        if source.exists():
+            destination.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, destination / name)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("project_dir", type=Path)
+    parser.add_argument("--skip-validation", action="store_true")
+    parser.add_argument("--max-file-bytes", type=int, default=25_000_000, help="Conservative per-file Drop limit used by the packager")
+    args = parser.parse_args()
+
+    root = args.project_dir.resolve()
+    project, _, _ = load_project(root)
+    dist = root / "dist"
+    if not (dist / "index.html").is_file():
+        print("error: build the site before packaging", file=sys.stderr)
+        return 1
+
+    deliverables = root / "deliverables"
+    deliverables.mkdir(parents=True, exist_ok=True)
+    for stale in deliverables.glob("*.zip*"):
+        stale.unlink()
+    qa = root / "qa"
+    qa.mkdir(parents=True, exist_ok=True)
+    slug = project["slug"]
+    results: dict[str, Any] = {"project": project["name"], "slug": slug, "generated_at": utc_now(), "packages": {}}
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="web-design-picker-stage-") as temp:
+            temp_root = Path(temp)
+            drop_stage = temp_root / "drop-site"
+            review_stage = temp_root / "review-site"
+            design_stage = temp_root / f"{slug}-design-assets"
+            source_stage = temp_root / f"{slug}-source-project"
+            handoff_stage = temp_root / f"{slug}-website-design-handoff"
+
+            copy_tree(dist, drop_stage)
+            copy_tree(dist, review_stage)
+            copy_tree(root / "design-package", design_stage)
+            stage_source(root, source_stage)
+
+            removed = remove_archives(drop_stage)
+            if removed:
+                print("Removed nested archive(s) from Drop stage: " + ", ".join(removed))
+
+            drop_zip = deliverables / f"{slug}-cloudflare-drop.zip"
+            drop_result = deterministic_zip(drop_stage, drop_zip, include_root=False, exclude_names=EXCLUDE_NAMES, allow_zip64=False)
+            drop_result["inspection"] = inspect_zip(drop_zip, require_root_index=True, max_file_bytes=args.max_file_bytes)
+            if drop_result["inspection"]["nested_archives"]:
+                raise RuntimeError("Cloudflare Drop package contains a nested archive")
+            if drop_result["inspection"]["oversize_files"]:
+                raise RuntimeError(f"Cloudflare Drop package contains files above {args.max_file_bytes} bytes")
+            write_checksum(drop_zip)
+            results["packages"]["cloudflare_drop"] = drop_result
+
+            review_zip = deliverables / f"{slug}-review-site.zip"
+            review_result = deterministic_zip(review_stage, review_zip, include_root=False, exclude_names=EXCLUDE_NAMES, allow_zip64=False)
+            review_result["inspection"] = inspect_zip(review_zip, require_root_index=True)
+            write_checksum(review_zip)
+            results["packages"]["review_site"] = review_result
+
+            design_zip = deliverables / f"{slug}-design-assets.zip"
+            design_result = deterministic_zip(design_stage, design_zip, include_root=True, exclude_names=EXCLUDE_NAMES, allow_zip64=False)
+            design_result["inspection"] = inspect_zip(design_zip, require_root_index=False)
+            write_checksum(design_zip)
+            results["packages"]["design_assets"] = design_result
+
+            source_zip = deliverables / f"{slug}-source-project.zip"
+            source_result = deterministic_zip(source_stage, source_zip, include_root=True, exclude_names=EXCLUDE_NAMES, allow_zip64=False)
+            source_result["inspection"] = inspect_zip(source_zip, require_root_index=False)
+            write_checksum(source_zip)
+            results["packages"]["source_project"] = source_result
+
+            # Full handoff contains expanded folders, not a ZIP-inside-ZIP deployment trap.
+            copy_tree(dist, handoff_stage / "site")
+            copy_tree(root / "design-package", handoff_stage / "design-assets")
+            stage_source(root, handoff_stage / "source")
+            copy_tree(root / "previews", handoff_stage / "previews")
+            copy_tree(root / "qa", handoff_stage / "qa")
+            write_text(
+                handoff_stage / "DELIVERY-README.txt",
+                f"""{project['name']} website design handoff
+
+site/                Combined picker, standalone directions, and asset catalog
+design-assets/       Editable and export-ready assets
+source/              Project manifests, source concepts, and working documents
+previews/            Desktop and mobile QA screenshots
+qa/                  Validation and browser reports
+
+Upload `{slug}-cloudflare-drop.zip` from the separate deliverables folder to Cloudflare Drop. Do not upload this full handoff ZIP as the site.
+The asset catalog builds family and all-assets ZIPs in the browser from static files; the Drop package itself contains no nested ZIP.
+""",
+            )
+            handoff_zip = deliverables / f"{slug}-website-design-handoff.zip"
+            handoff_result = deterministic_zip(handoff_stage, handoff_zip, include_root=True, exclude_names=EXCLUDE_NAMES, allow_zip64=True)
+            handoff_result["inspection"] = inspect_zip(handoff_zip, require_root_index=False)
+            write_checksum(handoff_zip)
+            results["packages"]["full_handoff"] = handoff_result
+
+            if not args.skip_validation:
+                results["packages"]["cloudflare_drop"]["validation"] = validate_extracted(drop_zip, root, cloudflare=True)
+                results["packages"]["review_site"]["validation"] = validate_extracted(review_zip, root, cloudflare=False)
+
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    manifest_path = deliverables / "delivery-manifest.json"
+    write_json(manifest_path, results)
+    print(f"Created delivery packages in {deliverables}")
+    for key, info in results["packages"].items():
+        print(f"{key:18} {Path(info['path']).name:52} {format_bytes(info['size_bytes'])}")
+    print(f"Manifest: {manifest_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web-design-picker/scripts/package_delivery.py
+++ b/web-design-picker/scripts/package_delivery.py
@@ -110,10 +110,17 @@ def main() -> int:
         return 1
 
     deliverables = root / "deliverables"
+    qa = root / "qa"
+    try:
+        reject_symlinks(deliverables)
+        reject_symlinks(qa)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
     deliverables.mkdir(parents=True, exist_ok=True)
     for stale in deliverables.glob("*.zip*"):
         stale.unlink()
-    qa = root / "qa"
     qa.mkdir(parents=True, exist_ok=True)
     slug = project["slug"]
     remove_validation_reports(qa, slug)

--- a/web-design-picker/scripts/package_delivery.py
+++ b/web-design-picker/scripts/package_delivery.py
@@ -11,12 +11,13 @@ import zipfile
 from pathlib import Path
 from typing import Any
 
-from _common import deterministic_zip, format_bytes, load_project, utc_now, write_checksum, write_json, write_text
+from _common import deterministic_zip, format_bytes, load_project, reject_symlinks, utc_now, write_checksum, write_json, write_text
 
 EXCLUDE_NAMES = {".DS_Store", "Thumbs.db", "__pycache__", ".git", "node_modules"}
 
 
 def copy_tree(source: Path, destination: Path) -> None:
+    reject_symlinks(source, exclude_names=EXCLUDE_NAMES)
     if source.exists():
         shutil.copytree(source, destination, dirs_exist_ok=True, ignore=shutil.ignore_patterns(*EXCLUDE_NAMES))
 
@@ -83,6 +84,7 @@ def stage_source(root: Path, destination: Path) -> None:
     for name in ["BRIEF.md", "CLAIM-LEDGER.md", "DIRECTION-BRIEFS.md", "README.md"]:
         source = root / name
         if source.exists():
+            reject_symlinks(source)
             destination.mkdir(parents=True, exist_ok=True)
             shutil.copy2(source, destination / name)
 
@@ -122,6 +124,11 @@ def main() -> int:
             copy_tree(dist, drop_stage)
             copy_tree(dist, review_stage)
             copy_tree(root / "design-package", design_stage)
+            asset_manifest = dist / "asset-manifest.json"
+            if not asset_manifest.is_file():
+                raise RuntimeError("Build output is missing asset-manifest.json")
+            design_stage.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(asset_manifest, design_stage / asset_manifest.name)
             stage_source(root, source_stage)
 
             removed = remove_archives(drop_stage)

--- a/web-design-picker/scripts/package_delivery.py
+++ b/web-design-picker/scripts/package_delivery.py
@@ -31,6 +31,12 @@ def remove_archives(root: Path) -> list[str]:
     return removed
 
 
+def remove_validation_reports(qa: Path, slug: str) -> None:
+    for package in (f"{slug}-cloudflare-drop", f"{slug}-review-site"):
+        for suffix in (".json", ".txt"):
+            (qa / f"{package}-validation{suffix}").unlink(missing_ok=True)
+
+
 def inspect_zip(zip_path: Path, *, require_root_index: bool, max_file_bytes: int | None = None) -> dict[str, Any]:
     with zipfile.ZipFile(zip_path) as archive:
         bad = archive.testzip()
@@ -110,6 +116,7 @@ def main() -> int:
     qa = root / "qa"
     qa.mkdir(parents=True, exist_ok=True)
     slug = project["slug"]
+    remove_validation_reports(qa, slug)
     results: dict[str, Any] = {"project": project["name"], "slug": slug, "generated_at": utc_now(), "packages": {}}
 
     try:
@@ -151,6 +158,10 @@ def main() -> int:
             write_checksum(review_zip)
             results["packages"]["review_site"] = review_result
 
+            if not args.skip_validation:
+                results["packages"]["cloudflare_drop"]["validation"] = validate_extracted(drop_zip, root, cloudflare=True)
+                results["packages"]["review_site"]["validation"] = validate_extracted(review_zip, root, cloudflare=False)
+
             design_zip = deliverables / f"{slug}-design-assets.zip"
             design_result = deterministic_zip(design_stage, design_zip, include_root=True, exclude_names=EXCLUDE_NAMES, allow_zip64=False)
             design_result["inspection"] = inspect_zip(design_zip, require_root_index=False)
@@ -188,10 +199,6 @@ The asset catalog builds family and all-assets ZIPs in the browser from static f
             handoff_result["inspection"] = inspect_zip(handoff_zip, require_root_index=False)
             write_checksum(handoff_zip)
             results["packages"]["full_handoff"] = handoff_result
-
-            if not args.skip_validation:
-                results["packages"]["cloudflare_drop"]["validation"] = validate_extracted(drop_zip, root, cloudflare=True)
-                results["packages"]["review_site"]["validation"] = validate_extracted(review_zip, root, cloudflare=False)
 
     except Exception as exc:
         print(f"error: {exc}", file=sys.stderr)

--- a/web-design-picker/scripts/run_factory.py
+++ b/web-design-picker/scripts/run_factory.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Build, inspect, browser-test, and package a web-design-picker project."""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from _common import load_project, read_json, utc_now, write_json
+
+
+class FactoryError(RuntimeError):
+    pass
+
+
+def run_step(name: str, command: list[str], log_path: Path, *, required: bool = True) -> dict[str, Any]:
+    print(f"[{name}] {' '.join(command)}")
+    result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text(result.stdout, encoding="utf-8")
+    print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
+    if required and result.returncode != 0:
+        raise FactoryError(f"{name} failed; see {log_path}")
+    return {"name": name, "command": command, "returncode": result.returncode, "log": str(log_path)}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("project_dir", type=Path)
+    parser.add_argument("--skip-browser", action="store_true", help="Skip Playwright screenshots and interaction tests")
+    parser.add_argument("--test-downloads", action="store_true", help="Generate family and all-assets ZIPs in the browser during QA")
+    parser.add_argument("--strict", action="store_true", help="Require completed distinctness scores and fail on static warnings")
+    parser.add_argument("--fail-on-slop", action="store_true", help="Treat heuristic anti-slop findings as a build failure")
+    parser.add_argument("--skip-package-validation", action="store_true")
+    args = parser.parse_args()
+
+    root = args.project_dir.resolve()
+    project, _, _ = load_project(root)
+    qa = root / "qa"
+    qa.mkdir(parents=True, exist_ok=True)
+    scripts = Path(__file__).resolve().parent
+    steps: list[dict[str, Any]] = []
+
+    try:
+        steps.append(run_step("build", [sys.executable, str(scripts / "build_picker.py"), str(root)], qa / "build.txt"))
+
+        static_cmd = [
+            sys.executable,
+            str(scripts / "validate_site.py"),
+            str(root / "dist"),
+            "--manifest",
+            str(root / "config/assets.json"),
+            "--cloudflare",
+            "--report-json",
+            str(qa / "static-validation.json"),
+        ]
+        if args.strict:
+            static_cmd.append("--strict")
+        steps.append(run_step("static validation", static_cmd, qa / "static-validation.txt"))
+
+        distinct_cmd = [
+            sys.executable,
+            str(scripts / "check_distinctness.py"),
+            str(root),
+            "--report-json",
+            str(qa / "distinctness.json"),
+        ]
+        if args.strict:
+            distinct_cmd.append("--strict")
+        steps.append(run_step("direction distinctness", distinct_cmd, qa / "distinctness.txt", required=args.strict))
+
+        slop_cmd = [
+            sys.executable,
+            str(scripts / "slop_lint.py"),
+            str(root / "dist"),
+            "--json",
+            str(qa / "anti-slop.json"),
+        ]
+        if args.fail_on_slop:
+            slop_cmd.append("--fail-on-findings")
+        steps.append(run_step("anti-slop review", slop_cmd, qa / "anti-slop.txt", required=args.fail_on_slop))
+
+        if not args.skip_browser:
+            browser_cmd = [
+                sys.executable,
+                str(scripts / "browser_qa.py"),
+                str(root),
+                "--report-json",
+                str(qa / "browser-qa.json"),
+            ]
+            if args.test_downloads:
+                browser_cmd.append("--test-downloads")
+            steps.append(run_step("browser QA", browser_cmd, qa / "browser-qa.txt"))
+
+        package_cmd = [sys.executable, str(scripts / "package_delivery.py"), str(root)]
+        if args.skip_package_validation:
+            package_cmd.append("--skip-validation")
+        steps.append(run_step("package", package_cmd, qa / "package.txt"))
+
+    except FactoryError as exc:
+        report = {"generated_at": utc_now(), "project": project["name"], "passed": False, "error": str(exc), "steps": steps}
+        write_json(qa / "factory-report.json", report)
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    delivery_manifest = root / "deliverables/delivery-manifest.json"
+    report = {
+        "generated_at": utc_now(),
+        "project": project["name"],
+        "passed": True,
+        "steps": steps,
+        "delivery": read_json(delivery_manifest) if delivery_manifest.exists() else None,
+    }
+    write_json(qa / "factory-report.json", report)
+    print(json.dumps({"passed": True, "deliverables": str(root / "deliverables")}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web-design-picker/scripts/run_factory.py
+++ b/web-design-picker/scripts/run_factory.py
@@ -73,7 +73,7 @@ def main() -> int:
         ]
         if args.strict:
             distinct_cmd.append("--strict")
-        steps.append(run_step("direction distinctness", distinct_cmd, qa / "distinctness.txt", required=args.strict))
+        steps.append(run_step("direction distinctness", distinct_cmd, qa / "distinctness.txt"))
 
         slop_cmd = [
             sys.executable,

--- a/web-design-picker/scripts/run_factory.py
+++ b/web-design-picker/scripts/run_factory.py
@@ -33,6 +33,7 @@ def main() -> int:
     parser.add_argument("--skip-browser", action="store_true", help="Skip Playwright screenshots and interaction tests")
     parser.add_argument("--test-downloads", action="store_true", help="Generate family and all-assets ZIPs in the browser during QA")
     parser.add_argument("--strict", action="store_true", help="Require completed distinctness scores and fail on static warnings")
+    parser.add_argument("--allow-external", action="store_true", help="Permit external http(s) references during static validation")
     parser.add_argument("--fail-on-slop", action="store_true", help="Treat heuristic anti-slop findings as a build failure")
     parser.add_argument("--skip-package-validation", action="store_true")
     args = parser.parse_args()
@@ -59,6 +60,8 @@ def main() -> int:
         ]
         if args.strict:
             static_cmd.append("--strict")
+        if args.allow_external:
+            static_cmd.append("--allow-external")
         steps.append(run_step("static validation", static_cmd, qa / "static-validation.txt"))
 
         distinct_cmd = [

--- a/web-design-picker/scripts/self_test.py
+++ b/web-design-picker/scripts/self_test.py
@@ -12,8 +12,11 @@ import zipfile
 from pathlib import Path
 
 import new_project
-from _common import copy_contents, deterministic_zip, read_json, relative_web_path, utc_now, validate_slug, write_json
+from _common import copy_contents, deterministic_zip, read_json, relative_web_path, utc_now, validate_output_stem, validate_slug, write_json
 from build_picker import ensure_direction_metadata, relative_from_page
+from make_asset_variants import main as make_asset_variants_main, render_svg as render_variant_svg
+from make_palette import main as make_palette_main
+from optimize_video import main as optimize_video_main
 from package_delivery import copy_tree
 from validate_site import check_html
 
@@ -44,6 +47,33 @@ def check_path_helpers() -> None:
         raise RuntimeError(f"Unsafe static path was accepted: {unsafe}")
 
 
+def check_output_stem_guards(parent: Path) -> None:
+    """Output names must stay single portable file stems before any writes."""
+    for safe in ("palette", "brand.v2", "logo_01", "hero-image"):
+        if validate_output_stem(safe) != safe:
+            raise RuntimeError(f"Safe output name was changed: {safe}")
+    for unsafe in (".", "..", "../outside", "nested/name", "C:\\outside", "name.", "name ", "CON", "lpt9.txt"):
+        try:
+            validate_output_stem(unsafe)
+        except ValueError:
+            continue
+        raise RuntimeError(f"Unsafe output name was accepted: {unsafe}")
+
+    with tempfile.TemporaryDirectory(prefix="web-design-picker-output-stem-", dir=parent) as temporary:
+        root = Path(temporary)
+        output = root / "output"
+        source = root / "source.svg"
+        source.write_text('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"/>', encoding="utf-8")
+        commands = (
+            (make_asset_variants_main, [str(source), str(output), "--name", "../escape"]),
+            (make_palette_main, [str(output), "--name", "../escape", "primary=#112233"]),
+            (optimize_video_main, [str(root / "source.mp4"), str(output), "--name", "../escape"]),
+        )
+        for command, arguments in commands:
+            if command(arguments) == 0 or output.exists():
+                raise RuntimeError("An output helper accepted an escaping output name or created output")
+
+
 def check_symlink_guards(parent: Path) -> None:
     """Delivery staging must reject links before copying external content."""
     with tempfile.TemporaryDirectory(prefix="web-design-picker-symlink-", dir=parent) as temporary:
@@ -68,6 +98,69 @@ def check_symlink_guards(parent: Path) -> None:
                 raise RuntimeError(f"Symlinked source was copied by {name} staging")
             if destination.exists():
                 raise RuntimeError(f"{name} staging created output before rejecting a symlink")
+
+
+def check_package_output_symlink_guards(parent: Path) -> None:
+    """Packaging must not unlink or write through symlinked output directories."""
+    with tempfile.TemporaryDirectory(prefix="web-design-picker-package-symlink-", dir=parent) as temporary:
+        root = Path(temporary)
+        script = Path(__file__).with_name("package_delivery.py")
+        for output_name in ("deliverables", "qa"):
+            project = root / output_name
+            config = project / "config"
+            config.mkdir(parents=True)
+            write_json(config / "project.json", {"name": "Package fixture", "slug": "package-fixture"})
+            write_json(config / "directions.json", [{"key": "first"}, {"key": "second"}])
+            write_json(config / "assets.json", {})
+            (project / "dist").mkdir()
+            (project / "dist/index.html").write_text("fixture\n", encoding="utf-8")
+
+            external = root / f"external-{output_name}"
+            external.mkdir()
+            sentinel = external / "sentinel.txt"
+            archive = external / "existing.zip"
+            sentinel.write_text("preserve sentinel\n", encoding="utf-8")
+            archive.write_bytes(b"preserve archive\n")
+            (project / output_name).symlink_to(external, target_is_directory=True)
+
+            internal_archive = None
+            if output_name == "qa":
+                deliverables = project / "deliverables"
+                deliverables.mkdir()
+                internal_archive = deliverables / "existing.zip"
+                internal_archive.write_bytes(b"preserve internal archive\n")
+            else:
+                (project / "qa").mkdir()
+
+            result = subprocess.run(
+                [sys.executable, str(script), str(project)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            if result.returncode == 0 or "Symlinks are not allowed" not in result.stdout:
+                raise RuntimeError(f"Packaging did not reject symlinked {output_name} output")
+            if sentinel.read_text(encoding="utf-8") != "preserve sentinel\n" or archive.read_bytes() != b"preserve archive\n":
+                raise RuntimeError(f"Packaging modified external {output_name} output before rejecting its symlink")
+            if internal_archive and internal_archive.read_bytes() != b"preserve internal archive\n":
+                raise RuntimeError("Packaging cleaned deliverables before rejecting a symlinked QA directory")
+
+
+def check_svg_variant_dimensions(parent: Path) -> None:
+    """SVG variant exports must use the requested longest edge in either orientation."""
+    with tempfile.TemporaryDirectory(prefix="web-design-picker-svg-variants-", dir=parent) as temporary:
+        root = Path(temporary)
+        for name, width, height in (("portrait", 100, 200), ("landscape", 300, 100)):
+            source = root / f"{name}.svg"
+            source.write_text(
+                f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}"><rect width="{width}" height="{height}"/></svg>',
+                encoding="utf-8",
+            )
+            image = render_variant_svg(source, 320)
+            if max(image.width, image.height) != 320:
+                raise RuntimeError(f"{name} SVG variant did not honor its requested longest edge: {image.size}")
+            if (image.width < image.height) != (name == "portrait"):
+                raise RuntimeError(f"{name} SVG variant changed its orientation: {image.size}")
 
 
 def check_source_map_guard(parent: Path) -> None:
@@ -215,6 +308,9 @@ def main() -> int:
     try:
         project.parent.mkdir(parents=True, exist_ok=True)
         check_symlink_guards(project.parent)
+        check_output_stem_guards(project.parent)
+        check_package_output_symlink_guards(project.parent)
+        check_svg_variant_dimensions(project.parent)
         check_source_map_guard(project.parent)
         check_secret_archive_guard(project.parent)
         check_favicon_metadata_variants(project.parent)

--- a/web-design-picker/scripts/self_test.py
+++ b/web-design-picker/scripts/self_test.py
@@ -23,6 +23,8 @@ def run(command: list[str]) -> None:
 
 
 def check_path_helpers() -> None:
+    if relative_web_path("concepts\\example.html") != "concepts/example.html":
+        raise RuntimeError("Relative static paths must normalize to forward slashes")
     if relative_from_page("assets/brand/example/favicon.svg", "concepts/example.html") != "../assets/brand/example/favicon.svg":
         raise RuntimeError("Relative browser paths must use forward slashes")
     for unsafe in ("/absolute.html", "C:\\absolute.html", "../outside.html", "folder/../outside.html"):

--- a/web-design-picker/scripts/self_test.py
+++ b/web-design-picker/scripts/self_test.py
@@ -11,8 +11,9 @@ import tempfile
 import zipfile
 from pathlib import Path
 
-from _common import read_json, relative_web_path, utc_now, validate_slug, write_json
+from _common import copy_contents, read_json, relative_web_path, utc_now, validate_slug, write_json
 from build_picker import relative_from_page
+from package_delivery import copy_tree
 
 
 def run(command: list[str]) -> None:
@@ -41,6 +42,32 @@ def check_path_helpers() -> None:
         raise RuntimeError(f"Unsafe static path was accepted: {unsafe}")
 
 
+def check_symlink_guards(parent: Path) -> None:
+    """Delivery staging must reject links before copying external content."""
+    with tempfile.TemporaryDirectory(prefix="web-design-picker-symlink-", dir=parent) as temporary:
+        root = Path(temporary)
+        source = root / "source"
+        source.mkdir()
+        external = root / "outside.txt"
+        external.write_text("outside\n", encoding="utf-8")
+        link = source / "external.txt"
+        try:
+            link.symlink_to(external)
+        except OSError as exc:
+            raise RuntimeError("Could not create the symlink security fixture") from exc
+
+        for copy, name in ((copy_contents, "contents"), (copy_tree, "tree")):
+            destination = root / f"{name}-stage"
+            try:
+                copy(source, destination)
+            except ValueError:
+                pass
+            else:
+                raise RuntimeError(f"Symlinked source was copied by {name} staging")
+            if destination.exists():
+                raise RuntimeError(f"{name} staging created output before rejecting a symlink")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--work-dir", type=Path, help="Keep the generated test project at this location")
@@ -61,6 +88,7 @@ def main() -> int:
 
     try:
         project.parent.mkdir(parents=True, exist_ok=True)
+        check_symlink_guards(project.parent)
         with tempfile.TemporaryDirectory(prefix="web-design-picker-slug-guard-", dir=project.parent) as guard_dir:
             slug_guard = Path(guard_dir)
             marker = slug_guard / "keep.txt"
@@ -137,6 +165,12 @@ def main() -> int:
                 raise RuntimeError("Drop ZIP has a CRC error")
             if any(Path(name).suffix.lower() == ".zip" for name in names):
                 raise RuntimeError("Drop ZIP contains a nested ZIP")
+
+        design_zip = project / "deliverables/factory-self-test-design-assets.zip"
+        with zipfile.ZipFile(design_zip) as archive:
+            manifest_name = "factory-self-test-design-assets/asset-manifest.json"
+            if manifest_name not in archive.namelist():
+                raise RuntimeError("Design-assets ZIP omits the generated asset manifest")
 
         report = {
             "generated_at": utc_now(),

--- a/web-design-picker/scripts/self_test.py
+++ b/web-design-picker/scripts/self_test.py
@@ -11,9 +11,10 @@ import tempfile
 import zipfile
 from pathlib import Path
 
-from _common import copy_contents, read_json, relative_web_path, utc_now, validate_slug, write_json
-from build_picker import relative_from_page
+from _common import copy_contents, deterministic_zip, read_json, relative_web_path, utc_now, validate_slug, write_json
+from build_picker import ensure_direction_metadata, relative_from_page
 from package_delivery import copy_tree
+from validate_site import check_html
 
 
 def run(command: list[str]) -> None:
@@ -68,6 +69,68 @@ def check_symlink_guards(parent: Path) -> None:
                 raise RuntimeError(f"{name} staging created output before rejecting a symlink")
 
 
+def check_source_map_guard(parent: Path) -> None:
+    """Delivery archives must reject nested source maps before writing output."""
+    with tempfile.TemporaryDirectory(prefix="web-design-picker-source-map-", dir=parent) as temporary:
+        root = Path(temporary)
+        source = root / "source" / "nested"
+        source.mkdir(parents=True)
+        (source / "app.MAP").write_text("source map fixture\n", encoding="utf-8")
+        output = root / "delivery.zip"
+        try:
+            deterministic_zip(root / "source", output)
+        except ValueError as exc:
+            if "Source map files" not in str(exc):
+                raise RuntimeError("Source map guard raised an unexpected error") from exc
+        else:
+            raise RuntimeError("Source map was accepted into a delivery archive")
+        if output.exists():
+            raise RuntimeError("Source map guard wrote a delivery archive")
+
+
+def check_favicon_metadata_variants(parent: Path) -> None:
+    """Every required favicon variant must survive one-off authored icons."""
+    with tempfile.TemporaryDirectory(prefix="web-design-picker-favicon-", dir=parent) as temporary:
+        root = Path(temporary)
+        page = root / "concepts" / "first.html"
+        page.parent.mkdir(parents=True)
+        page.write_text(
+            '<!doctype html><html><head><link rel="icon" href="authored-icon.svg"></head><body></body></html>',
+            encoding="utf-8",
+        )
+        direction = {"key": "first", "file": "concepts/first.html"}
+        ensure_direction_metadata(root, direction)
+        ensure_direction_metadata(root, direction)
+        rendered = page.read_text(encoding="utf-8")
+        expected = (
+            "../assets/brand/first/favicon.svg",
+            "../assets/brand/first/favicon.ico",
+            "../assets/brand/first/favicon-180.png",
+        )
+        if any(rendered.count(href) != 1 for href in expected):
+            raise RuntimeError("Required favicon variants were missing or duplicated")
+        if rendered.count("authored-icon.svg") != 1:
+            raise RuntimeError("Authored favicon link was unexpectedly changed")
+
+
+def check_aria_labelledby_controls(parent: Path) -> None:
+    """Skipped controls must not be checked for labels or label references."""
+    with tempfile.TemporaryDirectory(prefix="web-design-picker-aria-", dir=parent) as temporary:
+        root = Path(temporary)
+        page = root / "index.html"
+        page.write_text(
+            '<!doctype html><html lang="en"><head><title>Fixture</title><meta name="viewport" content="width=device-width"><link rel="icon" href="data:,x"></head><body><h1>Fixture</h1><input type="hidden" aria-labelledby="missing-hidden"><input aria-labelledby="missing-visible"></body></html>',
+            encoding="utf-8",
+        )
+        findings = []
+        check_html(root, page, findings, allow_external=False)
+        labelled_by = [finding for finding in findings if finding.code == "aria-labelledby"]
+        if len(labelled_by) != 1 or "missing-visible" not in labelled_by[0].message:
+            raise RuntimeError("aria-labelledby validation did not reject the visible control correctly")
+        if any("missing-hidden" in finding.message for finding in findings):
+            raise RuntimeError("Hidden control was checked for aria-labelledby")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--work-dir", type=Path, help="Keep the generated test project at this location")
@@ -89,6 +152,9 @@ def main() -> int:
     try:
         project.parent.mkdir(parents=True, exist_ok=True)
         check_symlink_guards(project.parent)
+        check_source_map_guard(project.parent)
+        check_favicon_metadata_variants(project.parent)
+        check_aria_labelledby_controls(project.parent)
         with tempfile.TemporaryDirectory(prefix="web-design-picker-slug-guard-", dir=project.parent) as guard_dir:
             slug_guard = Path(guard_dir)
             marker = slug_guard / "keep.txt"

--- a/web-design-picker/scripts/self_test.py
+++ b/web-design-picker/scripts/self_test.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Exercise the skill's scaffold, build, validation, and packaging pipeline."""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+from _common import read_json, relative_web_path, utc_now, write_json
+from build_picker import relative_from_page
+
+
+def run(command: list[str]) -> None:
+    result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
+    if result.returncode != 0:
+        raise RuntimeError("Command failed: " + " ".join(command))
+
+
+def check_path_helpers() -> None:
+    if relative_from_page("assets/brand/example/favicon.svg", "concepts/example.html") != "../assets/brand/example/favicon.svg":
+        raise RuntimeError("Relative browser paths must use forward slashes")
+    for unsafe in ("/absolute.html", "C:\\absolute.html", "../outside.html", "folder/../outside.html"):
+        try:
+            relative_web_path(unsafe)
+        except ValueError:
+            continue
+        raise RuntimeError(f"Unsafe static path was accepted: {unsafe}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--work-dir", type=Path, help="Keep the generated test project at this location")
+    parser.add_argument("--browser", action="store_true", help="Also run Playwright browser QA")
+    args = parser.parse_args()
+
+    check_path_helpers()
+
+    scripts = Path(__file__).resolve().parent
+    temporary = None
+    if args.work_dir:
+        project = args.work_dir.resolve()
+        if project.exists():
+            shutil.rmtree(project)
+    else:
+        temporary = tempfile.TemporaryDirectory(prefix="web-design-picker-selftest-")
+        project = Path(temporary.name) / "project"
+
+    try:
+        run([sys.executable, str(scripts / "new_project.py"), str(project), "--name", "Factory self-test", "--directions", "3"])
+
+        distinctness_path = project / "config/distinctness.json"
+        distinctness = read_json(distinctness_path)
+        for pair in distinctness["pairs"]:
+            pair["scores"] = {dimension: 2 for dimension in distinctness["dimensions"]}
+            pair["notes"] = "Synthetic self-test score; not a design judgment."
+        write_json(distinctness_path, distinctness)
+
+        run([sys.executable, str(scripts / "build_picker.py"), str(project)])
+        run([
+            sys.executable,
+            str(scripts / "validate_site.py"),
+            str(project / "dist"),
+            "--manifest",
+            str(project / "config/assets.json"),
+            "--cloudflare",
+            "--strict",
+            "--report-json",
+            str(project / "qa/static-validation.json"),
+        ])
+        run([sys.executable, str(scripts / "check_distinctness.py"), str(project), "--strict"])
+        run([sys.executable, str(scripts / "slop_lint.py"), str(project / "dist"), "--fail-on-findings"])
+        if args.browser:
+            run([sys.executable, str(scripts / "browser_qa.py"), str(project), "--test-downloads"])
+        run([sys.executable, str(scripts / "package_delivery.py"), str(project)])
+
+        drop_zip = project / "deliverables/factory-self-test-cloudflare-drop.zip"
+        with zipfile.ZipFile(drop_zip) as archive:
+            names = archive.namelist()
+            if not names or names[0] != "index.html":
+                raise RuntimeError("Drop ZIP does not begin with root index.html")
+            if archive.testzip():
+                raise RuntimeError("Drop ZIP has a CRC error")
+            if any(Path(name).suffix.lower() == ".zip" for name in names):
+                raise RuntimeError("Drop ZIP contains a nested ZIP")
+
+        report = {
+            "generated_at": utc_now(),
+            "passed": True,
+            "project": str(project),
+            "browser_tested": args.browser,
+            "drop_zip": str(drop_zip),
+            "drop_entries": len(names),
+        }
+        write_json(project / "qa/self-test.json", report)
+        print(json.dumps(report, indent=2))
+        return 0
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        if temporary:
+            temporary.cleanup()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web-design-picker/scripts/self_test.py
+++ b/web-design-picker/scripts/self_test.py
@@ -11,6 +11,7 @@ import tempfile
 import zipfile
 from pathlib import Path
 
+import new_project
 from _common import copy_contents, deterministic_zip, read_json, relative_web_path, utc_now, validate_slug, write_json
 from build_picker import ensure_direction_metadata, relative_from_page
 from package_delivery import copy_tree
@@ -88,6 +89,41 @@ def check_source_map_guard(parent: Path) -> None:
             raise RuntimeError("Source map guard wrote a delivery archive")
 
 
+def check_secret_archive_guard(parent: Path) -> None:
+    """Delivery archives must reject common secrets before writing output."""
+    fixtures = {
+        ".env": b"TOKEN=secret\n",
+        "nested/.ENV.production": b"TOKEN=secret\n",
+        "keys/client.KEY": b"key fixture\n",
+        "keys/certificate.PFX": b"container fixture\n",
+        "keys/id_ED25519": b"ssh key fixture\n",
+        "keys/material.txt": b"-----BEGIN OPENSSH PRIVATE KEY-----\nfixture\n",
+    }
+    with tempfile.TemporaryDirectory(prefix="web-design-picker-secret-", dir=parent) as temporary:
+        root = Path(temporary)
+        for index, (relative, content) in enumerate(fixtures.items()):
+            source = root / f"source-{index}"
+            target = source / relative
+            target.parent.mkdir(parents=True)
+            target.write_bytes(content)
+            output = root / f"delivery-{index}.zip"
+            try:
+                deterministic_zip(source, output)
+            except ValueError as exc:
+                if "Secret files" not in str(exc):
+                    raise RuntimeError("Secret archive guard raised an unexpected error") from exc
+            else:
+                raise RuntimeError(f"Secret fixture was accepted into a delivery archive: {relative}")
+            if output.exists():
+                raise RuntimeError(f"Secret archive guard wrote output for: {relative}")
+
+        safe_source = root / "safe"
+        safe_source.mkdir()
+        (safe_source / ".envrc").write_text("export DEMO=1\n", encoding="utf-8")
+        (safe_source / "id_ed25519.pub").write_text("ssh-ed25519 public-key\n", encoding="utf-8")
+        deterministic_zip(safe_source, root / "safe.zip")
+
+
 def check_favicon_metadata_variants(parent: Path) -> None:
     """Every required favicon variant must survive one-off authored icons."""
     with tempfile.TemporaryDirectory(prefix="web-design-picker-favicon-", dir=parent) as temporary:
@@ -131,6 +167,33 @@ def check_aria_labelledby_controls(parent: Path) -> None:
             raise RuntimeError("Hidden control was checked for aria-labelledby")
 
 
+def check_force_scaffold_preserves_existing_project(parent: Path) -> None:
+    """A failed forced scaffold must not replace an existing project."""
+    with tempfile.TemporaryDirectory(prefix="web-design-picker-force-", dir=parent) as temporary:
+        root = Path(temporary)
+        project = root / "project"
+        project.mkdir()
+        marker = project / "keep.txt"
+        marker.write_text("preserve this project\n", encoding="utf-8")
+        original_generator = new_project.generate_favicon_set
+
+        def fail_scaffold(*_args, **_kwargs):
+            raise new_project.FaviconError("injected scaffold failure")
+
+        new_project.generate_favicon_set = fail_scaffold
+        try:
+            result = new_project.main([str(project), "--name", "Failure fixture", "--force"])
+        finally:
+            new_project.generate_favicon_set = original_generator
+
+        if result != 1 or marker.read_text(encoding="utf-8") != "preserve this project\n":
+            raise RuntimeError("Forced scaffold failure did not preserve the existing project")
+        if [path.name for path in project.iterdir()] != ["keep.txt"]:
+            raise RuntimeError("Forced scaffold failure replaced the destination with partial output")
+        if any(root.glob(".project.staging-*")):
+            raise RuntimeError("Forced scaffold failure left a staging project behind")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--work-dir", type=Path, help="Keep the generated test project at this location")
@@ -153,8 +216,10 @@ def main() -> int:
         project.parent.mkdir(parents=True, exist_ok=True)
         check_symlink_guards(project.parent)
         check_source_map_guard(project.parent)
+        check_secret_archive_guard(project.parent)
         check_favicon_metadata_variants(project.parent)
         check_aria_labelledby_controls(project.parent)
+        check_force_scaffold_preserves_existing_project(project.parent)
         with tempfile.TemporaryDirectory(prefix="web-design-picker-slug-guard-", dir=project.parent) as guard_dir:
             slug_guard = Path(guard_dir)
             marker = slug_guard / "keep.txt"

--- a/web-design-picker/scripts/self_test.py
+++ b/web-design-picker/scripts/self_test.py
@@ -60,27 +60,28 @@ def main() -> int:
         project = Path(temporary.name) / "project"
 
     try:
-        slug_guard = project.parent / "slug-guard"
-        slug_guard.mkdir(parents=True)
-        marker = slug_guard / "keep.txt"
-        marker.write_text("keep\n", encoding="utf-8")
-        invalid_slug = subprocess.run(
-            [
-                sys.executable,
-                str(scripts / "new_project.py"),
-                str(slug_guard),
-                "--name",
-                "Invalid slug guard",
-                "--slug",
-                "../outside",
-                "--force",
-            ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-        )
-        if invalid_slug.returncode == 0 or not marker.is_file():
-            raise RuntimeError("Invalid slug validation modified the target project")
+        project.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(prefix="web-design-picker-slug-guard-", dir=project.parent) as guard_dir:
+            slug_guard = Path(guard_dir)
+            marker = slug_guard / "keep.txt"
+            marker.write_text("keep\n", encoding="utf-8")
+            invalid_slug = subprocess.run(
+                [
+                    sys.executable,
+                    str(scripts / "new_project.py"),
+                    str(slug_guard),
+                    "--name",
+                    "Invalid slug guard",
+                    "--slug",
+                    "../outside",
+                    "--force",
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            if invalid_slug.returncode == 0 or not marker.is_file():
+                raise RuntimeError("Invalid slug validation modified the target project")
 
         run([sys.executable, str(scripts / "new_project.py"), str(project), "--name", "Factory self-test", "--directions", "3"])
 

--- a/web-design-picker/scripts/self_test.py
+++ b/web-design-picker/scripts/self_test.py
@@ -60,7 +60,47 @@ def main() -> int:
         project = Path(temporary.name) / "project"
 
     try:
+        slug_guard = project.parent / "slug-guard"
+        slug_guard.mkdir(parents=True)
+        marker = slug_guard / "keep.txt"
+        marker.write_text("keep\n", encoding="utf-8")
+        invalid_slug = subprocess.run(
+            [
+                sys.executable,
+                str(scripts / "new_project.py"),
+                str(slug_guard),
+                "--name",
+                "Invalid slug guard",
+                "--slug",
+                "../outside",
+                "--force",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        if invalid_slug.returncode == 0 or not marker.is_file():
+            raise RuntimeError("Invalid slug validation modified the target project")
+
         run([sys.executable, str(scripts / "new_project.py"), str(project), "--name", "Factory self-test", "--directions", "3"])
+
+        assets_path = project / "config/assets.json"
+        assets = read_json(assets_path)
+        original_assets = json.loads(json.dumps(assets))
+        assets["shared"].append({
+            "title": "Unsafe path fixture",
+            "files": [{"label": "Outside", "href": "../outside.txt"}],
+        })
+        write_json(assets_path, assets)
+        unsafe_asset = subprocess.run(
+            [sys.executable, str(scripts / "build_picker.py"), str(project)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        if unsafe_asset.returncode == 0 or "Traceback" in unsafe_asset.stdout:
+            raise RuntimeError("Unsafe asset path did not produce a clean validation error")
+        write_json(assets_path, original_assets)
 
         distinctness_path = project / "config/distinctness.json"
         distinctness = read_json(distinctness_path)

--- a/web-design-picker/scripts/self_test.py
+++ b/web-design-picker/scripts/self_test.py
@@ -11,7 +11,7 @@ import tempfile
 import zipfile
 from pathlib import Path
 
-from _common import read_json, relative_web_path, utc_now, write_json
+from _common import read_json, relative_web_path, utc_now, validate_slug, write_json
 from build_picker import relative_from_page
 
 
@@ -23,6 +23,12 @@ def run(command: list[str]) -> None:
 
 
 def check_path_helpers() -> None:
+    try:
+        validate_slug("../../outside")
+    except ValueError:
+        pass
+    else:
+        raise RuntimeError("Unsafe project slug was accepted")
     if relative_web_path("concepts\\example.html") != "concepts/example.html":
         raise RuntimeError("Relative static paths must normalize to forward slashes")
     if relative_from_page("assets/brand/example/favicon.svg", "concepts/example.html") != "../assets/brand/example/favicon.svg":

--- a/web-design-picker/scripts/slop_lint.py
+++ b/web-design-picker/scripts/slop_lint.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Heuristically flag common generic AI-site design patterns for human review."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+
+
+@dataclass
+class Finding:
+    severity: str
+    rule: str
+    file: str
+    detail: str
+
+
+TEXT_SUFFIXES = {".html", ".htm", ".css", ".js", ".jsx", ".tsx", ".vue", ".svelte"}
+
+
+def scan_file(path: Path, root: Path) -> list[Finding]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    low = text.lower()
+    rel = path.relative_to(root).as_posix()
+    findings: list[Finding] = []
+
+    def add(severity: str, rule: str, detail: str) -> None:
+        findings.append(Finding(severity, rule, rel, detail))
+
+    font_hits = [name for name in ("inter", "geist mono", "geist", "space grotesk") if re.search(rf"font-family\s*:[^;]*\b{re.escape(name)}\b", low)]
+    if font_hits:
+        add("review", "default-font-stack", "Potentially generic default font choice: " + ", ".join(font_hits))
+    gradient_count = len(re.findall(r"(?:linear|radial|conic)-gradient\s*\(", low))
+    if gradient_count > 8:
+        add("review", "gradient-overuse", f"Contains {gradient_count} CSS gradients; verify each has a functional or brand reason.")
+    if "backdrop-filter" in low or "-webkit-backdrop-filter" in low:
+        add("review", "glassmorphism", "Uses backdrop-filter; verify glass treatment is not decorative default styling.")
+    pill_count = len(re.findall(r"border-radius\s*:\s*(?:999\w*|50px|100px|9999px)", low)) + len(re.findall(r"class\s*=\s*['\"][^'\"]*(?:pill|chip)[^'\"]*['\"]", low))
+    if pill_count >= 4:
+        add("review", "gratuitous-pills", f"Detected {pill_count} pill/chip signals.")
+    if re.search(r"@keyframes\s+[\w-]*pulse|animation(?:-name)?\s*:[^;]*pulse", low):
+        add("review", "pulse-animation", "Contains a pulse animation.")
+    if "intersectionobserver" in low or re.search(r"(?:scroll|reveal)[-_ ]?(?:trigger|animation|effect)", low):
+        add("review", "scroll-reveal", "Contains scroll/reveal logic; confirm content is not hidden until scrolling.")
+    if re.search(r"cursor\s*:\s*url\(", low) or re.search(r"custom[-_ ]cursor|cursor[-_ ]follower", low):
+        add("review", "oversized-custom-cursor", "Contains custom cursor styling or logic.")
+    if re.search(r"class\s*=\s*['\"][^'\"]*bento[^'\"]*['\"]|grid-template-areas[^;]*bento", low):
+        add("review", "bento-grid", "Contains an explicitly named bento layout.")
+    eyebrow_count = len(re.findall(r"(?:class|id)\s*=\s*['\"][^'\"]*(?:eyebrow|kicker|pretitle|overline)[^'\"]*['\"]", low))
+    if eyebrow_count >= 4:
+        add("review", "repeated-eyebrows", f"Detected {eyebrow_count} eyebrow/kicker/pretitle elements.")
+    if re.search(r"<h1\b[^>]*>.*?<(?:(?:em)|(?:i))\b", low, re.S):
+        add("review", "italicized-headline-word", "Main headline contains italic emphasis; verify it is conceptually necessary.")
+    if re.search(r">\s*0[1-9]\s*<", text):
+        add("review", "leading-zero-section-numbers", "Contains leading-zero display numbers.")
+    if "mailto:" in low:
+        form_count = len(re.findall(r"<form\b", low))
+        if form_count == 0:
+            add("review", "mailto-only-contact", "Contains mailto contact behavior and no form.")
+    if "newsletter" in low and re.search(r"<form\b", low):
+        add("review", "template-newsletter", "Contains a newsletter form; verify there is a specific value proposition and real endpoint.")
+    tiny_sizes = [float(value) for value in re.findall(r"font-size\s*:\s*([0-9.]+)px", low) if float(value) < 10.5]
+    if tiny_sizes:
+        add("review", "tiny-text", f"Contains {len(tiny_sizes)} font-size declaration(s) below 10.5px.")
+    if re.search(r"#(?:7c3aed|8b5cf6|9333ea|a855f7|6d28d9|c084fc)\b", low) and gradient_count:
+        add("review", "purple-gradient-default", "Uses common purple gradient colors.")
+    card_count = len(re.findall(r"class\s*=\s*['\"][^'\"]*(?:card|tile)[^'\"]*['\"]", low))
+    if card_count >= 8 and len(re.findall(r"border-radius\s*:", low)) >= 4:
+        add("review", "rounded-card-system", f"Contains {card_count} card/tile class uses with repeated rounded-corner styling.")
+    if "join our newsletter" in low or "subscribe to our newsletter" in low:
+        add("review", "generic-newsletter-copy", "Uses generic newsletter copy.")
+    if re.search(r"<h[1-3]\b[^>]*>[^<]{0,50}(?:innovative solutions|trusted partner|bringing .* to life)", low):
+        add("review", "generic-positioning-copy", "Headline contains generic positioning language.")
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Flag generic AI-site design patterns for human review.")
+    parser.add_argument("root", type=Path)
+    parser.add_argument("--json", type=Path, dest="json_path")
+    parser.add_argument("--fail-on-findings", action="store_true")
+    args = parser.parse_args(argv)
+    if not args.root.exists():
+        print(f"ERROR: path does not exist: {args.root}", file=sys.stderr)
+        return 2
+    root = args.root.resolve()
+    files = [p for p in root.rglob("*") if p.is_file() and p.suffix.lower() in TEXT_SUFFIXES]
+    findings = [finding for path in files for finding in scan_file(path, root)]
+    report = {"root": str(root), "files_scanned": len(files), "finding_count": len(findings), "findings": [asdict(f) for f in findings]}
+    if args.json_path:
+        args.json_path.parent.mkdir(parents=True, exist_ok=True)
+        args.json_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    if not findings:
+        print(f"No heuristic anti-slop findings across {len(files)} files.")
+        return 0
+    print(f"{len(findings)} heuristic finding(s) across {len(files)} files. Review; do not treat as automatic defects.\n")
+    for finding in findings:
+        print(f"[{finding.severity}] {finding.rule}, {finding.file}\n  {finding.detail}")
+    return 3 if args.fail_on_findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web-design-picker/scripts/validate_site.py
+++ b/web-design-picker/scripts/validate_site.py
@@ -30,6 +30,10 @@ CSS_URL_RE = re.compile(
     r"url\(\s*(?:\"(?P<double>[^\"]*)\"|'(?P<single>[^']*)'|(?P<bare>[^)\s'\"]+))\s*\)",
     re.I,
 )
+CSS_QUOTED_IMPORT_RE = re.compile(
+    r"@import\s+(?:\"(?P<double>[^\"]*)\"|'(?P<single>[^']*)')(?=\s|;)",
+    re.I,
+)
 
 
 def srcset_urls(value: str) -> list[str]:
@@ -73,6 +77,7 @@ class DocumentParser(HTMLParser):
         self._in_title = False
         self.meta_names: dict[str, str] = {}
         self.icons: list[str] = []
+        self.web_manifests: list[str] = []
         self.h1_count = 0
         self.images: list[dict[str, str]] = []
         self.videos: list[tuple[dict[str, str], list[str]]] = []
@@ -83,10 +88,10 @@ class DocumentParser(HTMLParser):
         self.ids: set[str] = set()
         self.inline_css: list[str] = []
         self.mailto_links: list[str] = []
-        self.buttons_without_label = 0
         self._button_depth = 0
         self._button_has_text: list[bool] = []
         self._button_attrs: list[dict[str, str]] = []
+        self.buttons: list[tuple[dict[str, str], bool]] = []
         self.invalid_button_types: list[str] = []
 
     def handle_starttag(self, tag: str, attrs_list: list[tuple[str, str | None]]) -> None:
@@ -102,6 +107,8 @@ class DocumentParser(HTMLParser):
                 self.meta_names[name] = attrs.get("content", "")
         if tag == "link" and "icon" in attrs.get("rel", "").lower():
             self.icons.append(attrs.get("href", ""))
+        if tag == "link" and "manifest" in attrs.get("rel", "").lower().split() and attrs.get("href"):
+            self.web_manifests.append(attrs["href"])
         if tag == "h1":
             self.h1_count += 1
         if tag == "img":
@@ -154,8 +161,7 @@ class DocumentParser(HTMLParser):
         if tag == "button" and self._button_depth:
             has_text = self._button_has_text.pop()
             attrs = self._button_attrs.pop()
-            if not has_text and not attrs.get("aria-label") and not attrs.get("aria-labelledby") and not attrs.get("title"):
-                self.buttons_without_label += 1
+            self.buttons.append((attrs, has_text))
             self._button_depth -= 1
 
     def handle_data(self, data: str) -> None:
@@ -191,21 +197,93 @@ def is_within(path: Path, root: Path) -> bool:
         return False
 
 
-def check_css_urls(root: Path, source: Path, css: str, findings: list[Finding]) -> None:
+def check_css_reference(root: Path, source: Path, url: str, findings: list[Finding]) -> None:
     relative = source.relative_to(root)
+    parsed = urlsplit(url)
+    if not url or parsed.scheme.lower() in IGNORE_SCHEMES or parsed.netloc or not parsed.path:
+        return
+    target = resolve_local(root, source, url)
+    if target is None:
+        return
+    if not is_within(target, root):
+        add(findings, "error", "css-path-escape", relative, f"CSS URL leaves site root: {url}")
+        return
+    if not target.exists():
+        add(findings, "error", "css-missing-reference", relative, f"Missing CSS URL target: {url}")
+
+
+def check_css_urls(root: Path, source: Path, css: str, findings: list[Finding]) -> None:
+    for match in CSS_QUOTED_IMPORT_RE.finditer(css):
+        url = next((value for value in match.group("double", "single") if value is not None), "").strip()
+        check_css_reference(root, source, url, findings)
     for match in CSS_URL_RE.finditer(css):
         url = next((value for value in match.group("double", "single", "bare") if value is not None), "").strip()
-        parsed = urlsplit(url)
-        if not url or parsed.scheme.lower() in IGNORE_SCHEMES or parsed.netloc or not parsed.path:
+        check_css_reference(root, source, url, findings)
+
+
+def check_aria_labelledby(
+    tag: str,
+    attrs: dict[str, str],
+    ids: set[str],
+    relative: Path,
+    findings: list[Finding],
+) -> tuple[bool, bool]:
+    if "aria-labelledby" not in attrs:
+        return False, False
+    labelled_by_ids = attrs["aria-labelledby"].split()
+    if not labelled_by_ids:
+        add(findings, "error", "aria-labelledby", relative, f"{tag} has an empty aria-labelledby attribute")
+        return False, True
+    missing_ids = [label_id for label_id in labelled_by_ids if label_id not in ids]
+    if missing_ids:
+        add(findings, "error", "aria-labelledby", relative, f"{tag} references missing aria-labelledby ID(s): {', '.join(missing_ids)}")
+        return False, True
+    return True, False
+
+
+def webmanifest_urls(data: Any) -> list[str]:
+    if not isinstance(data, dict):
+        return []
+    urls = [value for value in [data.get("start_url")] if isinstance(value, str)]
+    for key in ("icons", "screenshots"):
+        for item in data.get(key, []):
+            if isinstance(item, dict) and isinstance(item.get("src"), str):
+                urls.append(item["src"])
+    for shortcut in data.get("shortcuts", []):
+        if not isinstance(shortcut, dict):
             continue
-        target = resolve_local(root, source, url)
-        if target is None:
+        if isinstance(shortcut.get("url"), str):
+            urls.append(shortcut["url"])
+        for icon in shortcut.get("icons", []):
+            if isinstance(icon, dict) and isinstance(icon.get("src"), str):
+                urls.append(icon["src"])
+    return urls
+
+
+def check_webmanifest(root: Path, html_file: Path, url: str, findings: list[Finding]) -> None:
+    target = resolve_local(root, html_file, url)
+    if target is None or not is_within(target, root) or not target.is_file():
+        return
+    relative = target.relative_to(root)
+    try:
+        data = json.loads(target.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        add(findings, "error", "webmanifest-json", relative, f"Invalid web manifest JSON: {exc.msg}")
+        return
+    if not isinstance(data, dict):
+        add(findings, "error", "webmanifest-json", relative, "Web manifest must contain a JSON object")
+        return
+    for raw in webmanifest_urls(data):
+        parsed = urlsplit(raw)
+        if parsed.scheme.lower() in IGNORE_SCHEMES or parsed.netloc or not parsed.path:
             continue
-        if not is_within(target, root):
-            add(findings, "error", "css-path-escape", relative, f"CSS URL leaves site root: {url}")
+        resource = resolve_local(root, target, raw)
+        if resource is None:
             continue
-        if not target.exists():
-            add(findings, "error", "css-missing-reference", relative, f"Missing CSS URL target: {url}")
+        if not is_within(resource, root):
+            add(findings, "error", "webmanifest-path-escape", relative, f"Web manifest target leaves site root: {raw}")
+        elif not resource.exists():
+            add(findings, "error", "webmanifest-missing", relative, f"Web manifest target missing from site: {raw}")
 
 
 def check_html(root: Path, path: Path, findings: list[Finding], allow_external: bool) -> None:
@@ -250,23 +328,19 @@ def check_html(root: Path, path: Path, findings: list[Finding], allow_external: 
         control_type = attrs.get("type", "").lower()
         if control_type in {"hidden", "submit", "button", "reset", "image"}:
             continue
-        labelled_by_ids = attrs.get("aria-labelledby", "").split()
-        valid_labelled_by = False
-        if "aria-labelledby" in attrs:
-            if not labelled_by_ids:
-                add(findings, "error", "aria-labelledby", relative, f"{tag} has an empty aria-labelledby attribute")
-            else:
-                missing_ids = [label_id for label_id in labelled_by_ids if label_id not in parser.ids]
-                if missing_ids:
-                    add(findings, "error", "aria-labelledby", relative, f"{tag} references missing aria-labelledby ID(s): {', '.join(missing_ids)}")
-                else:
-                    valid_labelled_by = True
+        valid_labelled_by, invalid_labelled_by = check_aria_labelledby(tag, attrs, parser.ids, relative, findings)
         control_id = attrs.get("id")
-        labelled = bool(attrs.get("aria-label") or valid_labelled_by or (control_id and control_id in parser.labels_for))
-        if not labelled:
+        labelled = bool(attrs.get("aria-label", "").strip() or valid_labelled_by or (control_id and control_id in parser.labels_for))
+        if not labelled and not invalid_labelled_by:
             add(findings, "error", "form-label", relative, f"Unlabelled {tag}: id={control_id or '(none)'} name={attrs.get('name', '(none)')}")
-    if parser.buttons_without_label:
-        add(findings, "error", "button-label", relative, f"{parser.buttons_without_label} button(s) have no accessible name")
+    buttons_without_label = 0
+    for attrs, has_text in parser.buttons:
+        valid_labelled_by, invalid_labelled_by = check_aria_labelledby("button", attrs, parser.ids, relative, findings)
+        labelled = has_text or bool(attrs.get("aria-label", "").strip()) or valid_labelled_by
+        if not labelled and not invalid_labelled_by:
+            buttons_without_label += 1
+    if buttons_without_label:
+        add(findings, "error", "button-label", relative, f"{buttons_without_label} button(s) have no accessible name")
     for button_type in parser.invalid_button_types:
         detail = "missing type" if not button_type else f"invalid type: {button_type}"
         add(findings, "error", "button-type", relative, f"Button has {detail}; use button, submit, or reset")
@@ -307,6 +381,8 @@ def check_html(root: Path, path: Path, findings: list[Finding], allow_external: 
                 css = target.read_text(encoding="utf-8", errors="ignore")
                 check_css_urls(root, target, css, findings)
                 external_css += "\n" + css
+    for url in parser.web_manifests:
+        check_webmanifest(root, path, url, findings)
     combined = (text + "\n" + external_css).lower()
 
     slop_checks = [

--- a/web-design-picker/scripts/validate_site.py
+++ b/web-design-picker/scripts/validate_site.py
@@ -32,6 +32,29 @@ CSS_URL_RE = re.compile(
 )
 
 
+def srcset_urls(value: str) -> list[str]:
+    urls = []
+    index = 0
+    length = len(value)
+    while index < length:
+        while index < length and (value[index].isspace() or value[index] == ","):
+            index += 1
+        start = index
+        if value[index:index + 5].lower() == "data:":
+            while index < length and not value[index].isspace():
+                index += 1
+        else:
+            while index < length and not value[index].isspace() and value[index] != ",":
+                index += 1
+        if start < index:
+            urls.append(value[start:index])
+        while index < length and value[index] != ",":
+            index += 1
+        if index < length:
+            index += 1
+    return urls
+
+
 @dataclass
 class Finding:
     severity: str
@@ -52,7 +75,8 @@ class DocumentParser(HTMLParser):
         self.icons: list[str] = []
         self.h1_count = 0
         self.images: list[dict[str, str]] = []
-        self.videos: list[dict[str, str]] = []
+        self.videos: list[tuple[dict[str, str], list[str]]] = []
+        self._open_video_indexes: list[int] = []
         self.iframes: list[dict[str, str]] = []
         self.labels_for: set[str] = set()
         self.controls: list[tuple[str, dict[str, str]]] = []
@@ -83,7 +107,10 @@ class DocumentParser(HTMLParser):
         if tag == "img":
             self.images.append(attrs)
         if tag == "video":
-            self.videos.append(attrs)
+            self.videos.append((attrs, []))
+            self._open_video_indexes.append(len(self.videos) - 1)
+        if tag == "source" and self._open_video_indexes and attrs.get("src", "").strip():
+            self.videos[self._open_video_indexes[-1]][1].append(attrs["src"].strip())
         if tag == "iframe":
             self.iframes.append(attrs)
         if tag == "label" and attrs.get("for"):
@@ -111,10 +138,8 @@ class DocumentParser(HTMLParser):
             if not value:
                 continue
             if attr == "srcset":
-                for candidate in value.split(","):
-                    url = candidate.strip().split()[0] if candidate.strip() else ""
-                    if url:
-                        self.references.append((tag, attr, url))
+                for url in srcset_urls(value):
+                    self.references.append((tag, attr, url))
             else:
                 self.references.append((tag, attr, value))
 
@@ -124,6 +149,8 @@ class DocumentParser(HTMLParser):
             self._in_title = False
         if tag == "style":
             self._in_style = False
+        if tag == "video" and self._open_video_indexes:
+            self._open_video_indexes.pop()
         if tag == "button" and self._button_depth:
             has_text = self._button_has_text.pop()
             attrs = self._button_attrs.pop()
@@ -197,7 +224,7 @@ def check_html(root: Path, path: Path, findings: list[Finding], allow_external: 
         add(findings, "error", "missing-title", relative, "Missing non-empty <title>")
     if "viewport" not in parser.meta_names:
         add(findings, "error", "missing-viewport", relative, "Missing viewport meta tag")
-    if not parser.icons:
+    if not any(href.strip() for href in parser.icons):
         add(findings, "error", "missing-favicon", relative, "No favicon declaration found")
     is_picker_shell = 'role="tablist"' in text.lower() and '<iframe' in text.lower()
     if parser.h1_count != 1 and not is_picker_shell:
@@ -206,7 +233,9 @@ def check_html(root: Path, path: Path, findings: list[Finding], allow_external: 
     for image in parser.images:
         if "alt" not in image:
             add(findings, "error", "missing-alt", relative, f"Image lacks alt attribute: {image.get('src', '(inline)')}")
-    for video in parser.videos:
+    for video, source_srcs in parser.videos:
+        if not video.get("src", "").strip() and not source_srcs:
+            add(findings, "error", "video-source", relative, "Video requires a non-empty src or child source src")
         if not video.get("poster"):
             add(findings, "warning", "video-poster", relative, f"Video lacks poster: {video.get('src', '(source child)')}")
         if "playsinline" not in video:
@@ -262,8 +291,9 @@ def check_html(root: Path, path: Path, findings: list[Finding], allow_external: 
             add(findings, "error", "missing-reference", relative, f"Missing {tag} {attr} target: {url}")
         if parsed.fragment and target.exists() and target.suffix.lower() in {".html", ".htm", ""}:
             target_text = target.read_text(encoding="utf-8", errors="ignore")
-            fragment = re.escape(unquote(parsed.fragment))
-            if not re.search(rf'\bid=["\']{fragment}["\']', target_text):
+            target_parser = DocumentParser()
+            target_parser.feed(target_text)
+            if unquote(parsed.fragment) not in target_parser.ids:
                 add(findings, "warning", "missing-fragment", relative, f"Fragment target not found: {url}")
 
     for css in parser.inline_css:
@@ -332,7 +362,7 @@ def main() -> int:
     if not (root / "index.html").is_file():
         add(findings, "error", "missing-index", ".", "index.html is not at site root")
 
-    html_files = sorted(root.rglob("*.html"))
+    html_files = sorted(path for path in root.rglob("*") if path.is_file() and path.suffix.lower() in {".html", ".htm"})
     if not html_files:
         add(findings, "error", "no-html", ".", "No HTML files found")
     for path in html_files:

--- a/web-design-picker/scripts/validate_site.py
+++ b/web-design-picker/scripts/validate_site.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Validate a static web-design-picker site, its assets, and common anti-slop risks."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, asdict
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urlsplit
+
+from _common import format_bytes, read_json, utc_now, write_json
+
+REFERENCE_ATTRS = {
+    "a": ["href"],
+    "link": ["href"],
+    "script": ["src"],
+    "img": ["src", "srcset"],
+    "source": ["src", "srcset"],
+    "video": ["src", "poster"],
+    "audio": ["src"],
+    "iframe": ["src"],
+    "object": ["data"],
+}
+IGNORE_SCHEMES = {"http", "https", "mailto", "tel", "data", "javascript", "blob"}
+
+
+@dataclass
+class Finding:
+    severity: str
+    code: str
+    file: str
+    message: str
+
+
+class DocumentParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.references: list[tuple[str, str, str]] = []
+        self.external: list[str] = []
+        self.html_lang = ""
+        self.title_parts: list[str] = []
+        self._in_title = False
+        self.meta_names: dict[str, str] = {}
+        self.icons: list[str] = []
+        self.h1_count = 0
+        self.images: list[dict[str, str]] = []
+        self.videos: list[dict[str, str]] = []
+        self.iframes: list[dict[str, str]] = []
+        self.labels_for: set[str] = set()
+        self.controls: list[tuple[str, dict[str, str]]] = []
+        self.ids: set[str] = set()
+        self.inline_css: list[str] = []
+        self.mailto_links: list[str] = []
+        self.buttons_without_label = 0
+        self._button_depth = 0
+        self._button_has_text: list[bool] = []
+        self._button_attrs: list[dict[str, str]] = []
+
+    def handle_starttag(self, tag: str, attrs_list: list[tuple[str, str | None]]) -> None:
+        attrs = {key.lower(): (value or "") for key, value in attrs_list}
+        tag = tag.lower()
+        if tag == "html":
+            self.html_lang = attrs.get("lang", "")
+        if tag == "title":
+            self._in_title = True
+        if tag == "meta":
+            name = attrs.get("name", "").lower()
+            if name:
+                self.meta_names[name] = attrs.get("content", "")
+        if tag == "link" and "icon" in attrs.get("rel", "").lower():
+            self.icons.append(attrs.get("href", ""))
+        if tag == "h1":
+            self.h1_count += 1
+        if tag == "img":
+            self.images.append(attrs)
+        if tag == "video":
+            self.videos.append(attrs)
+        if tag == "iframe":
+            self.iframes.append(attrs)
+        if tag == "label" and attrs.get("for"):
+            self.labels_for.add(attrs["for"])
+        if tag in {"input", "select", "textarea"}:
+            self.controls.append((tag, attrs))
+        if attrs.get("id"):
+            self.ids.add(attrs["id"])
+        if tag == "style":
+            self._in_style = True
+        if tag == "a" and attrs.get("href", "").lower().startswith("mailto:"):
+            self.mailto_links.append(attrs["href"])
+        if tag == "button":
+            self._button_depth += 1
+            self._button_has_text.append(False)
+            self._button_attrs.append(attrs)
+
+        for attr in REFERENCE_ATTRS.get(tag, []):
+            value = attrs.get(attr)
+            if not value:
+                continue
+            if attr == "srcset":
+                for candidate in value.split(","):
+                    url = candidate.strip().split()[0] if candidate.strip() else ""
+                    if url:
+                        self.references.append((tag, attr, url))
+            else:
+                self.references.append((tag, attr, value))
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+        if tag == "title":
+            self._in_title = False
+        if tag == "style":
+            self._in_style = False
+        if tag == "button" and self._button_depth:
+            has_text = self._button_has_text.pop()
+            attrs = self._button_attrs.pop()
+            if not has_text and not attrs.get("aria-label") and not attrs.get("aria-labelledby") and not attrs.get("title"):
+                self.buttons_without_label += 1
+            self._button_depth -= 1
+
+    def handle_data(self, data: str) -> None:
+        if self._in_title:
+            self.title_parts.append(data)
+        if getattr(self, "_in_style", False):
+            self.inline_css.append(data)
+        if self._button_depth and data.strip():
+            self._button_has_text[-1] = True
+
+
+def add(findings: list[Finding], severity: str, code: str, file: Path | str, message: str) -> None:
+    findings.append(Finding(severity, code, str(file), message))
+
+
+def resolve_local(root: Path, html_file: Path, url: str) -> Path | None:
+    parsed = urlsplit(url)
+    if parsed.scheme.lower() in IGNORE_SCHEMES or parsed.netloc:
+        return None
+    raw = unquote(parsed.path)
+    if not raw:
+        return html_file
+    if raw.startswith("/"):
+        return root / raw.lstrip("/")
+    return (html_file.parent / raw).resolve()
+
+
+def is_within(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def check_html(root: Path, path: Path, findings: list[Finding], allow_external: bool) -> None:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    parser = DocumentParser()
+    try:
+        parser.feed(text)
+    except Exception as exc:
+        add(findings, "error", "html-parse", path.relative_to(root), f"HTML parser failed: {exc}")
+        return
+
+    relative = path.relative_to(root)
+    if not parser.html_lang:
+        add(findings, "error", "missing-lang", relative, "Missing <html lang> attribute")
+    if not "".join(parser.title_parts).strip():
+        add(findings, "error", "missing-title", relative, "Missing non-empty <title>")
+    if "viewport" not in parser.meta_names:
+        add(findings, "error", "missing-viewport", relative, "Missing viewport meta tag")
+    if not parser.icons:
+        add(findings, "error", "missing-favicon", relative, "No favicon declaration found")
+    is_picker_shell = 'role="tablist"' in text.lower() and '<iframe' in text.lower()
+    if parser.h1_count != 1 and not is_picker_shell:
+        add(findings, "warning", "h1-count", relative, f"Expected one H1; found {parser.h1_count}")
+
+    for image in parser.images:
+        if "alt" not in image:
+            add(findings, "error", "missing-alt", relative, f"Image lacks alt attribute: {image.get('src', '(inline)')}")
+    for video in parser.videos:
+        if not video.get("poster"):
+            add(findings, "warning", "video-poster", relative, f"Video lacks poster: {video.get('src', '(source child)')}")
+        if "playsinline" not in video:
+            add(findings, "warning", "video-playsinline", relative, "Video lacks playsinline")
+    for iframe in parser.iframes:
+        if not iframe.get("title"):
+            add(findings, "error", "iframe-title", relative, f"Iframe lacks title: {iframe.get('src', '(unknown)')}")
+
+    for tag, attrs in parser.controls:
+        control_type = attrs.get("type", "").lower()
+        if control_type in {"hidden", "submit", "button", "reset", "image"}:
+            continue
+        control_id = attrs.get("id")
+        labelled = bool(attrs.get("aria-label") or attrs.get("aria-labelledby") or (control_id and control_id in parser.labels_for))
+        if not labelled:
+            add(findings, "error", "form-label", relative, f"Unlabelled {tag}: id={control_id or '(none)'} name={attrs.get('name', '(none)')}")
+    if parser.buttons_without_label:
+        add(findings, "error", "button-label", relative, f"{parser.buttons_without_label} button(s) have no accessible name")
+    if parser.mailto_links:
+        add(findings, "warning", "mailto-cta", relative, "mailto link present; do not present it as a submitted intake workflow")
+
+    for tag, attr, url in parser.references:
+        parsed = urlsplit(url)
+        if parsed.scheme.lower() in {"http", "https"} or parsed.netloc:
+            if not allow_external:
+                add(findings, "warning", "external-reference", relative, f"External {attr}: {url}")
+            continue
+        if parsed.scheme.lower() in IGNORE_SCHEMES:
+            continue
+        target = resolve_local(root, path, url)
+        if target is None:
+            continue
+        if not is_within(target, root):
+            add(findings, "error", "path-escape", relative, f"Reference leaves site root: {url}")
+            continue
+        if parsed.path and not target.exists():
+            add(findings, "error", "missing-reference", relative, f"Missing {tag} {attr} target: {url}")
+        if parsed.fragment and target.exists() and target.suffix.lower() in {".html", ".htm", ""}:
+            target_text = target.read_text(encoding="utf-8", errors="ignore")
+            fragment = re.escape(unquote(parsed.fragment))
+            if not re.search(rf'\bid=["\']{fragment}["\']', target_text):
+                add(findings, "warning", "missing-fragment", relative, f"Fragment target not found: {url}")
+
+    external_css = ""
+    for tag, attr, url in parser.references:
+        if tag == "link" and attr == "href" and urlsplit(url).path.lower().endswith(".css"):
+            target = resolve_local(root, path, url)
+            if target and target.exists() and is_within(target, root):
+                external_css += "\n" + target.read_text(encoding="utf-8", errors="ignore")
+    combined = (text + "\n" + external_css).lower()
+
+    slop_checks = [
+        (r"\b(inter|geist mono|geist|space grotesk)\b", "reflex-font", "Fashion-default font detected; verify a project-specific reason"),
+        (r"backdrop-filter\s*:", "glassmorphism", "backdrop-filter detected; verify glass treatment is justified"),
+        (r"border-radius\s*:\s*(999|9999|50%)", "pill-everything", "Pill/circle radius detected; verify it is an appropriate control shape"),
+        (r"animation[^;{]*(pulse|pulsing)", "pulse-animation", "Pulse animation detected"),
+        (r"intersectionobserver|scroll-reveal|reveal-on-scroll", "scroll-reveal", "Scroll-triggered reveal logic detected"),
+        (r"\b(bento|marquee|ticker)\b", "template-pattern", "Bento/marquee/ticker pattern detected; verify content need"),
+        (r"contact now", "contact-now", "Generic 'Contact now' copy detected"),
+        (r"bringing your vision to life|where creativity meets precision|innovative solutions|one-stop shop|cutting-edge|trusted partner", "generic-copy", "Generic marketing phrase detected"),
+        (r">\s*0[1-9]\s*<", "zero-padded-label", "Zero-padded decorative number label detected"),
+    ]
+    for pattern, code, message in slop_checks:
+        if re.search(pattern, combined, re.I):
+            add(findings, "warning", code, relative, message)
+
+    gradient_count = len(re.findall(r"(?:linear|radial|conic)-gradient\s*\(", combined))
+    checker_exception = ".preview.checker" in combined and gradient_count <= 4 and "radial-gradient" not in combined and "conic-gradient" not in combined
+    if gradient_count and not checker_exception:
+        add(findings, "warning", "gradients", relative, f"Found {gradient_count} CSS gradient(s); verify they are not decorative filler")
+
+
+def manifest_paths(data: Any) -> list[str]:
+    paths: list[str] = []
+    if isinstance(data, dict):
+        for key, value in data.items():
+            if key in {"href", "preview", "poster", "path"} and isinstance(value, str):
+                paths.append(value)
+            else:
+                paths.extend(manifest_paths(value))
+    elif isinstance(data, list):
+        for item in data:
+            paths.extend(manifest_paths(item))
+    return paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("site_dir", type=Path)
+    parser.add_argument("--manifest", type=Path, help="Optional config/assets.json to validate")
+    parser.add_argument("--strict", action="store_true", help="Return failure when warnings remain")
+    parser.add_argument("--allow-external", action="store_true")
+    parser.add_argument("--cloudflare", action="store_true", help="Apply conservative Cloudflare Drop packaging checks")
+    parser.add_argument("--report-json", type=Path)
+    args = parser.parse_args()
+
+    root = args.site_dir.resolve()
+    findings: list[Finding] = []
+    if not root.is_dir():
+        print(f"error: not a directory: {root}", file=sys.stderr)
+        return 1
+    if not (root / "index.html").is_file():
+        add(findings, "error", "missing-index", ".", "index.html is not at site root")
+
+    html_files = sorted(root.rglob("*.html"))
+    if not html_files:
+        add(findings, "error", "no-html", ".", "No HTML files found")
+    for path in html_files:
+        check_html(root, path, findings, args.allow_external)
+
+    for path in sorted(root.rglob("*")):
+        if path.is_symlink():
+            add(findings, "error", "symlink", path.relative_to(root), "Symlinks are not allowed in portable static packages")
+        if path.is_file() and path.stat().st_size > 25 * 1024 * 1024:
+            add(findings, "warning", "large-file", path.relative_to(root), f"Large file: {format_bytes(path.stat().st_size)}")
+        if args.cloudflare and path.is_file() and path.suffix.lower() == ".zip":
+            add(findings, "warning", "nested-zip", path.relative_to(root), "Nested ZIP excluded by default from conservative Drop package")
+
+    if args.manifest:
+        data = read_json(args.manifest.resolve())
+        for raw in manifest_paths(data):
+            parsed = urlsplit(raw)
+            if parsed.scheme or parsed.netloc or not parsed.path:
+                continue
+            target = root / parsed.path.lstrip("/")
+            if not target.exists():
+                add(findings, "error", "manifest-missing", args.manifest, f"Manifest target missing from site: {raw}")
+
+    errors = [item for item in findings if item.severity == "error"]
+    warnings = [item for item in findings if item.severity == "warning"]
+    report = {
+        "generated_at": utc_now(),
+        "site_dir": str(root),
+        "html_files": len(html_files),
+        "errors": len(errors),
+        "warnings": len(warnings),
+        "findings": [asdict(item) for item in findings],
+    }
+    if args.report_json:
+        write_json(args.report_json.resolve(), report)
+
+    print(f"Checked {len(html_files)} HTML file(s) under {root}")
+    for item in findings:
+        print(f"{item.severity.upper():7} {item.code:22} {item.file}: {item.message}")
+    print(f"Result: {len(errors)} error(s), {len(warnings)} warning(s)")
+
+    if errors or (args.strict and warnings):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web-design-picker/scripts/validate_site.py
+++ b/web-design-picker/scripts/validate_site.py
@@ -211,6 +211,8 @@ def check_html(root: Path, path: Path, findings: list[Finding], allow_external: 
             add(findings, "warning", "video-poster", relative, f"Video lacks poster: {video.get('src', '(source child)')}")
         if "playsinline" not in video:
             add(findings, "warning", "video-playsinline", relative, "Video lacks playsinline")
+        if "autoplay" in video and "muted" not in video:
+            add(findings, "error", "video-autoplay-muted", relative, "Autoplay video must include muted")
     for iframe in parser.iframes:
         if not iframe.get("title"):
             add(findings, "error", "iframe-title", relative, f"Iframe lacks title: {iframe.get('src', '(unknown)')}")
@@ -219,8 +221,19 @@ def check_html(root: Path, path: Path, findings: list[Finding], allow_external: 
         control_type = attrs.get("type", "").lower()
         if control_type in {"hidden", "submit", "button", "reset", "image"}:
             continue
+        labelled_by_ids = attrs.get("aria-labelledby", "").split()
+        valid_labelled_by = False
+        if "aria-labelledby" in attrs:
+            if not labelled_by_ids:
+                add(findings, "error", "aria-labelledby", relative, f"{tag} has an empty aria-labelledby attribute")
+            else:
+                missing_ids = [label_id for label_id in labelled_by_ids if label_id not in parser.ids]
+                if missing_ids:
+                    add(findings, "error", "aria-labelledby", relative, f"{tag} references missing aria-labelledby ID(s): {', '.join(missing_ids)}")
+                else:
+                    valid_labelled_by = True
         control_id = attrs.get("id")
-        labelled = bool(attrs.get("aria-label") or attrs.get("aria-labelledby") or (control_id and control_id in parser.labels_for))
+        labelled = bool(attrs.get("aria-label") or valid_labelled_by or (control_id and control_id in parser.labels_for))
         if not labelled:
             add(findings, "error", "form-label", relative, f"Unlabelled {tag}: id={control_id or '(none)'} name={attrs.get('name', '(none)')}")
     if parser.buttons_without_label:

--- a/web-design-picker/scripts/validate_site.py
+++ b/web-design-picker/scripts/validate_site.py
@@ -26,6 +26,10 @@ REFERENCE_ATTRS = {
     "object": ["data"],
 }
 IGNORE_SCHEMES = {"http", "https", "mailto", "tel", "data", "javascript", "blob"}
+CSS_URL_RE = re.compile(
+    r"url\(\s*(?:\"(?P<double>[^\"]*)\"|'(?P<single>[^']*)'|(?P<bare>[^)\s'\"]+))\s*\)",
+    re.I,
+)
 
 
 @dataclass
@@ -59,6 +63,7 @@ class DocumentParser(HTMLParser):
         self._button_depth = 0
         self._button_has_text: list[bool] = []
         self._button_attrs: list[dict[str, str]] = []
+        self.invalid_button_types: list[str] = []
 
     def handle_starttag(self, tag: str, attrs_list: list[tuple[str, str | None]]) -> None:
         attrs = {key.lower(): (value or "") for key, value in attrs_list}
@@ -89,9 +94,14 @@ class DocumentParser(HTMLParser):
             self.ids.add(attrs["id"])
         if tag == "style":
             self._in_style = True
+        if attrs.get("style"):
+            self.inline_css.append(attrs["style"])
         if tag == "a" and attrs.get("href", "").lower().startswith("mailto:"):
             self.mailto_links.append(attrs["href"])
         if tag == "button":
+            button_type = attrs.get("type", "").lower()
+            if button_type not in {"button", "submit", "reset"}:
+                self.invalid_button_types.append(button_type)
             self._button_depth += 1
             self._button_has_text.append(False)
             self._button_attrs.append(attrs)
@@ -154,6 +164,23 @@ def is_within(path: Path, root: Path) -> bool:
         return False
 
 
+def check_css_urls(root: Path, source: Path, css: str, findings: list[Finding]) -> None:
+    relative = source.relative_to(root)
+    for match in CSS_URL_RE.finditer(css):
+        url = next((value for value in match.group("double", "single", "bare") if value is not None), "").strip()
+        parsed = urlsplit(url)
+        if not url or parsed.scheme.lower() in IGNORE_SCHEMES or parsed.netloc or not parsed.path:
+            continue
+        target = resolve_local(root, source, url)
+        if target is None:
+            continue
+        if not is_within(target, root):
+            add(findings, "error", "css-path-escape", relative, f"CSS URL leaves site root: {url}")
+            continue
+        if not target.exists():
+            add(findings, "error", "css-missing-reference", relative, f"Missing CSS URL target: {url}")
+
+
 def check_html(root: Path, path: Path, findings: list[Finding], allow_external: bool) -> None:
     text = path.read_text(encoding="utf-8", errors="replace")
     parser = DocumentParser()
@@ -198,6 +225,9 @@ def check_html(root: Path, path: Path, findings: list[Finding], allow_external: 
             add(findings, "error", "form-label", relative, f"Unlabelled {tag}: id={control_id or '(none)'} name={attrs.get('name', '(none)')}")
     if parser.buttons_without_label:
         add(findings, "error", "button-label", relative, f"{parser.buttons_without_label} button(s) have no accessible name")
+    for button_type in parser.invalid_button_types:
+        detail = "missing type" if not button_type else f"invalid type: {button_type}"
+        add(findings, "error", "button-type", relative, f"Button has {detail}; use button, submit, or reset")
     if parser.mailto_links:
         add(findings, "warning", "mailto-cta", relative, "mailto link present; do not present it as a submitted intake workflow")
 
@@ -223,12 +253,17 @@ def check_html(root: Path, path: Path, findings: list[Finding], allow_external: 
             if not re.search(rf'\bid=["\']{fragment}["\']', target_text):
                 add(findings, "warning", "missing-fragment", relative, f"Fragment target not found: {url}")
 
+    for css in parser.inline_css:
+        check_css_urls(root, path, css, findings)
+
     external_css = ""
     for tag, attr, url in parser.references:
         if tag == "link" and attr == "href" and urlsplit(url).path.lower().endswith(".css"):
             target = resolve_local(root, path, url)
             if target and target.exists() and is_within(target, root):
-                external_css += "\n" + target.read_text(encoding="utf-8", errors="ignore")
+                css = target.read_text(encoding="utf-8", errors="ignore")
+                check_css_urls(root, target, css, findings)
+                external_css += "\n" + css
     combined = (text + "\n" + external_css).lower()
 
     slop_checks = [

--- a/web-design-picker/scripts/validate_site.py
+++ b/web-design-picker/scripts/validate_site.py
@@ -304,7 +304,10 @@ def main() -> int:
             parsed = urlsplit(raw)
             if parsed.scheme or parsed.netloc or not parsed.path:
                 continue
-            target = root / parsed.path.lstrip("/")
+            target = (root / unquote(parsed.path).lstrip("/")).resolve()
+            if not is_within(target, root):
+                add(findings, "error", "manifest-path-escape", args.manifest, f"Manifest target leaves site root: {raw}")
+                continue
             if not target.exists():
                 add(findings, "error", "manifest-missing", args.manifest, f"Manifest target missing from site: {raw}")
 

--- a/web-design-picker/scripts/validate_skill.py
+++ b/web-design-picker/scripts/validate_skill.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Validate an Agent Skill package and compile its Python helpers."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import tempfile
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover
+    raise SystemExit("PyYAML is required to validate skill frontmatter") from exc
+
+NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+
+
+def parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+    if not text.startswith("---\n"):
+        raise ValueError("SKILL.md must begin with YAML frontmatter at byte 0")
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        raise ValueError("SKILL.md frontmatter closing delimiter not found")
+    data = yaml.safe_load(text[4:end])
+    if not isinstance(data, dict):
+        raise ValueError("Frontmatter must be a YAML mapping")
+    return data, text[end + 5 :]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("skill_dir", type=Path, nargs="?", default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--report-json", type=Path)
+    args = parser.parse_args()
+
+    root = args.skill_dir.resolve()
+    errors: list[str] = []
+    warnings: list[str] = []
+    skill_file = root / "SKILL.md"
+    if not skill_file.exists():
+        errors.append("SKILL.md is missing")
+        metadata: dict[str, Any] = {}
+        body = ""
+    else:
+        text = skill_file.read_text(encoding="utf-8")
+        try:
+            metadata, body = parse_frontmatter(text)
+        except Exception as exc:
+            errors.append(str(exc))
+            metadata, body = {}, ""
+
+    name = metadata.get("name")
+    description = metadata.get("description")
+    if not isinstance(name, str) or not NAME_RE.fullmatch(name):
+        errors.append("frontmatter name must use lowercase letters, digits, and single hyphens")
+    elif name != root.name:
+        errors.append(f"frontmatter name {name!r} must match parent directory {root.name!r}")
+    if not isinstance(description, str) or not description.strip():
+        errors.append("frontmatter description is required")
+    elif len(description) > 1024:
+        errors.append("frontmatter description exceeds 1024 characters")
+    compatibility = metadata.get("compatibility")
+    if compatibility is not None and (not isinstance(compatibility, str) or len(compatibility) > 500):
+        errors.append("compatibility must be a string no longer than 500 characters")
+
+    if skill_file.exists():
+        line_count = len(skill_file.read_text(encoding="utf-8").splitlines())
+        if line_count > 500:
+            warnings.append(f"SKILL.md has {line_count} lines; progressive disclosure recommends fewer than 500")
+        for target in LINK_RE.findall(body):
+            if "://" in target or target.startswith("#"):
+                continue
+            target_path = (root / target.split("#", 1)[0]).resolve()
+            try:
+                target_path.relative_to(root)
+            except ValueError:
+                errors.append(f"SKILL.md link leaves skill root: {target}")
+                continue
+            if not target_path.exists():
+                errors.append(f"SKILL.md link target missing: {target}")
+
+    manifest = root / "manifest.txt"
+    actual_files = sorted(path.relative_to(root).as_posix() for path in root.rglob("*") if path.is_file() and path.name != "manifest.txt" and "__pycache__" not in path.parts and path.suffix != ".pyc")
+    if manifest.exists():
+        listed = [line.strip() for line in manifest.read_text(encoding="utf-8").splitlines() if line.strip()]
+        if listed != sorted(set(listed)):
+            warnings.append("manifest.txt is not sorted or contains duplicates")
+        missing = sorted(set(actual_files) - set(listed))
+        extra = sorted(set(listed) - set(actual_files))
+        if missing:
+            errors.append(f"manifest.txt omits: {', '.join(missing)}")
+        if extra:
+            errors.append(f"manifest.txt lists missing files: {', '.join(extra)}")
+    python_files = sorted((root / "scripts").glob("*.py"))
+    if python_files:
+        with tempfile.TemporaryDirectory(prefix="web-design-picker-pyc-") as pycache:
+            env = dict(os.environ)
+            env["PYTHONPYCACHEPREFIX"] = pycache
+            result = subprocess.run([sys.executable, "-m", "py_compile", *map(str, python_files)], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, env=env)
+        if result.returncode != 0:
+            errors.append(f"Python compile failure:\n{result.stderr.strip()}")
+
+    report = {
+        "skill": name,
+        "root": str(root),
+        "errors": errors,
+        "warnings": warnings,
+        "file_count": len(actual_files) + (1 if manifest.exists() else 0),
+        "python_scripts": len(python_files),
+    }
+    if args.report_json:
+        args.report_json.parent.mkdir(parents=True, exist_ok=True)
+        args.report_json.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+    print(f"Skill: {name or '(unknown)'}")
+    for error in errors:
+        print(f"ERROR   {error}")
+    for warning in warnings:
+        print(f"WARNING {warning}")
+    print(f"Files: {report['file_count']} | Python scripts: {report['python_scripts']}")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web-design-picker/scripts/web_design_picker.py
+++ b/web-design-picker/scripts/web_design_picker.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Unified command-line entry point for the web-design-picker skill."""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent
+
+
+def run_script(script: str, arguments: list[str]) -> int:
+    command = [sys.executable, str(SCRIPTS / script), *arguments]
+    return subprocess.call(command)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Scaffold, build, validate, preview, and package a multi-direction "
+            "website design picker project."
+        )
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init", help="Scaffold a new two-to-five direction project")
+    init_parser.add_argument("project_dir", type=Path)
+    init_parser.add_argument("--name", required=True)
+    init_parser.add_argument("--slug")
+    init_parser.add_argument("--directions", type=int, choices=range(2, 6), default=3)
+    init_parser.add_argument("--force", action="store_true")
+
+    build_parser = subparsers.add_parser("build", help="Build the picker, concepts, and asset catalog")
+    build_parser.add_argument("project_dir", type=Path)
+    build_parser.add_argument("--no-clean", action="store_true")
+
+    validate_parser = subparsers.add_parser("validate", help="Run static, distinctness, and anti-slop checks")
+    validate_parser.add_argument("project_dir", type=Path)
+    validate_parser.add_argument("--strict", action="store_true")
+    validate_parser.add_argument("--allow-external", action="store_true")
+    validate_parser.add_argument("--fail-on-slop", action="store_true")
+
+    preview_parser = subparsers.add_parser("preview", help="Capture responsive previews and run browser QA")
+    preview_parser.add_argument("project_dir", type=Path)
+    preview_parser.add_argument("--chromium", type=Path)
+    preview_parser.add_argument("--wait-ms", type=int, default=350)
+    preview_parser.add_argument("--test-downloads", action="store_true")
+
+    package_parser = subparsers.add_parser("package", help="Create Cloudflare Drop and design-handoff archives")
+    package_parser.add_argument("project_dir", type=Path)
+    package_parser.add_argument("--skip-validation", action="store_true")
+    package_parser.add_argument("--max-file-bytes", type=int, default=25_000_000)
+
+    run_parser = subparsers.add_parser("run", help="Run the complete factory pipeline")
+    run_parser.add_argument("project_dir", type=Path)
+    run_parser.add_argument("--skip-browser", action="store_true")
+    run_parser.add_argument("--test-downloads", action="store_true")
+    run_parser.add_argument("--strict", action="store_true")
+    run_parser.add_argument("--fail-on-slop", action="store_true")
+    run_parser.add_argument("--skip-package-validation", action="store_true")
+
+    self_test_parser = subparsers.add_parser("self-test", help="Exercise the full skill pipeline on a synthetic project")
+    self_test_parser.add_argument("--work-dir", type=Path)
+    self_test_parser.add_argument("--browser", action="store_true")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "init":
+        forwarded = [str(args.project_dir), "--name", args.name, "--directions", str(args.directions)]
+        if args.slug:
+            forwarded.extend(["--slug", args.slug])
+        if args.force:
+            forwarded.append("--force")
+        return run_script("new_project.py", forwarded)
+
+    if args.command == "build":
+        forwarded = [str(args.project_dir)]
+        if args.no_clean:
+            forwarded.append("--no-clean")
+        return run_script("build_picker.py", forwarded)
+
+    if args.command == "validate":
+        root = args.project_dir.resolve()
+        qa = root / "qa"
+        qa.mkdir(parents=True, exist_ok=True)
+
+        static_args = [
+            str(root / "dist"),
+            "--manifest",
+            str(root / "config/assets.json"),
+            "--cloudflare",
+            "--report-json",
+            str(qa / "static-validation.json"),
+        ]
+        if args.strict:
+            static_args.append("--strict")
+        if args.allow_external:
+            static_args.append("--allow-external")
+        code = run_script("validate_site.py", static_args)
+        if code:
+            return code
+
+        distinct_args = [str(root), "--report-json", str(qa / "distinctness.json")]
+        if args.strict:
+            distinct_args.append("--strict")
+        code = run_script("check_distinctness.py", distinct_args)
+        if code and args.strict:
+            return code
+
+        slop_args = [str(root / "dist"), "--json", str(qa / "anti-slop.json")]
+        if args.fail_on_slop:
+            slop_args.append("--fail-on-findings")
+        return run_script("slop_lint.py", slop_args)
+
+    if args.command == "preview":
+        forwarded = [
+            str(args.project_dir),
+            "--wait-ms",
+            str(args.wait_ms),
+            "--report-json",
+            str(args.project_dir.resolve() / "qa/browser-qa.json"),
+        ]
+        if args.chromium:
+            forwarded.extend(["--chromium", str(args.chromium)])
+        if args.test_downloads:
+            forwarded.append("--test-downloads")
+        return run_script("browser_qa.py", forwarded)
+
+    if args.command == "package":
+        forwarded = [str(args.project_dir), "--max-file-bytes", str(args.max_file_bytes)]
+        if args.skip_validation:
+            forwarded.append("--skip-validation")
+        return run_script("package_delivery.py", forwarded)
+
+    if args.command == "run":
+        forwarded = [str(args.project_dir)]
+        for enabled, flag in (
+            (args.skip_browser, "--skip-browser"),
+            (args.test_downloads, "--test-downloads"),
+            (args.strict, "--strict"),
+            (args.fail_on_slop, "--fail-on-slop"),
+            (args.skip_package_validation, "--skip-package-validation"),
+        ):
+            if enabled:
+                forwarded.append(flag)
+        return run_script("run_factory.py", forwarded)
+
+    forwarded: list[str] = []
+    if args.work_dir:
+        forwarded.extend(["--work-dir", str(args.work_dir)])
+    if args.browser:
+        forwarded.append("--browser")
+    return run_script("self_test.py", forwarded)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web-design-picker/scripts/web_design_picker.py
+++ b/web-design-picker/scripts/web_design_picker.py
@@ -57,6 +57,7 @@ def main(argv: list[str] | None = None) -> int:
     run_parser.add_argument("--skip-browser", action="store_true")
     run_parser.add_argument("--test-downloads", action="store_true")
     run_parser.add_argument("--strict", action="store_true")
+    run_parser.add_argument("--allow-external", action="store_true", help="Permit external http(s) references during static validation")
     run_parser.add_argument("--fail-on-slop", action="store_true")
     run_parser.add_argument("--skip-package-validation", action="store_true")
 
@@ -139,6 +140,7 @@ def main(argv: list[str] | None = None) -> int:
             (args.skip_browser, "--skip-browser"),
             (args.test_downloads, "--test-downloads"),
             (args.strict, "--strict"),
+            (args.allow_external, "--allow-external"),
             (args.fail_on_slop, "--fail-on-slop"),
             (args.skip_package_validation, "--skip-package-validation"),
         ):


### PR DESCRIPTION
## Summary

- Add the `web-design-picker` root skill and plugin with project scaffolding, review-site generation, asset packaging, browser QA, and Cloudflare Drop output.
- Register it in the marketplace, catalog, and docs; release repository metadata as `2.8.0`.
- Harden Windows SVG rendering and project/archive path handling.

## Verification

- Package browser self-test: 0 errors, 0 warnings, 14 screenshots.
- `npm run validate:catalog`
- `npm run validate:agent-skills`
- `npm run check:docs-css`
- `claude plugin validate --strict .\web-design-picker`
- Focused Node tests: 15 passed.
- Full `npm test`: 248 passed with 12 unchanged Windows baseline failures, 2 skipped, 1 todo.
- Accessibility: new page 0 violations; existing homepage contrast issue remains.